### PR TITLE
Feature/throw condition expectation

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -169,14 +169,14 @@ final class Assert
      * @param string $message Short description about what exactly is being asserted.
      * @throws \Throwable when the condition is true.
      */
-    public static function throwIf(bool $condition, \Throwable|string $exception, string $message = ''): void
+    public static function throwsIf(bool $condition, \Throwable|string $exception, string $message = ''): void
     {
         if ($condition === true) {
             self::exception($exception);
             throw \is_string($exception) ? new $exception($message) : $exception;
         }
 
-        StaticState::log('Assert throw if: condition is false', $message);
+        StaticState::log('Assert throws if: condition is false', $message);
     }
 
     /**
@@ -187,14 +187,14 @@ final class Assert
      * @param string $message Short description about what exactly is being asserted.
      * @throws \Throwable when the condition is false.
      */
-    public static function throwUnless(bool $condition, \Throwable|string $exception, string $message = ''): void
+    public static function throwsUnless(bool $condition, \Throwable|string $exception, string $message = ''): void
     {
         if ($condition === false) {
             self::exception($exception);
             throw \is_string($exception) ? new $exception($message) : $exception;
         }
 
-        StaticState::log('Assert throw unless: condition is true', $message);
+        StaticState::log('Assert throws unless: condition is true', $message);
     }
 
     /**

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -162,6 +162,42 @@ final class Assert
     }
 
     /**
+     * Throws an exception if the condition is true.
+     *
+     * @param bool $condition The condition to check.
+     * @param \Throwable|class-string<\Throwable> $exception The exception to throw or exception class.
+     * @param string $message Short description about what exactly is being asserted.
+     * @throws \Throwable when the condition is true.
+     */
+    public static function throwIf(bool $condition, \Throwable|string $exception, string $message = ''): void
+    {
+        if ($condition === true) {
+            self::exception($exception);
+            throw is_string($exception) ? new $exception($message) : $exception;
+        }
+
+        StaticState::log('Assert throw if: condition is false', $message);
+    }
+
+    /**
+     * Throws an exception unless the condition is true.
+     *
+     * @param bool $condition The condition to check.
+     * @param \Throwable|class-string<\Throwable> $exception The exception to throw or exception class.
+     * @param string $message Short description about what exactly is being asserted.
+     * @throws \Throwable when the condition is false.
+     */
+    public static function throwUnless(bool $condition, \Throwable|string $exception, string $message = ''): void
+    {
+        if ($condition === false) {
+            self::exception($exception);
+            throw is_string($exception) ? new $exception($message) : $exception;
+        }
+
+        StaticState::log('Assert throw unless: condition is true', $message);
+    }
+
+    /**
      * Asserts that the given objects do not leak memory after the test execution.
      *
      * @param object ...$objects The objects to monitor for memory leaks.

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -173,7 +173,7 @@ final class Assert
     {
         if ($condition === true) {
             self::exception($exception);
-            throw is_string($exception) ? new $exception($message) : $exception;
+            throw \is_string($exception) ? new $exception($message) : $exception;
         }
 
         StaticState::log('Assert throw if: condition is false', $message);
@@ -191,7 +191,7 @@ final class Assert
     {
         if ($condition === false) {
             self::exception($exception);
-            throw is_string($exception) ? new $exception($message) : $exception;
+            throw \is_string($exception) ? new $exception($message) : $exception;
         }
 
         StaticState::log('Assert throw unless: condition is true', $message);

--- a/tests/Testo/AsserTest.php
+++ b/tests/Testo/AsserTest.php
@@ -19,8 +19,8 @@ final class AsserTest
         Assert::notSame(42, '42');
         Assert::true(true);
         Assert::false(false);
-        Assert::contains(1, [1,2,3]);
-        Assert::contains(2, new \ArrayIterator([1,2,3]));
+        Assert::contains(1, [1, 2, 3]);
+        Assert::contains(2, new \ArrayIterator([1, 2, 3]));
         Assert::instanceOf(\Exception::class, new \RuntimeException());
     }
 
@@ -87,5 +87,65 @@ final class AsserTest
     public function expectExceptionAttribute(): never
     {
         throw new \RuntimeException('This is an expected exception.');
+    }
+
+    #[Test]
+    public function throwIfConditionFalse(): void
+    {
+        Assert::throwIf(false, new \RuntimeException('Should not throw'), 'Condition is false');
+    }
+
+    #[Test]
+    public function throwUnlessConditionTrue(): void
+    {
+        Assert::throwUnless(true, new \RuntimeException('Should not throw'), 'Condition is true');
+    }
+
+    #[Test]
+    public function throwIfConditionFalseWithClass(): void
+    {
+        Assert::throwIf(false, \RuntimeException::class, 'Condition is false with class string');
+    }
+
+    #[Test]
+    public function throwUnlessConditionTrueWithClass(): void
+    {
+        Assert::throwUnless(true, \RuntimeException::class, 'Condition is true with class string');
+    }
+
+    #[Test]
+    #[ExpectException(\RuntimeException::class)]
+    public function throwIfConditionTrue(): void
+    {
+        Assert::throwIf(true, new \RuntimeException('Condition is true, should throw'), 'Throw when true');
+    }
+
+    #[Test]
+    #[ExpectException(\RuntimeException::class)]
+    public function throwUnlessConditionFalse(): void
+    {
+        Assert::throwUnless(false, new \RuntimeException('Condition is false, should throw'), 'Throw when false');
+    }
+
+    #[Test]
+    #[ExpectException(\InvalidArgumentException::class)]
+    public function throwIfConditionTrueWithClass(): void
+    {
+        Assert::throwIf(true, \InvalidArgumentException::class, 'Throw when true with class string');
+    }
+
+    #[Test]
+    #[ExpectException(\InvalidArgumentException::class)]
+    public function throwUnlessConditionFalseWithClass(): void
+    {
+        Assert::throwUnless(false, \InvalidArgumentException::class, 'Throw when false with class string');
+    }
+
+    #[Test]
+    #[ExpectException(\RuntimeException::class)]
+    public function throwIfWithCustomExceptionMessage(): void
+    {
+        $exception = new \RuntimeException('Custom message from exception');
+        Assert::throwIf(true, $exception, 'Custom assertion message');
     }
 }

--- a/tests/Testo/AsserTest.php
+++ b/tests/Testo/AsserTest.php
@@ -90,62 +90,62 @@ final class AsserTest
     }
 
     #[Test]
-    public function throwIfConditionFalse(): void
+    public function throwsIfConditionFalse(): void
     {
-        Assert::throwIf(false, new \RuntimeException('Should not throw'), 'Condition is false');
+        Assert::throwsIf(false, new \RuntimeException('Should not throw'), 'Condition is false');
     }
 
     #[Test]
-    public function throwUnlessConditionTrue(): void
+    public function throwsUnlessConditionTrue(): void
     {
-        Assert::throwUnless(true, new \RuntimeException('Should not throw'), 'Condition is true');
+        Assert::throwsUnless(true, new \RuntimeException('Should not throw'), 'Condition is true');
     }
 
     #[Test]
-    public function throwIfConditionFalseWithClass(): void
+    public function throwsIfConditionFalseWithClass(): void
     {
-        Assert::throwIf(false, \RuntimeException::class, 'Condition is false with class string');
+        Assert::throwsIf(false, \RuntimeException::class, 'Condition is false with class string');
     }
 
     #[Test]
-    public function throwUnlessConditionTrueWithClass(): void
+    public function throwsUnlessConditionTrueWithClass(): void
     {
-        Assert::throwUnless(true, \RuntimeException::class, 'Condition is true with class string');
-    }
-
-    #[Test]
-    #[ExpectException(\RuntimeException::class)]
-    public function throwIfConditionTrue(): void
-    {
-        Assert::throwIf(true, new \RuntimeException('Condition is true, should throw'), 'Throw when true');
+        Assert::throwsUnless(true, \RuntimeException::class, 'Condition is true with class string');
     }
 
     #[Test]
     #[ExpectException(\RuntimeException::class)]
-    public function throwUnlessConditionFalse(): void
+    public function throwsIfConditionTrue(): void
     {
-        Assert::throwUnless(false, new \RuntimeException('Condition is false, should throw'), 'Throw when false');
+        Assert::throwsIf(true, new \RuntimeException('Condition is true, should throw'), 'Throw when true');
+    }
+
+    #[Test]
+    #[ExpectException(\RuntimeException::class)]
+    public function throwsUnlessConditionFalse(): void
+    {
+        Assert::throwsUnless(false, new \RuntimeException('Condition is false, should throw'), 'Throw when false');
     }
 
     #[Test]
     #[ExpectException(\InvalidArgumentException::class)]
-    public function throwIfConditionTrueWithClass(): void
+    public function throwsIfConditionTrueWithClass(): void
     {
-        Assert::throwIf(true, \InvalidArgumentException::class, 'Throw when true with class string');
+        Assert::throwsIf(true, \InvalidArgumentException::class, 'Throw when true with class string');
     }
 
     #[Test]
     #[ExpectException(\InvalidArgumentException::class)]
-    public function throwUnlessConditionFalseWithClass(): void
+    public function throwsUnlessConditionFalseWithClass(): void
     {
-        Assert::throwUnless(false, \InvalidArgumentException::class, 'Throw when false with class string');
+        Assert::throwsUnless(false, \InvalidArgumentException::class, 'Throw when false with class string');
     }
 
     #[Test]
     #[ExpectException(\RuntimeException::class)]
-    public function throwIfWithCustomExceptionMessage(): void
+    public function throwsIfWithCustomExceptionMessage(): void
     {
         $exception = new \RuntimeException('Custom message from exception');
-        Assert::throwIf(true, $exception, 'Custom assertion message');
+        Assert::throwsIf(true, $exception, 'Custom assertion message');
     }
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! -->

## What was changed

This PR introduced `throwsIf` and `throwsUnless` to conditionally verify an exception by a given boolean expression evaluation.

## Why?

They are helpful when we have to write many conditions to check throwed exceptions.

## Checklist

- Closes #<!-- add issue number here -->
- Tested
  - [ ] Tested manually
  - [x] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->
