### PR TITLE
Implement filter functionality

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,169 @@
+# Command Line Interface
+
+This document describes the command line interface for Testo.
+
+## Commands
+
+### `run`
+
+Execute test suites with optional filtering and output formatting.
+
+This is the default command and can be omitted when using flags.
+
+```bash
+./bin/testo run [options]
+./bin/testo [options]  # run is optional
+```
+
+**Examples:**
+```bash
+# Explicit run command
+./bin/testo run
+./bin/testo run --suite=Unit
+
+# Implicit run command (default)
+./bin/testo
+./bin/testo --suite=Unit
+```
+
+## Common Configuration Flags
+
+### `--config`
+
+Specify path to configuration file.
+
+**Default:** `./testo.php`
+
+**Examples:**
+```bash
+./bin/testo run --config=./custom-testo.php
+./bin/testo run --suite=Integration --config=./ci-testo.php
+```
+
+## Running Tests
+
+### Output Formatting
+
+#### `--teamcity`
+
+Enable TeamCity service message format for JetBrains IDE integration.
+
+Used by the [Testo plugin](https://plugins.jetbrains.com/plugin/28842-testo) for PHPStorm/IntelliJ IDEA and TeamCity CI server.
+
+**Examples:**
+```bash
+./bin/testo --teamcity
+./bin/testo --suite=Unit --teamcity
+```
+
+### Filtering
+
+Testo provides three types of filters that can be combined to selectively run tests.
+
+**Filter Combination Logic:**
+- Same type filters use OR logic: `--filter=test1 --filter=test2` → test1 OR test2
+- Different type filters use AND logic: `--filter=test1 --suite=Unit` → test1 AND Unit
+- Formula: `AND(OR(filters), OR(paths), OR(suites))`
+
+For detailed information about filtering behavior, see [filter.md](filter.md).
+
+#### `--suite`
+
+Filter tests by test suite name. Suites are defined in configuration.
+
+**Repeatable:** Yes (OR logic)
+
+**Examples:**
+```bash
+# Single suite
+./bin/testo run --suite=Unit
+
+# Multiple suites
+./bin/testo run --suite=Unit --suite=Integration
+```
+
+#### `--path`
+
+Filter test files by glob patterns. Supports wildcards: `*`, `?`, `[abc]`
+
+**Repeatable:** Yes (OR logic)
+
+**Note:** Asterisk `*` is automatically appended if the path doesn't end with a wildcard.
+- `tests/Unit` becomes `tests/Unit*`
+- `tests/Unit/` becomes `tests/Unit/*`
+
+**Examples:**
+```bash
+# Matches tests/Unit*
+./bin/testo run --path="tests/Unit"
+
+# Matches tests/Unit/*Test.php
+./bin/testo run --path="tests/Unit/*Test.php"
+
+# Multiple paths
+./bin/testo run --path="tests/Unit" --path="tests/Integration"
+
+# Nested directories
+./bin/testo run --path="tests/*/Security/*Test.php"
+```
+
+#### `--filter`
+
+Filter tests by class, method, or function names.
+
+**Repeatable:** Yes (OR logic)
+
+**Supported Formats:**
+- **Method**: `ClassName::methodName` or `Namespace\ClassName::methodName`
+- **FQN**: `Namespace\ClassName` or `Namespace\functionName`
+- **Fragment**: `methodName`, `functionName`, or `ShortClassName`
+
+**Examples:**
+```bash
+# Specific method
+./bin/testo run --filter=UserTest::testLogin
+
+# Entire class
+./bin/testo run --filter=UserTest
+
+# By FQN
+./bin/testo run --filter=Tests\Unit\UserTest
+
+# Method name across all classes
+./bin/testo run --filter=testLogin
+
+# Multiple filters (OR)
+./bin/testo run --filter=UserTest::testCreate --filter=UserTest::testUpdate
+
+# Combine with other filters (AND)
+./bin/testo run --filter=testAuthentication --suite=Unit
+./bin/testo run --filter=UserTest --path="tests/Unit"
+```
+
+**Filter Behavior:** See [filter.md](filter.md) for details.
+
+### Combining Filters
+
+**Examples:**
+```bash
+# Name AND suite
+./bin/testo run --filter=testLogin --suite=Unit
+
+# Name AND path
+./bin/testo run --filter=UserTest --path="tests/Unit"
+
+# All three types (AND)
+./bin/testo run --filter=testImportant --path="tests/Unit" --suite=Critical
+
+# Multiple values with multiple types
+./bin/testo run \
+  --filter=testCreate --filter=testUpdate \
+  --path="tests/Unit" --path="tests/Integration" \
+  --suite=Critical
+```
+
+## Exit Codes
+
+- `0` (SUCCESS): All tests passed
+- `1` (FAILURE): One or more tests failed
+- `2` (INVALID): Invalid command or configuration

--- a/docs/filter.md
+++ b/docs/filter.md
@@ -1,0 +1,193 @@
+# Test Filtering
+
+This document describes the business logic of test filtering in Testo.
+
+## Overview
+
+Testo provides a flexible filtering system that operates in multiple stages to progressively narrow down the test set. Filtering can be controlled programmatically via the `Filter` class or automatically from CLI arguments.
+
+## Filter Class
+
+The `Testo\Common\Filter` class is an immutable DTO containing test filtering criteria:
+
+```php
+use Testo\Common\Filter;
+
+$filter = new Filter(
+    suites: ['Unit', 'Integration'],
+    names: ['UserTest::testLogin', 'testAuthentication'],
+    paths: ['tests/Unit/*', 'tests/Integration/*'],
+);
+```
+
+### Properties
+
+**`testSuites`**: `list<non-empty-string>`
+- Test suite names to filter by
+- Used in Stage 1 to determine which configuration scopes to load
+
+**`names`**: `list<non-empty-string>`
+- Class, method, or function names to filter by
+- Supports three formats:
+  - Method: `ClassName::methodName` or `Namespace\ClassName::methodName`
+  - FQN: `Namespace\ClassName` or `Namespace\functionName`
+  - Fragment: `methodName`, `functionName`, or `ShortClassName`
+
+**`paths`**: `list<non-empty-string>`
+- File or directory paths to filter by
+- Supports glob patterns: `*`, `?`, `[abc]`
+
+### Usage with Application
+
+The `Filter` object can be passed to `Application::run()`:
+
+```php
+use Testo\Application;
+use Testo\Common\Filter;
+
+$app = Application::createFromInput(/* ... */);
+
+$filter = new Filter(
+    suites: ['Unit'],
+    names: ['UserTest'],
+);
+
+$result = $app->run($filter);
+```
+
+When running from CLI, the `Filter` is populated automatically from command arguments via `Filter::fromScope()`.
+
+## Filter Combination Logic
+
+### Same Type: OR Logic
+
+Multiple values within the same filter type are combined with OR logic:
+
+- `names: ['test1', 'test2']` → matches if name is test1 **OR** test2
+- `paths: ['path1', 'path2']` → matches if path is path1 **OR** path2
+- `suites: ['Unit', 'Integration']` → matches if suite is Unit **OR** Integration
+
+### Different Types: AND Logic
+
+Different filter types are combined with AND logic:
+
+- `names: ['test1'], suites: ['Unit']` → matches if name is test1 **AND** suite is Unit
+- `names: ['UserTest'], paths: ['tests/Unit/*']` → matches if name is UserTest **AND** path matches tests/Unit/*
+
+**Formula**: `AND(OR(names), OR(paths), OR(suites))`
+
+**Example:**
+```php
+$filter = new Filter(
+    names: ['test1', 'test2'],        // test1 OR test2
+    paths: ['path1', 'path2'],        // path1 OR path2
+    suites: ['Unit', 'Critical'], // Unit OR Critical
+);
+// Result: (test1 OR test2) AND (path1 OR path2) AND (Unit OR Critical)
+```
+
+## Name Filter Behavior
+
+The behavior of name filtering is implemented in `FilterInterceptor` and depends on the name format:
+
+### Method Format (`ClassName::methodName`)
+
+When using method format with `::` separator:
+- Only the specified method is matched
+- Other methods in the same class are excluded
+- Result: Test case with **only the specified method**
+
+**Example:**
+```php
+$filter = new Filter(names: ['UserTest::testLogin']);
+// Result: UserTest class with only testLogin method
+```
+
+### FQN or Fragment Format
+
+When using FQN (with `\`) or simple fragment (no separators):
+
+**Case 1: Class name matches**
+- Result: **Entire test case with all methods**
+
+**Case 2: Class name doesn't match**
+- System checks individual methods/functions
+- Result: Test case with **only matched methods**
+- If no methods match: Test case is skipped
+
+**Examples:**
+```php
+// FQN - matches entire class
+$filter = new Filter(names: ['Tests\Unit\UserTest']);
+// Result: UserTest class with all methods
+
+// Fragment - matches entire class
+$filter = new Filter(names: ['UserTest']);
+// Result: UserTest class with all methods
+
+// Fragment - matches method in any class
+$filter = new Filter(names: ['testLogin']);
+// Result: All classes with testLogin method, each with only that method
+```
+
+## Filtering Pipeline
+
+Filtering operates in four stages:
+
+### Stage 1: Suite Filter (Configuration Level)
+
+**Input:** `Filter::$suites`
+
+- Filters configuration scopes based on suite names
+- Each suite defines file scanning locations and patterns
+- Determines initial set of directories to scan
+- Multiple suites use OR logic
+
+### Stage 2: Path Filter (Finder Level)
+
+**Input:** `Filter::$paths`
+
+- Applied at file finder level during directory scanning
+- Uses glob patterns to match file paths
+- Supports wildcards: `*`, `?`, `[abc]`
+- Multiple paths use OR logic
+- Returns list of files to be processed
+
+### Stage 3: File Filter (Tokenizer Level)
+
+**Input:** `Filter::$names`
+**Implementation:** `FilterInterceptor::locateFile()`
+
+- Pre-filters test files before loading for reflection
+- Uses lightweight tokenization instead of full reflection
+- Checks if file contains any matching classes, methods, or functions
+- Skips files that don't match any patterns
+- Multiple names use OR logic
+
+### Stage 4: Test Filter (Reflection Level)
+
+**Input:** `Filter::$names`
+**Implementation:** `FilterInterceptor::locateTestCases()`
+
+- Filters individual test cases and methods after reflection
+- Implements hierarchical filtering:
+  - For method format (`::`) - filters specific methods only
+  - For FQN/fragment format - checks class name first, then methods
+- Returns filtered test case definitions ready for execution
+
+## Pattern Matching
+
+`FilterInterceptor` uses whole-word boundary matching with regex:
+
+```php
+private static function has(string $needle, string $haystack): bool
+{
+    return \preg_match('/\\b' . \preg_quote($needle, '/') . '\\b$/', $haystack) === 1;
+}
+```
+
+**Behavior:**
+- `User` matches `App\User` ✓
+- `User` does NOT match `App\UserManager` ✗
+- `test` matches `testMethod` ✓
+- `test` does NOT match `latestMethod` ✗

--- a/src/Application.php
+++ b/src/Application.php
@@ -75,19 +75,22 @@ final class Application
 
         # Register Config inflector
         $container->addInflector($container->make(ConfigInflector::class, $args));
+        $container->bind(Filter::class, Filter::fromScope(...));
 
         return new self($container);
     }
 
-    public function run($filter = new Filter()): RunResult
+    public function run(?Filter $filter = null): RunResult
     {
-        $suiteResults = [];
+        $filter === null or $this->container->set($filter);
+        $filter ??= $this->container->get(Filter::class);
 
         $suiteProvider = $this->container->get(SuiteProvider::class);
         $suiteRunner = $this->container->get(SuiteRunner::class);
         $status = Status::Passed;
 
         # Iterate Test Suites
+        $suiteResults = [];
         foreach ($suiteProvider->withFilter($filter)->getSuites() as $suite) {
             $suiteResults[] = $suiteResult = $suiteRunner->runSuite($suite, $filter);
             $suiteResult->status->isFailure() and $status = Status::Failed;

--- a/src/Common/Command/Run.php
+++ b/src/Common/Command/Run.php
@@ -10,8 +10,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Testo\Common\Filter;
-use Testo\Common\Input\RunScope;
 use Testo\Render\StdoutRenderer;
 use Testo\Render\TeamcityInterceptor;
 use Testo\Render\TerminalInterceptor;
@@ -26,7 +24,18 @@ final class Run extends Base
         parent::configure();
         $this->addArgument('path', InputArgument::OPTIONAL, 'Path to tests', '');
         $this->addOption('teamcity', null, InputOption::VALUE_NONE);
-        $this->addOption('filter', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Test suites to be run');
+        $this->addOption(
+            'filter',
+            null,
+            InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+            'Filter methods or functions to be run',
+        );
+        $this->addOption(
+            'path',
+            null,
+            InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+            'Glob patterns for test files to be run',
+        );
     }
 
     public function __invoke(
@@ -37,13 +46,7 @@ final class Run extends Base
             ? $this->container->bind(StdoutRenderer::class, TeamcityInterceptor::class)
             : $this->container->bind(StdoutRenderer::class, TerminalInterceptor::class);
 
-        tr($this->container->get(RunScope::class));
-        $filter = new Filter();
-        $filterOptions = $input->getOption('filter');
-        if ($filterOptions) {
-            $filter = $filter->withTestSuites(...$filterOptions);
-        }
-        $result = $this->application->run($filter);
+        $result = $this->application->run();
 
         return $result->status->isSuccessful()
             ? Command::SUCCESS

--- a/src/Common/Command/Run.php
+++ b/src/Common/Command/Run.php
@@ -14,6 +14,52 @@ use Testo\Render\StdoutRenderer;
 use Testo\Render\TeamcityInterceptor;
 use Testo\Render\TerminalInterceptor;
 
+/**
+ * Executes test suites with optional filtering and custom output formatting.
+ *
+ * Runs tests from specified paths with support for method/function filtering,
+ * test suite filtering, glob pattern matching for test discovery, and output
+ * format selection for different environments (terminal or CI systems like TeamCity).
+ *
+ * Filter Logic:
+ * - Multiple values of same filter type use OR logic (e.g., --filter=test1 --filter=test2)
+ * - Different filter types use AND logic (e.g., --filter + --path + --suite)
+ * - Final result: AND(OR(filters), OR(paths), OR(suites))
+ *
+ * ```bash
+ *  # Run all tests in default location
+ *  ./bin/testo run
+ *
+ *  # Run tests from specific directory
+ *  ./bin/testo run tests/Unit
+ *
+ *  # Run tests matching glob patterns (wildcards supported)
+ *  ./bin/testo run --path="tests/Unit/*Test.php" --path="tests/Integration/*Test.php"
+ *
+ *  # Filter specific test methods or functions by name (OR logic)
+ *  ./bin/testo run --filter=testUserAuthentication --filter=testDatabaseConnection
+ *
+ *  # Filter specific methods in classes (using short name or FQN)
+ *  ./bin/testo run --filter="UserTest::testAuthentication"
+ *  ./bin/testo run --filter="Tests\Unit\UserTest::testAuthentication"
+ *
+ *  # Filter by test suite name (OR logic)
+ *  ./bin/testo run --suite=Unit --suite=Integration
+ *
+ *  # Combine filters with AND logic between types
+ *  # Runs tests that match (UserTest::testCreate OR UserTest::testUpdate) AND (Critical suite)
+ *  ./bin/testo run --filter=UserTest::testCreate --filter=UserTest::testUpdate --suite=Critical
+ *
+ *  # Complex filtering: path AND filter AND suite
+ *  # Runs tests in Unit directory that match testImportant* AND are in Critical suite
+ *  ./bin/testo run --path="tests/Unit/*" --filter=testImportant --suite=Critical
+ *
+ *  # Run tests with custom config
+ *  ./bin/testo run --config=./testo.php
+ * ```
+ *
+ * @internal
+ */
 #[AsCommand(
     name: 'run',
 )]
