### PR TITLE
feat(assert): add `Assert::lessThan` and `Assert::lessThanOrEqual`

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -92,6 +92,48 @@ final class Assert
     }
 
     /**
+     * Asserts that actual value is less than the defined maximum.
+     *
+     * @param mixed $maximum The defined maximum value.
+     * @param mixed $actual The actual value to compare against the maximum value.
+     * @param string $message Short description about what exactly is being asserted.
+     * @throws AssertException when the assertion fails.
+     */
+    public static function lessThan(mixed $maximum, mixed $actual, string $message = ''): void
+    {
+        $actual < $maximum
+            ? StaticState::log('Assert `' . Support::stringify($actual) . '` is less than: `' . Support::stringify($maximum) . '`', $message)
+            : StaticState::fail(AssertException::compare(
+                $maximum,
+                $actual,
+                $message,
+                pattern: 'Failed asserting that `%2s` is less than `%1s`',
+                showDiff: false,
+            ));
+    }
+
+    /**
+     * Asserts that actual value is less than or equal to the defined maximum.
+     *
+     * @param mixed $maximum The defined maximum value.
+     * @param mixed $actual The actual value to compare against the maximum value.
+     * @param string $message Short description about what exactly is being asserted.
+     * @throws AssertException when the assertion fails.
+     */
+    public static function lessThanOrEqual(mixed $maximum, mixed $actual, string $message = ''): void
+    {
+        $actual <= $maximum
+            ? StaticState::log('Assert `' . Support::stringify($actual) . '` is less than or equal to: `' . Support::stringify($maximum) . '`', $message)
+            : StaticState::fail(AssertException::compare(
+                $maximum,
+                $actual,
+                $message,
+                pattern: 'Failed asserting that `%2s` is less than or equal to `%1s`',
+                showDiff: false,
+            ));
+    }
+
+    /**
      * Asserts that the condition is true.
      *
      * @param bool $condition The condition asserting to be true.

--- a/tests/Testo/AsserTest.php
+++ b/tests/Testo/AsserTest.php
@@ -27,6 +27,8 @@ final class AsserTest
         Assert::instanceOf(\Exception::class, new \RuntimeException());
         Assert::equals(1, '1');
         Assert::notEquals(42, 43);
+        Assert::lessThan(2, 1);
+        Assert::lessThanOrEqual(2, 1);
     }
 
     #[Test]

--- a/tests/Testo/Assert/AssertLessThan.php
+++ b/tests/Testo/Assert/AssertLessThan.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Assert;
+
+use Testo\Assert;
+use Testo\Attribute\Test;
+
+/**
+ * Assertion examples.
+ */
+final class AssertLessThan
+{
+    #[Test]
+    public function numbers(): void
+    {
+        Assert::lessThan(2, 1);
+        Assert::lessThan(1.1, 1);
+        Assert::lessThan('2', 1); //'2' coerces to 2
+    }
+
+    #[Test]
+    public function strings(): void
+    {
+        Assert::lessThan("43", "42"); // numeric strings are cast to numbers
+        Assert::lessThan("aaaa", "aaa"); // shorter string is smaller
+        Assert::lessThan("beerz", "beers"); // byte-wise comparison (first different letters are compared as byte values)
+    }
+
+    #[Test]
+    public function arrays(): void
+    {
+        Assert::lessThan([1, 2, 3], [1, 2]); // prefix rule: shorter wins
+        Assert::lessThan([1, 4], [1, 3]); // first differing element decides: 3 < 4
+        Assert::lessThan(['a' => 1, 'b' => 2, 'c' => 0], ['a' => 1, 'b' => 2]); // associative, same key order: shorter wins
+
+        // comparison of associative arrays with different keys won't work and throws AssertException:
+        // Assert::lessThan(['a' => 1, 'x' => 999], ['a' => 1, 'b' => 1]);
+    }
+
+    #[Test]
+    public function datetimes(): void
+    {
+        $max  = new \DateTimeImmutable('2025-01-02 00:00:00+00:00');
+        $actual = new \DateTimeImmutable('2025-01-01 00:00:00+00:00');
+        Assert::lessThan($max, $actual); // earlier time is smaller
+    }
+}

--- a/tests/Testo/Assert/AssertLessThanOrEqual.php
+++ b/tests/Testo/Assert/AssertLessThanOrEqual.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Assert;
+
+use Testo\Assert;
+use Testo\Attribute\Test;
+
+/**
+ * Assertion examples.
+ */
+final class AssertLessThanOrEqual
+{
+    #[Test]
+    public function numbers(): void
+    {
+        Assert::lessThanOrEqual(2, 1);
+        Assert::lessThanOrEqual(1.1, 1);
+        Assert::lessThanOrEqual('2', 1); //'1' coerces to 1
+        Assert::lessThanOrEqual('1', 1);
+    }
+
+    #[Test]
+    public function strings(): void
+    {
+        Assert::lessThanOrEqual("42", "42"); // numeric strings are cast to numbers
+        Assert::lessThanOrEqual("43", "42");
+        Assert::lessThanOrEqual("aaaa", "aaa"); // shorter string is smaller
+        Assert::lessThanOrEqual("aaa", "aaa");
+        Assert::lessThanOrEqual("beerz", "beers"); // byte-wise comparison (first different letters are compared as byte values)
+    }
+
+    #[Test]
+    public function arrays(): void
+    {
+        Assert::lessThanOrEqual([1, 2], [1, 2]); // same arrays considered equal
+        Assert::lessThanOrEqual([1, 2, 3], [1, 2]); // prefix rule: shorter wins
+        Assert::lessThanOrEqual([1, 4], [1, 3]); // first differing element decides: 3 < 4
+        Assert::lessThanOrEqual(['a' => 1, 'b' => 2, 'c' => 0], ['a' => 1, 'b' => 2]); // associative, same key order: shorter wins
+        Assert::lessThanOrEqual(['b' => 2, 'a' => 1], ['a' => 1, 'b' => 2]); // associative arrays, same elements, different order - considered equal
+
+        // comparison of associative arrays with different keys won't work and throws AssertException:
+        // Assert::lessThanOrEqual(['a' => 1, 'x' => 999], ['a' => 1, 'b' => 1]);
+    }
+
+    #[Test]
+    public function datetimes(): void
+    {
+        $max  = new \DateTimeImmutable('2025-01-02 00:00:00+00:00');
+        $actual1 = new \DateTimeImmutable('2025-01-01 00:00:00+00:00');
+        $actual2 = new \DateTimeImmutable('2025-01-02 00:00:00+00:00');
+        Assert::lessThanOrEqual($max, $actual1); // earlier time is smaller
+        Assert::lessThanOrEqual($max, $actual2); // same times are equal
+    }
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! -->

## What was changed

Added new `Assert::lessThan()` and `Assert::lessThanOrEqual()` methods

See commit history for details.

## Why?

Filling Assert methods library.

## Checklist

- Closes #<!-- add issue number here -->
- Tested
  - [x] Tested manually
  - [x] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->

I just noticed that I named methods in commit message as `Assert::lesser` instead of `Assert::less`. It is correct in the code though: `Assert::less()` as it should be. 
Should I change messages?