### PR TITLE
feat(assert): add `Assert::contains`

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -89,6 +89,30 @@ final class Assert
     }
 
     /**
+     * Asserts that given array contains expected value.
+     *
+     * @param mixed $needle The expected value.
+     * @param iterable $haystack Iterable (array or Traversable) to search in.
+     * @param string $message Short description about what exactly is being asserted.
+     * @throws AssertException when the assertion fails.
+     */
+    public static function contains(mixed $needle, iterable $haystack, string $message = ''): void
+    {
+        foreach ($haystack as $element) {
+            if ($needle === $element) {
+                StaticState::log('Assert contains', $message);
+                return;
+            }
+        }
+        StaticState::fail(AssertException::compare(
+            $needle,
+            $haystack,
+            $message,
+            'Failed asserting that `%1$s` contains `%2$s`',
+        ));
+    }
+
+    /**
      * Asserts that the given value is null.
      *
      * @param mixed $actual The actual value to check for null.

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -109,7 +109,7 @@ final class Assert
     }
 
     /**
-     * Asserts that given array contains expected value.
+     * Asserts that given collection contains expected value.
      *
      * @param mixed $needle The expected value.
      * @param iterable $haystack Iterable (array or Traversable) to search in.

--- a/tests/Testo/AsserTest.php
+++ b/tests/Testo/AsserTest.php
@@ -19,6 +19,8 @@ final class AsserTest
         Assert::notSame(42, '42');
         Assert::true(true);
         Assert::false(false);
+        Assert::contains(1, [1,2,3]);
+        Assert::contains(2, new \ArrayIterator([1,2,3]));
     }
 
     #[Test]


### PR DESCRIPTION
<!-- Thanks for opening a PR! -->

## What was changed

Added new Assert method `Assert::contains`. It asserts that the iterable haystack contains needle.

## Why?

In order to fill simple assert functions library

## Checklist

- Tested
  - [ ] Tested manually
  - [x] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->
