### PR TITLE
feat(assert): add `Assert:equal()`, `Assert::notEqual()` and fix default compare message

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -61,8 +61,13 @@ final class Assert
     public static function equals(mixed $expected, mixed $actual, string $message = ''): void
     {
         $actual == $expected
-            ? StaticState::log('Assert equal: `' . Support::stringify($expected) . '`', $message)
-            : StaticState::fail(AssertException::compare($expected, $actual, $message));
+            ? StaticState::log('Assert equals: `' . Support::stringify($expected) . '`', $message)
+            : StaticState::fail(AssertException::compare(
+                $expected,
+                $actual,
+                $message,
+                pattern: 'Failed asserting that `%1s` is equals to `%2s`',
+            ));
     }
 
     /**
@@ -76,12 +81,12 @@ final class Assert
     public static function notEquals(mixed $expected, mixed $actual, string $message = ''): void
     {
         $actual != $expected
-            ? StaticState::log('Assert not equal: `' . Support::stringify($expected) . '`', $message)
+            ? StaticState::log('Assert not equals: `' . Support::stringify($expected) . '`', $message)
             : StaticState::fail(AssertException::compare(
                 $expected,
                 $actual,
                 $message,
-                pattern: 'Failed asserting that `%1s` is not equal to `%2s`',
+                pattern: 'Failed asserting that `%1s` is not equals to `%2s`',
                 showDiff: false,
             ));
     }

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -58,7 +58,7 @@ final class Assert
      * @param string $message Short description about what exactly is being asserted.
      * @throws AssertException when the assertion fails.
      */