@@ -35,6 +81,12 @@ final class Run extends Base
             null,
             InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
             'Glob patterns for test files to be run',
+        );
+        $this->addOption(
+            'suite',
+            null,
+            InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+            'Filter test suites by name',
         );
     }
 

--- a/src/Common/Command/Run.php
+++ b/src/Common/Command/Run.php
@@ -6,7 +6,6 @@ namespace Testo\Common\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -68,7 +67,6 @@ final class Run extends Base
     public function configure(): void
     {
         parent::configure();
-        $this->addArgument('path', InputArgument::OPTIONAL, 'Path to tests', '');
         $this->addOption('teamcity', null, InputOption::VALUE_NONE);
         $this->addOption(
             'filter',

--- a/src/Common/Filter.php
+++ b/src/Common/Filter.php
@@ -7,33 +7,55 @@ namespace Testo\Common;
 use Testo\Common\Input\RunScope;
 
 /**
- * Filter tests by various criteria.
+ * Immutable DTO containing test filtering criteria.
  *
- * todo: Implement filtering logic.
+ * Can be created manually and passed to Application::run() or populated automatically
+ * from CLI arguments.
  */
 final class Filter
 {
-    use CloneWith;
-
-    // private readonly $conditionFile
-
     public function __construct(
         /**
-         * @var list<non-empty-string> Names of the test suites to filter by.
+         * Test suite names to filter by.
+         *
+         * @var list<non-empty-string>
          */
-        public readonly array $testSuites = [],
+        public readonly array $suites = [],
 
         /**
-         * @var list<non-empty-string> List of class, method, or function names to filter by.
+         * Class, method, or function names to filter by.
+         *
+         * Supports formats:
+         * - Method: ClassName::methodName or Namespace\ClassName::methodName
+         * - FQN: Namespace\ClassName or Namespace\functionName
+         * - Fragment: methodName, functionName, or ShortClassName
+         *
+         * @var list<non-empty-string>
          */
         public readonly array $names = [],
 
         /**
-         * @var list<non-empty-string> List of file or dir paths to filter by.
+         * File or directory paths to filter by.
+         *
+         * Supports glob patterns: *, ?, [abc]
+         *
+         * @var list<non-empty-string>
          */
         public readonly array $paths = [],
     ) {}
 
+    /**
+     * Create Filter from RunScope populated by CLI arguments.
+     *
+     * Automatically categorizes filter values from CLI:
+     * - Values containing dots or existing file paths → paths
+     * - Other values → names
+     * - Suite values → testSuites
+     *
+     * @param RunScope $scope Configuration scope with CLI arguments
+     *
+     * @return self New Filter instance with categorized criteria
+     */
     public static function fromScope(RunScope $scope): self
     {
         // TODO remove in the future
@@ -44,27 +66,30 @@ final class Filter
         $filter = \array_diff($scope->filter, $files);
 
         return new self(
-            testSuites: $scope->suite,
+            suites: $scope->suite,
             names: $filter,
             paths: \array_merge($scope->path, $files),
         );
     }
 
     /**
-     * Filter tests by Suite names.
+     * Create a new Filter instance with modified properties.
      *
-     * @param non-empty-string ...$names Names of the test suites to filter by.
+     * @param list<non-empty-string>|null $testSuites New test suite names, or null to keep existing
+     * @param list<non-empty-string>|null $names New names, or null to keep existing
+     * @param list<non-empty-string>|null $paths New paths, or null to keep existing
      *
-     * @return self A new instance of Filter with the specified test names.
+     * @return self New Filter instance with updated properties
      */
-    public function withTestSuites(string ...$names): self
-    {
-        return $this->cloneWith('testSuites', \array_unique(\array_merge($this->testSuites, $names)));
-    }
-
-    public function withTestCases($name): self
-    {
-        // TODO
-        return $this;
+    public function with(
+        ?array $testSuites = null,
+        ?array $names = null,
+        ?array $paths = null,
+    ): self {
+        return new self(
+            suites: $testSuites ?? $this->suites,
+            names: $names ?? $this->names,
+            paths: $paths ?? $this->paths,
+        );
     }
 }

--- a/src/Common/Filter.php
+++ b/src/Common/Filter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Testo\Common;
 
+use Testo\Common\Input\RunScope;
+
 /**
  * Filter tests by various criteria.
  *
@@ -13,12 +15,40 @@ final class Filter
 {
     use CloneWith;
 
+    // private readonly $conditionFile
+
     public function __construct(
         /**
          * @var list<non-empty-string> Names of the test suites to filter by.
          */
         public readonly array $testSuites = [],
+
+        /**
+         * @var list<non-empty-string> List of class, method, or function names to filter by.
+         */
+        public readonly array $names = [],
+
+        /**
+         * @var list<non-empty-string> List of file or dir paths to filter by.
+         */
+        public readonly array $paths = [],
     ) {}
+
+    public static function fromScope(RunScope $scope): self
+    {
+        // TODO remove in the future
+        $files = \array_filter(
+            $scope->filter,
+            static fn($value) => \str_contains($value, '.') || \file_exists($value),
+        );
+        $filter = \array_diff($scope->filter, $files);
+
+        return new self(
+            testSuites: $scope->suite,
+            names: $filter,
+            paths: \array_merge($scope->path, $files),
+        );
+    }
 
     /**
      * Filter tests by Suite names.

--- a/src/Common/Input/RunScope.php
+++ b/src/Common/Input/RunScope.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Testo\Common\Input;
 
 use Testo\Config\Internal\Attribute\InflectableConfig;
-use Testo\Config\Internal\Attribute\InputArgument;
 use Testo\Config\Internal\Attribute\InputOption;
 
 /**
@@ -15,13 +14,20 @@ use Testo\Config\Internal\Attribute\InputOption;
 final class RunScope
 {
     /**
-     * Comma-separated list of filters to apply.
-     *
      * @var non-empty-string[]
      */
     #[InputOption('filter')]
     public array $filter = [];
 
-    #[InputArgument('path')]
-    public string $path = '';
+    /**
+     * @var non-empty-string[]
+     */
+    #[InputOption('path')]
+    public array $path = [];
+
+    /**
+     * @var non-empty-string[]
+     */
+    #[InputOption('suite')]
+    public array $suite = [];
 }

--- a/src/Common/Internal/ObjectContainer.php
+++ b/src/Common/Internal/ObjectContainer.php
@@ -64,7 +64,7 @@ final class ObjectContainer implements Container
     public function set(object $service, ?string $id = null): void
     {
         \assert($id === null || $service instanceof $id, "Service must be instance of {$id}.");
-        $this->cache[$id ?? \get_class($service)] = $service;
+        $this->cache[$id ?? $service::class] = $service;
     }
 
     public function make(string $class, array $arguments = []): object

--- a/src/Common/Path.php
+++ b/src/Common/Path.php
@@ -197,6 +197,23 @@ final class Path implements \Stringable
     }
 
     /**
+     * Match the path against a pattern using shell wildcard pattern matching.
+     *
+     * Both the path and pattern are converted to absolute paths before matching.
+     * Supports standard wildcards: * (any characters), ? (single character), [abc] (character class).
+     *
+     * @param non-empty-string|self $pattern The pattern to match against. Can be a string path or Path object.
+     *        Will be converted to absolute path before matching.
+     *
+     * @return bool True if the path matches the pattern, false otherwise.
+     */
+    public function match(string|self $pattern): bool
+    {
+        \is_string($pattern) and $pattern = self::create($pattern);
+        return \fnmatch((string) $pattern->absolute(), $this->absolute()->path, \FNM_NOESCAPE | \FNM_CASEFOLD);
+    }
+
+    /**
      * Return a normalized relative version of this path.
      *
      * @return non-empty-string

--- a/src/Interceptor/Locator/FilterInterceptor.php
+++ b/src/Interceptor/Locator/FilterInterceptor.php
@@ -162,6 +162,14 @@ final class FilterInterceptor implements FileLocatorInterceptor, CaseLocatorInte
     }
 
     /**
+     * @return bool True if the needle is found as a whole word in the haystack, false otherwise.
+     */
+    private static function has(string $needle, string $haystack): bool
+    {
+        return \preg_match('/\\b' . \preg_quote($needle, '/') . '\\b$/', $haystack) === 1;
+    }
+
+    /**
      * Check if tokenized file contains any matching classes, functions, or methods.
      *
      * Performs quick matching against tokenized file data without loading full reflections.
@@ -209,13 +217,5 @@ final class FilterInterceptor implements FileLocatorInterceptor, CaseLocatorInte
         }
 
         return false;
-    }
-
-    /**
-     * @return bool True if the needle is found as a whole word in the haystack, false otherwise.
-     */
-    private static function has(string $needle, string $haystack): bool
-    {
-        return \preg_match('/\\b' . \preg_quote($needle, '/') . '\\b$/', $haystack) === 1;
     }
 }