-    public static function equal(mixed $expected, mixed $actual, string $message = ''): void
+    public static function equals(mixed $expected, mixed $actual, string $message = ''): void
     {
         $actual == $expected
             ? StaticState::log('Assert equal: `' . Support::stringify($expected) . '`', $message)
@@ -73,7 +73,7 @@ final class Assert
      * @param string $message Short description about what exactly is being asserted.
      * @throws AssertException when the assertion fails.
      */
-    public static function notEqual(mixed $expected, mixed $actual, string $message = ''): void
+    public static function notEquals(mixed $expected, mixed $actual, string $message = ''): void
     {
         $actual != $expected
             ? StaticState::log('Assert not equal: `' . Support::stringify($expected) . '`', $message)

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -51,6 +51,42 @@ final class Assert
     }
 
     /**
+     * Asserts that two values are equal (not strict).
+     *
+     * @param mixed $expected The expected value.
+     * @param mixed $actual The actual value to compare against the expected value.
+     * @param string $message Short description about what exactly is being asserted.
+     * @throws AssertException when the assertion fails.
+     */
+    public static function equal(mixed $expected, mixed $actual, string $message = ''): void
+    {
+        $actual == $expected
+            ? StaticState::log('Assert equal: `' . Support::stringify($expected) . '`', $message)
+            : StaticState::fail(AssertException::compare($expected, $actual, $message));
+    }
+
+    /**
+     * Asserts that two values are not equal (not strict).
+     *
+     * @param mixed $expected The expected value.
+     * @param mixed $actual The actual value to compare against the expected value.
+     * @param string $message Short description about what exactly is being asserted.
+     * @throws AssertException when the assertion fails.
+     */
+    public static function notEqual(mixed $expected, mixed $actual, string $message = ''): void
+    {
+        $actual != $expected
+            ? StaticState::log('Assert not equal: `' . Support::stringify($expected) . '`', $message)
+            : StaticState::fail(AssertException::compare(
+                $expected,
+                $actual,
+                $message,
+                pattern: 'Failed asserting that `%1s` is not equal to `%2s`',
+                showDiff: false,
+            ));
+    }
+
+    /**
      * Asserts that the condition is true.
      *
      * @param bool $condition The condition asserting to be true.
@@ -104,7 +140,7 @@ final class Assert
                 $expected,
                 $actual,
                 $message,
-                'Expected instance of `%2$s`, got `%1$s`',
+                'Expected instance of `%1$s`, got `%2$s`',
             ));
     }
 
@@ -128,7 +164,7 @@ final class Assert
             $needle,
             $haystack,
             $message,
-            'Failed asserting that `%1$s` contains `%2$s`',
+            'Failed asserting that `%2$s` contains `%1$s`',
         ));
     }
 

--- a/src/Assert/State/AssertException.php
+++ b/src/Assert/State/AssertException.php
@@ -45,8 +45,8 @@ final class AssertException extends \Exception implements Record
 
         $msg = \sprintf(
             $pattern,
-            Support::stringify($actual),
             Support::stringify($expected),
+            Support::stringify($actual),
         );
         return new self(
             assertion: $msg,

--- a/tests/Testo/AsserTest.php
+++ b/tests/Testo/AsserTest.php
@@ -22,6 +22,8 @@ final class AsserTest
         Assert::contains(1, [1,2,3]);
         Assert::contains(2, new \ArrayIterator([1,2,3]));
         Assert::instanceOf(\Exception::class, new \RuntimeException());
+        Assert::equal(1, '1');
+        Assert::notEqual(42,43);
     }
 
     #[Test]

--- a/tests/Testo/AsserTest.php
+++ b/tests/Testo/AsserTest.php
@@ -9,6 +9,9 @@ use Testo\Attribute\ExpectException;
 use Testo\Attribute\RetryPolicy;
 use Testo\Attribute\Test;
 
+/**
+ * Assertion examples.
+ */
 final class AsserTest
 {
     #[Test]
@@ -22,8 +25,8 @@ final class AsserTest
         Assert::contains(1, [1,2,3]);
         Assert::contains(2, new \ArrayIterator([1,2,3]));
         Assert::instanceOf(\Exception::class, new \RuntimeException());
-        Assert::equal(1, '1');
-        Assert::notEqual(42,43);
+        Assert::equals(1, '1');
+        Assert::notEquals(42, 43);
     }
 
     #[Test]

--- a/tests/Testo/Assert/AssertEquals.php
+++ b/tests/Testo/Assert/AssertEquals.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Assert;
+
+use Testo\Assert;
+use Testo\Attribute\Test;
+
+/**
+ * Assertion examples.
+ */
+final class AssertEquals
+{
+    #[Test]
+    public function numbers(): void
+    {
+        Assert::equals(1, 1);
+        Assert::equals(1, 1.0);
+        Assert::equals(1.0, 1);
+        Assert::equals("2", 2);
+    }
+
+    #[Test]
+    public function arrays(): void
+    {
+        # Same
+        Assert::equals([1, 2], [1, 2]);
+        Assert::equals(
+            ['a' => 1, 'b' => 2],
+            ['a' => 1, 'b' => 2],
+        );
+        # Different order
+        Assert::equals(
+            ['b' => 2, 'a' => 1],
+            ['a' => 1, 'b' => 2],
+        );
+    }
+
+    #[Test]
+    public function objects(): void
+    {
+        Assert::equals(
+            (object) ['a' => 1, 'b' => 2],
+            (object) ['b' => 2, 'a' => 1],
+        );
+    }
+}

--- a/tests/Testo/Assert/AssertNotEquals.php
+++ b/tests/Testo/Assert/AssertNotEquals.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Assert;
+
+use Testo\Assert;
+use Testo\Attribute\Test;
+
+/**
+ * Assertion examples.
+ */
+final class AssertNotEquals
+{
+    #[Test]
+    public function numbers(): void
+    {
+        Assert::notEquals(1, 2);
+    }
+
+    #[Test]
+    public function arrays(): void
+    {
+        Assert::notEquals([2, 1], [1, 2]);
+    }
+
+    #[Test]
+    public function objects(): void
+    {
+        Assert::notEquals(
+            (object) ['a' => 1],
+            (object) ['a' => 2],
+        );
+    }
+}


### PR DESCRIPTION
- feat: add new `Assert:equal()`, `Assert::notEqual()`
- fix: change expected and actual values in correct order in default compare message

<!-- Thanks for opening a PR! -->

## What was changed

- Added new `Assert:equal()`, `Assert::notEqual()` methods for not strict comparison
- Changed expected and actual values in compare method, placed them in correct order in default compare message

See commit history for details.

## Why?

On order to fill simple Assert methods library.

## Checklist

- Closes #<!-- add issue number here -->
- Tested
  - [x] Tested manually
  - [x] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->