--- a/src/Interceptor/Locator/FilterInterceptor.php
+++ b/src/Interceptor/Locator/FilterInterceptor.php
@@ -5,46 +5,217 @@ declare(strict_types=1);
 namespace Testo\Interceptor\Locator;
 
 use Testo\Common\Filter;
+use Testo\Interceptor\CaseLocatorInterceptor;
 use Testo\Interceptor\FileLocatorInterceptor;
+use Testo\Module\Tokenizer\Reflection\FileDefinitions;
 use Testo\Module\Tokenizer\Reflection\TokenizedFile;
+use Testo\Test\Dto\CaseDefinitions;
+use Testo\Test\Dto\TestDefinitions;
 
-final class FilterInterceptor implements FileLocatorInterceptor
+/**
+ * Two-stage interceptor for filtering test execution by name patterns.
+ *
+ * Stage 1 (FileLocatorInterceptor): Pre-filters test files before loading for reflection analysis.
+ * Stage 2 (CaseLocatorInterceptor): Filters test cases and individual tests before execution.
+ *
+ * Supports three filter formats:
+ * - FQN: Fully qualified names like `Namespace\ClassName` or `Namespace\functionName`
+ * - Method: Class and method pairs like `ClassName::methodName` or `Namespace\ClassName::methodName`
+ * - Fragment: Partial names like `methodName`, `functionName`, or `ShortClassName`
+ *
+ * Filtering logic (OR across all patterns):
+ * - If test case name (class name) matches: entire case passes with all tests
+ * - If test case name doesn't match: filter individual methods/functions
+ *   - If any methods/functions match: case passes with only matched tests
+ *   - If no methods/functions match: case is skipped entirely
+ */
+final class FilterInterceptor implements FileLocatorInterceptor, CaseLocatorInterceptor
 {
+    /** @var bool True if filtering is disabled (no filters provided) */
+    private readonly bool $skip;
+
+    /**
+     * Fully qualified names to filter by. Like `Namespace\ClassName` or `Namespace\functionName`.
+     * @var list<non-empty-string>
+     */
+    private readonly array $fqn;
+
+    /**
+     * Possible method names to filter by. Like `ClassName::methodName`.
+     *
+     * @var list<array{non-empty-string, non-empty-string}>
+     */
+    private readonly array $method;
+
+    /**
+     * Partial name fragment to filter by. Like `methodName`, `shortFunctionName`, or `ShortClassName`.
+     *
+     * @var list<non-empty-string>
+     */
+    private readonly array $fragment;
+
     public function __construct(
-        private readonly Filter $filter,
-    ) {}
+        Filter $filter,
+    ) {
+        $fqn = $method = $fragment = [];
+        foreach ($filter->names as $name) {
+            if (\str_contains($name, '::')) {
+                $method[] = \explode('::', \ltrim($name, '\\'), 2);
+            } elseif (\str_contains($name, '\\')) {
+                $fqn[] = \trim($name, '\\');
+            } else {
+                $fragment[] = $name;
+            }
+        }
 
-    public function locateFile(TokenizedFile $file, callable $next): ?bool
-    {
-        $failed = false;
-
-        $this->filter->names === [] or $failed = !$this->matchNames($file, $this->filter->names);
-
-        return $failed ? false : $next($file);
+        $this->skip = $fqn === [] && $method === [] && $fragment === [];
+        $this->fqn = $fqn;
+        $this->method = $method;
+        $this->fragment = $fragment;
     }
 
     /**
-     * @param non-empty-list<non-empty-string> $names
-     * @return bool True if any name matches, false otherwise.
+     * Stage 1: Filter test files before loading for reflection analysis.
+     *
+     * Performs quick pre-filtering based on tokenized file data to skip files
+     * that don't contain any matching classes, methods, or functions.
+     *
+     * @param TokenizedFile $file Tokenized file with class/function/method names
+     * @param callable(TokenizedFile): (null|bool) $next Next interceptor in the chain
+     *
+     * @return bool|null True to include file, false to skip, null for passthrough
      */
-    private function matchNames(TokenizedFile $file, array $names): bool
+    public function locateFile(TokenizedFile $file, callable $next): ?bool
     {
+        return match (true) {
+            $this->skip,
+            $this->matchFile($file) => $next($file),
+            default => false,
+        };
+    }
+
+    /**
+     * Stage 2: Filter test cases and methods after reflection analysis.
+     *
+     * Filters loaded test definitions based on class and method names:
+     * - If class name matches: includes entire case with all tests
+     * - If class name doesn't match: filters individual methods/functions
+     * - If no methods match: excludes entire case
+     *
+     * @param FileDefinitions $file File with test case definitions
+     * @param callable(FileDefinitions): CaseDefinitions $next Next interceptor in the chain
+     *
+     * @return CaseDefinitions Filtered test case definitions
+     */
+    public function locateTestCases(FileDefinitions $file, callable $next): CaseDefinitions
+    {
+        if ($this->skip) {
+            return $next($file);
+        }
+
+        $definitions = $next($file);
+
+        $result = [];
+        foreach ($definitions->getCases() as $case) {
+            $methods = [];
+            # Filter by class name
+            if ($case->reflection !== null) {
+                $className = $case->reflection->getName();
+                # Match class name
+                foreach ([...$this->fqn, ...$this->fragment] as $name) {
+                    if (self::has($name, $className)) {
+                        $result[] = $case;
+                        continue 2;
+                    }
+                }
+
+                # Match methods
+                foreach ($this->method as [$filterClass, $filterMethod]) {
+                    # Skip if class name does not match
+                    if (!self::has($filterClass, $className)) {
+                        continue;
+                    }
+
+                    # Match method name
+                    foreach ($case->tests->getTests() as $name => $test) {
+                        $filterMethod === $test->reflection->getShortName() and $methods[$name] = $test;
+                    }
+                }
+
+            }
+
+            # Filter by function name
+            foreach ($case->tests->getTests() as $name => $test) {
+                foreach ([...$this->fqn, ...$this->fragment] as $f) {
+                    if (self::has($f, $test->reflection->getName())) {
+                        $methods[$name] = $test;
+                        continue 2;
+                    }
+                }
+            }
+
+            # We have matched methods
+            $methods === [] or $result[] = $case->with(tests: TestDefinitions::fromArray(...$methods));
+        }
+
+        return CaseDefinitions::fromArray(...$result);
+    }
+
+    /**
+     * Check if tokenized file contains any matching classes, functions, or methods.
+     *
+     * Performs quick matching against tokenized file data without loading full reflections.
+     * Checks functions, classes, and methods in sequence, returning true on first match.
+     *
+     * @param TokenizedFile $file Tokenized file with extracted names
+     *
+     * @return bool True if any name matches, false otherwise
+     */
+    private function matchFile(TokenizedFile $file): bool
+    {
+        # Match functions
         foreach ($file->getFunctions() as $fqn) {
-            foreach ($names as $name) {
-                if (\preg_match('/\\b' . \preg_quote($name, '/') . '\\b/', $fqn) === 1) {
+            foreach ([...$this->fqn, ...$this->fragment] as $name) {
+                if (self::has($name, $fqn)) {
                     return true;
                 }
             }
         }
 
+        # Match classes
+        foreach ($file->getClasses() as $class) {
+            foreach ([...$this->fqn, ...$this->fragment] as $name) {
+                if (self::has($name, $class)) {
+                    return true;
+                }
+            }
+        }
+
+        # Match methods
         foreach ($file->getMethodsFQN() as $fqn) {
-            foreach ($names as $name) {
-                if (\preg_match('/\\b' . \preg_quote($name, '/') . '\\b/', $fqn) === 1) {
+            # By fragment
+            foreach ($this->fragment as $name) {
+                if (self::has($name, $fqn)) {
+                    return true;
+                }
+            }
+
+            # By class and method name
+            foreach ($this->method as [$className, $methodName]) {
+                if (self::has($className . '::' . $methodName, $fqn)) {
                     return true;
                 }
             }
         }
 
         return false;
+    }
+
+    /**
+     * @return bool True if the needle is found as a whole word in the haystack, false otherwise.
+     */
+    private static function has(string $needle, string $haystack): bool
+    {
+        return \preg_match('/\\b' . \preg_quote($needle, '/') . '\\b$/', $haystack) === 1;
     }
 }

--- a/src/Interceptor/Locator/FilterInterceptor.php
+++ b/src/Interceptor/Locator/FilterInterceptor.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Interceptor\Locator;
+
+use Testo\Common\Filter;
+use Testo\Interceptor\FileLocatorInterceptor;
+use Testo\Module\Tokenizer\Reflection\TokenizedFile;
+
+final class FilterInterceptor implements FileLocatorInterceptor
+{
+    public function __construct(
+        private readonly Filter $filter,
+    ) {}
+
+    public function locateFile(TokenizedFile $file, callable $next): ?bool
+    {
+        $failed = false;
+
+        $this->filter->names === [] or $failed = !$this->matchNames($file, $this->filter->names);
+
+        return $failed ? false : $next($file);
+    }
+
+    /**
+     * @param non-empty-list<non-empty-string> $names
+     * @return bool True if any name matches, false otherwise.
+     */
+    private function matchNames(TokenizedFile $file, array $names): bool
+    {
+        foreach ($file->getFunctions() as $fqn) {
+            foreach ($names as $name) {
+                if (\preg_match('/\\b' . \preg_quote($name, '/') . '\\b/', $fqn) === 1) {
+                    return true;
+                }
+            }
+        }
+
+        foreach ($file->getMethodsFQN() as $fqn) {
+            foreach ($names as $name) {
+                if (\preg_match('/\\b' . \preg_quote($name, '/') . '\\b/', $fqn) === 1) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Module/Finder/Finder.php
+++ b/src/Module/Finder/Finder.php
@@ -73,6 +73,20 @@ final class Finder implements \Countable, \IteratorAggregate
         return $this->finder->count();
     }
 
+    /**
+     * Apply a custom filter to the finder.
+     *
+     * @param \Closure(SplFileInfo): bool $filter A closure that defines the filtering logic.
+     *
+     * @psalm-immutable
+     */
+    public function withFilter(\Closure $filter): self
+    {
+        $self = clone $this;
+        $self->finder->filter($filter);
+        return $self;
+    }
+
     public function __clone(): void
     {
         $this->finder = clone $this->finder;

--- a/src/Module/Interceptor/InterceptorProvider.php
+++ b/src/Module/Interceptor/InterceptorProvider.php
@@ -8,6 +8,9 @@ use Testo\Assert\Interceptor\AssertCollectorInterceptor;
 use Testo\Assert\Interceptor\ExpectationsInterceptor;
 use Testo\Attribute\Interceptable;
 use Testo\Common\Container;
+use Testo\Interceptor\Locator\FilePostfixTestLocatorInterceptor;
+use Testo\Interceptor\Locator\FilterInterceptor;
+use Testo\Interceptor\Locator\TestoAttributesLocatorInterceptor;
 use Testo\Interceptor\Reflection\AttributesInterceptor;
 use Testo\Interceptor\Reflection\Reflection;
 use Testo\Interceptor\TestCaseCallInterceptor\InstantiateTestCase;
@@ -50,6 +53,9 @@ final class InterceptorProvider
     public function fromConfig(string $class): array
     {
         return $this->fromClasses($class, ...[
+            FilterInterceptor::class,
+            new FilePostfixTestLocatorInterceptor(),
+            new TestoAttributesLocatorInterceptor(),
             StdoutRenderer::class,
             new InstantiateTestCase(),
             new AssertCollectorInterceptor(),

--- a/src/Module/Tokenizer/FileLocator.php
+++ b/src/Module/Tokenizer/FileLocator.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Testo\Module\Tokenizer;
 
+use Testo\Common\Filter;
+use Testo\Common\Path;
+use Testo\Config\FinderConfig;
 use Testo\Module\Finder\Finder;
 use Testo\Module\Tokenizer\Reflection\TokenizedFile;
 
@@ -24,6 +27,28 @@ final class FileLocator implements \IteratorAggregate
         protected readonly bool $debug = false,
     ) {
         $this->finder = $finder->files();
+    }
+
+    public static function fromFinderConfig(FinderConfig $config, Filter $filter = new Filter()): self
+    {
+        $finder = new Finder($config);
+        $toFilter = $filter->paths;
+        $toFilter === [] or $finder = $finder->withFilter(
+            static function (\SplFileInfo $info) use ($toFilter): bool {
+                foreach ($toFilter as $pattern) {
+                    $path = Path::create($info->getRealPath());
+                    if ($path->match("$pattern*")) {
+                        return true;
+                    }
+                }
+
+                return false;
+            },
+        );
+
+        return new self(
+            $finder,
+        );
     }
 
     /**

--- a/src/Test/Definition/CaseDefinition.php
+++ b/src/Test/Definition/CaseDefinition.php
@@ -15,13 +15,14 @@ final class CaseDefinition
         // public ?string $runner = null,
     ) {}
 
-    public function setName(
+    public function with(
         ?string $name = null,
+        ?TestDefinitions $tests = null,
     ): self {
         return new self(
             $name ?? $this->name,
             $this->reflection,
-            $this->tests,
+            $tests ?? $this->tests,
         );
     }
 

--- a/src/Test/Dto/TestDefinitions.php
+++ b/src/Test/Dto/TestDefinitions.php
@@ -17,10 +17,16 @@ final class TestDefinitions
      */
     private array $tests = [];
 
+    /**
+     * Create TestDefinitions from an array of TestDefinition.
+     *
+     * @param TestDefinition ...$values
+     * @note You must use named non-empty-string arguments to preserve keys.
+     */
     public static function fromArray(TestDefinition ...$values): self
     {
         $self = new self();
-        $self->tests = \array_values($values);
+        $self->tests = $values;
         return $self;
     }
 

--- a/src/Test/Dto/TestDefinitions.php
+++ b/src/Test/Dto/TestDefinitions.php
@@ -20,7 +20,6 @@ final class TestDefinitions
     /**
      * Create TestDefinitions from an array of TestDefinition.
      *
-     * @param TestDefinition ...$values
      * @note You must use named non-empty-string arguments to preserve keys.
      */
     public static function fromArray(TestDefinition ...$values): self

--- a/src/Test/Runner/SuiteRunner.php
+++ b/src/Test/Runner/SuiteRunner.php
@@ -45,7 +45,7 @@ final class SuiteRunner
     public function run(SuiteInfo $suite, Filter $filter): SuiteResult
     {
         # Apply suite name filter if exists
-        $suite->name === null or $filter = $filter->withTestSuites($suite->name);
+        $suite->name === null or $filter = $filter->with(testSuites: [$suite->name]);
 
         // todo if random, run in random order?
 

--- a/src/Test/SuiteCollector.php
+++ b/src/Test/SuiteCollector.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Testo\Test;
 
+use Testo\Common\Filter;
 use Testo\Config\SuiteConfig;
 use Testo\Interceptor\CaseLocatorInterceptor;
 use Testo\Interceptor\FileLocatorInterceptor;
-use Testo\Interceptor\Locator\FilePostfixTestLocatorInterceptor;
-use Testo\Interceptor\Locator\TestoAttributesLocatorInterceptor;
-use Testo\Module\Finder\Finder;
 use Testo\Module\Interceptor\InterceptorProvider;
 use Testo\Module\Interceptor\Internal\Pipeline;
 use Testo\Module\Tokenizer\FileLocator;
@@ -38,20 +36,20 @@ final class SuiteCollector
         return $this->suites[$name] ?? null;
     }
 
-    public function getOrCreate(SuiteConfig $config): SuiteInfo
+    public function getOrCreate(SuiteConfig $config, Filter $filter): SuiteInfo
     {
-        return $this->suites[$config->name] ??= $this->createInfo($config);
+        return $this->suites[$config->name] ??= $this->createInfo($config, $filter);
     }
 
-    private function createInfo(SuiteConfig $config): SuiteInfo
+    private function createInfo(SuiteConfig $config, Filter $filter): SuiteInfo
     {
-        $files = $this->getFilesIterator($config);
+        $files = $this->getFilesIterator($config, $filter);
         $definitions = $this->getCaseDefinitions($config, $files);
 
         $cases = [];
         foreach ($definitions as $definition) {
             # Skip empty test cases
-            if ($definition->tests === []) {
+            if ($definition->tests->getTests() === []) {
                 continue;
             }
 
@@ -69,16 +67,12 @@ final class SuiteCollector
      *
      * @return iterable<TokenizedFile>
      */
-    private function getFilesIterator(SuiteConfig $config): iterable
+    private function getFilesIterator(SuiteConfig $config, Filter $filter): iterable
     {
-        $locator = new FileLocator(new Finder($config->location));
+        $locator = FileLocator::fromFinderConfig($config->location, $filter);
 
         # Prepare interceptors pipeline
-        $interceptors = $this->interceptorProvider->fromClasses(FileLocatorInterceptor::class);
-
-        # todo remove:
-        $interceptors[] = new FilePostfixTestLocatorInterceptor();
-        $interceptors[] = new TestoAttributesLocatorInterceptor();
+        $interceptors = $this->interceptorProvider->fromConfig(FileLocatorInterceptor::class);
 
         /**
          * @see FileLocatorInterceptor::locateFile()
@@ -106,11 +100,7 @@ final class SuiteCollector
     {
         $cases = [];
         # Prepare interceptors pipeline
-        $interceptors = $this->interceptorProvider->fromClasses(CaseLocatorInterceptor::class);
-
-        // todo remove:
-        $interceptors[] = new FilePostfixTestLocatorInterceptor();
-        $interceptors[] = new TestoAttributesLocatorInterceptor();
+        $interceptors = $this->interceptorProvider->fromConfig(CaseLocatorInterceptor::class);
 
         /**
          * @see CaseLocatorInterceptor::locateTestCases()

--- a/src/Test/SuiteProvider.php
+++ b/src/Test/SuiteProvider.php
@@ -46,7 +46,7 @@ final class SuiteProvider
     public function getSuites(): array
     {
         $result = [];
-        $filterNames = $this->filter?->testSuites ?? [];
+        $filterNames = $this->filter?->suites ?? [];
 
         foreach ($this->configs as $config) {
             // Apply suite name filter

--- a/src/Test/SuiteProvider.php
+++ b/src/Test/SuiteProvider.php
@@ -20,11 +20,14 @@ final class SuiteProvider
     /** @var list<SuiteConfig> */
     private readonly array $configs;
 
+    private readonly ?Filter $filter;
+
     public function __construct(
         ApplicationConfig $applicationConfig,
         private readonly SuiteCollector $collector,
     ) {
         $this->configs = $applicationConfig->suites;
+        $this->filter = null;
     }
 
     /**
@@ -32,18 +35,7 @@ final class SuiteProvider
      */
     public function withFilter(Filter $filter): self
     {
-        # Apply suite name filter if exists
-        if ($filter->testSuites === []) {
-            return $this;
-        }
-
-        $suites = \array_filter(
-            $this->configs,
-            static fn(SuiteConfig $suite) => \in_array($suite->name, $filter->testSuites, true),
-        );
-
-        /** @see self::$suites */
-        return $this->cloneWith('suites', $suites);
+        return $this->cloneWith('filter', $filter);
     }
 
     /**
@@ -54,8 +46,18 @@ final class SuiteProvider
     public function getSuites(): array
     {
         $result = [];
+        $filterNames = $this->filter?->testSuites ?? [];
+
         foreach ($this->configs as $config) {
-            $result[] = $this->collector->getOrCreate($config);
+            // Apply suite name filter
+            if ($filterNames !== [] && !\in_array($config->name, $filterNames, true)) {
+                continue;
+            }
+
+            $info = $this->collector->getOrCreate($config);
+            if ($info->testCases->getCases() !== []) {
+                $result[] = $info;
+            }
         }
 
         return $result;

--- a/src/Test/SuiteProvider.php
+++ b/src/Test/SuiteProvider.php
@@ -54,7 +54,7 @@ final class SuiteProvider
                 continue;
             }
 
-            $info = $this->collector->getOrCreate($config);
+            $info = $this->collector->getOrCreate($config, $this->filter);
             if ($info->testCases->getCases() !== []) {
                 $result[] = $info;
             }

--- a/tests/Testo/Unit/PathTest.php
+++ b/tests/Testo/Unit/PathTest.php
@@ -447,4 +447,92 @@ final class PathTest
         // Assert
         Assert::same('some/path/file.txt', $result);
     }
+
+    public static function providePathsForMatch(): \Generator
+    {
+        yield 'exact match' => ['test/file.txt', 'test/file.txt', true];
+        yield 'wildcard asterisk matches multiple chars' => ['test/file.txt', 'test/*.txt', true];
+        yield 'wildcard asterisk at start' => ['test/file.txt', '*/file.txt', true];
+        yield 'wildcard asterisk in middle' => ['test/some/file.txt', 'test/*/file.txt', true];
+        yield 'multiple wildcards' => ['test/path/file.txt', 'test/*/*.txt', true];
+        yield 'wildcard question mark matches single char' => ['test/file1.txt', 'test/file?.txt', true];
+        yield 'character class matches' => ['test/file1.txt', 'test/file[123].txt', true];
+        yield 'character class does not match' => ['test/file4.txt', 'test/file[123].txt', false];
+        yield 'no match different extension' => ['test/file.php', 'test/*.txt', false];
+        yield 'no match different path' => ['other/file.txt', 'test/*.txt', false];
+        yield 'wildcard double asterisk simulation' => ['test/deep/nested/file.txt', 'test/*/nested/*.txt', false];
+        yield 'pattern with no wildcards no match' => ['test/file.txt', 'test/other.txt', false];
+    }
+
+    #[DataProvider('providePathsForMatch')]
+    public function testMatch(string $pathString, string $pattern, bool $expected): void
+    {
+        // Arrange
+        $path = Path::create($pathString)->absolute();
+
+        // Act
+        $result = $path->match($pattern);
+
+        // Assert
+        Assert::same($expected, $result, "Path '$pathString' should " . ($expected ? 'match' : 'not match') . " pattern '$pattern'");
+    }
+
+    public function testMatchWithPathObject(): void
+    {
+        // Arrange
+        $path = Path::create('test/file.txt')->absolute();
+        $pattern = Path::create('test/*.txt');
+
+        // Act
+        $result = $path->match($pattern);
+
+        // Assert
+        Assert::true($result, 'Path should match pattern when pattern is Path object');
+    }
+
+    public function testMatchWithRelativePaths(): void
+    {
+        // Arrange - both paths are relative and will be converted to absolute
+        $path = Path::create('test/file.txt');
+        $pattern = 'test/*.txt';
+
+        // Act
+        $result = $path->match($pattern);
+
+        // Assert
+        Assert::true($result, 'Relative path should match pattern after conversion to absolute');
+    }
+
+    public function testMatchWithComplexPattern(): void
+    {
+        // Arrange
+        $path = Path::create('src/Common/Path.php')->absolute();
+        $pattern = 'src/Common/*.php';
+
+        // Act
+        $result = $path->match($pattern);
+
+        // Assert
+        Assert::true($result, 'Path should match complex pattern');
+    }
+
+    public function testMatchCaseSensitive(): void
+    {
+        // Arrange
+        $path = Path::create('Test/File.TXT')->absolute();
+        $pattern = 'test/file.txt';
+
+        // Act
+        $result = $path->match($pattern);
+
+        // Assert
+        // On Windows, filesystem is case-insensitive, on Unix it's case-sensitive
+        // This test documents the actual behavior
+        $isWindows = DIRECTORY_SEPARATOR === '\\';
+        if ($isWindows) {
+            Assert::true($result, 'On Windows, match should be case-insensitive');
+        } else {
+            Assert::false($result, 'On Unix, match should be case-sensitive');
+        }
+    }
 }


### PR DESCRIPTION
# Test Filtering Feature

This document describes the test filtering functionality in Testo, which allows selective test execution based on various criteria.

## Overview

Testo provides a flexible filtering system that operates in multiple stages:

1. **Stage 1 (Suite Filter)**: Determines configuration scopes that define file scanning locations
2. **Stage 2 (Path Filter)**: Applied at the finder level - scans directories and locates files
3. **Stage 3 (File Filter)**: Pre-filters test files before loading them for reflection analysis
4. **Stage 4 (Test Filter)**: Filters individual test cases and methods after reflection analysis

This multi-stage approach optimizes performance by progressively narrowing down the test set, skipping unnecessary operations at each level.

## Filter Types

The filtering system supports three types of filters, each working independently:

### 1. Name Filter (`--filter`)

Filters tests by method or function names. Supports three formats:

- **FQN (Fully Qualified Name)**: `Namespace\ClassName` or `Namespace\functionName`
- **Method**: `ClassName::methodName` or `Namespace\ClassName::methodName`
- **Fragment**: Simple names like `methodName`, `functionName`, or `ShortClassName`

### 2. Path Filter (`--path`)

Filters test files by glob patterns with wildcard support (`*`, `?`, `[abc]`).

### 3. Suite Filter (`--suite`)

Filters tests by test suite name.

## Filter Logic

### Combining Multiple Filters

- **Same type filters use OR logic**: Multiple values of the same filter type are combined with OR
  - Example: `--filter=test1 --filter=test2` matches tests where name is `test1` OR `test2`

- **Different type filters use AND logic**: Different filter types are combined with AND
  - Example: `--filter=test1 --path="tests/Unit/*"` matches tests where name is `test1` AND file is in `tests/Unit/`

**Formula**: `AND(OR(filters), OR(paths), OR(suites))`

### Name Filter Behavior

When filtering by name (`--filter`), the behavior depends on the filter format:

#### Method Format (`ClassName::methodName`)

When using the method format with `::` separator:
- Only checks if the specified method exists in the matching class
- Result: Test case is included with **only the specified method**
- Other methods in the same class are excluded
- Example: `--filter=UserTest::testLogin` includes only `testLogin` method from `UserTest` class

#### FQN or Fragment Format

When using FQN (with `\`) or simple fragment (no separators):
1. **Class name match**: If the test case class name matches the filter
   - Result: **Entire test case is included with all its test methods**

2. **Class name doesn't match**: If the test case class name doesn't match
   - The system then checks individual methods/functions
   - If any methods/functions match: Test case is included with only matched methods
   - If no methods/functions match: Test case is skipped entirely

Examples:
- `--filter=UserTest` → includes entire `UserTest` class with all methods
- `--filter=Tests\Unit\UserTest` → includes entire class with all methods
- `--filter=testLogin` → includes any class that has `testLogin` method, with only that method

## Usage Examples

### Basic Filtering

```bash
# Run all tests in default location
./bin/testo run

# Run tests from specific directory
./bin/testo run tests/Unit

# Run tests matching glob patterns (wildcards supported)
./bin/testo run --path="tests/Unit/*Test.php" --path="tests/Integration/*Test.php"
```

### Filter by Test Name

```bash
# Filter specific test methods or functions by name (OR logic)
./bin/testo run --filter=testUserAuthentication --filter=testDatabaseConnection

# Filter specific methods in classes (using short name or FQN)
./bin/testo run --filter="UserTest::testAuthentication"
./bin/testo run --filter="Tests\Unit\UserTest::testAuthentication"
```

### Filter by Suite

```bash
# Filter by test suite name (OR logic)
./bin/testo run --suite=Unit --suite=Integration
```

### Complex Filtering

```bash
# Combine filters with AND logic between types
# Runs tests that match (UserTest::testCreate OR UserTest::testUpdate) AND (Critical suite)
./bin/testo run --filter=UserTest::testCreate --filter=UserTest::testUpdate --suite=Critical

# Complex filtering: path AND filter AND suite
# Runs tests in Unit directory that match testImportant AND are in Critical suite
./bin/testo run --path="tests/Unit/*" --filter=testImportant --suite=Critical
```

### CI Integration

```bash
# Run with TeamCity output format for CI
./bin/testo run --teamcity

# Run tests with custom config
./bin/testo run --config=./testo.php
```



---



## Implementation Details

### Multi-Stage Filtering Pipeline

#### Stage 1: Suite Filter (Configuration Level)

Applied at the configuration level to determine which test suites to run:
- Filters configuration scopes based on `--suite` option
- Each suite defines file scanning locations and patterns
- Determines the initial set of directories to scan

#### Stage 2: Path Filter (Finder Level)

Applied at the file finder level during directory scanning:
- Uses `--path` option with glob patterns
- Matches file paths against wildcard patterns (`*`, `?`, `[abc]`)
- Returns list of files to be processed
- Works with Symfony Finder component

#### Stage 3: File Filter (FilterInterceptor - FileLocatorInterceptor)

Implemented in `FilterInterceptor::locateFile()`:

```php
public function locateFile(TokenizedFile $file, callable $next): ?bool
```

- Performs quick pre-filtering based on tokenized file data
- Skips files that don't contain any matching classes, methods, or functions
- Uses lightweight tokenization instead of full reflection for performance
- Checks against `--filter` patterns before loading reflections

#### Stage 4: Test Filter (FilterInterceptor - CaseLocatorInterceptor)

Implemented in `FilterInterceptor::locateTestCases()`:

```php
public function locateTestCases(FileDefinitions $file, callable $next): CaseDefinitions
```

- Filters loaded test definitions based on class and method names
- Implements the hierarchical filtering logic:
  - For method format (`::`) - filters specific methods only
  - For FQN/fragment format - checks class name first, then methods
- Returns filtered test case definitions ready for execution

### Pattern Matching

The filter uses whole-word matching with regex:

```php
private static function has(string $needle, string $haystack): bool
{
    return \preg_match('/\\b' . \preg_quote($needle, '/') . '\\b$/', $haystack) === 1;
}
```

This ensures:
- `User` matches `App\User` but not `App\UserManager`
- `test` matches `testMethod` but not `latestMethod`

## Performance Considerations

1. **Multi-stage progressive filtering**: Each stage narrows down the test set before moving to the next, more expensive operation
2. **Suite-level pre-filtering**: Stage 1 limits the scope of directories to scan based on configuration
3. **Path-based file selection**: Stage 2 uses efficient glob matching to select files before parsing
4. **Tokenization over reflection**: Stage 3 uses lightweight tokenization instead of full reflection for initial filtering
5. **Early exit**: Returns immediately on first match in file filtering stage
6. **Lazy evaluation**: Only loads and processes files that pass Stages 2 and 3
7. **Hierarchical test filtering**: Stage 4 checks class names before iterating through methods

## Command Reference

### Arguments

- `path` (optional): Path to test directory or file

### Options

- `--filter`: Filter methods or functions to be run (repeatable)
  - Supports `methodName`, `ClassName::methodName`, and `Namespace\ClassName::methodName` formats

- `--path`: Glob patterns for test files to be run (repeatable)
  - Supports wildcards: `*`, `?`, `[abc]`

- `--suite`: Filter test suites by name (repeatable)

- `--teamcity`: Enable TeamCity CI output format

- `--config`: Path to the configuration file

## Examples by Use Case

### Run specific test method

```bash
./bin/testo run --filter=UserTest::testLogin
```

### Run all tests in a class

```bash
./bin/testo run --filter=UserTest
```

### Run tests across multiple files

```bash
./bin/testo run --path="tests/Unit/User*Test.php" --path="tests/Unit/Auth*Test.php"
```

### Run critical tests in specific directory

```bash
./bin/testo run --path="tests/Unit/*" --suite=Critical
```

### Run specific methods from multiple classes

```bash
./bin/testo run --filter=UserTest::testLogin --filter=AuthTest::testLogin
```

### CI/CD Pipeline

```bash
# Run unit tests with TeamCity reporting
./bin/testo run --suite=Unit --teamcity

# Run integration tests with specific config
./bin/testo run --suite=Integration --config=./ci-testo.php --teamcity
```