### PR TITLE
feat(assert): add `Assert::blank()` method

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -190,6 +190,36 @@ final class Assert
     }
 
     /**
+     * Checks if a value is blank.
+     *
+     * Successful only for values representing absence of data:
+     * null, empty string, empty array or countable object with no elements.
+     *
+     * Unlike empty(), does not consider false, 0, and "0" as blank,
+     * since they represent valid data.
+     * @param mixed $actual The actual value to check for blank.
+     * @param string $message Short description about what exactly is being asserted.
+     * @throws AssertException when the assertion fails.
+     */
+    public static function blank(
+        mixed $actual,
+        string $message = '',
+    ): void {
+        if (
+            $actual === null || $actual === '' || $actual === [] || ($actual instanceof \Countable && \count($actual) === 0)
+        ) {
+            StaticState::log('Assert `blank`', $message);
+            return;
+        }
+        StaticState::fail(AssertException::compare(
+            null,
+            $actual,
+            $message,
+            'Failed asserting that `%2$s` does not contain any data',
+        ));
+    }
+
+    /**
      * Fails the test.
      *
      * Use this method to explicitly indicate that the test should end in failure.

--- a/tests/Assert/Self/AssertBlank.php
+++ b/tests/Assert/Self/AssertBlank.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Assert\Self;
+
+use Testo\Assert;
+use Testo\Attribute\Test;
+
+/**
+ * Assertion examples.
+ */
+final class AssertBlank
+{
+    #[Test]
+    public function checkBlankData(): void
+    {
+        Assert::blank([]);
+        Assert::blank("");
+        Assert::blank(null);
+        Assert::blank(new \ArrayIterator());
+    }
+
+    #[Test]
+    public function checkZeroIsNotBlank(): void
+    {
+        Assert::exception(Assert\State\AssertException::class);
+        Assert::blank(0);
+    }
+
+    #[Test]
+    public function checkZeroStringIsNotBlank(): void
+    {
+        Assert::exception(Assert\State\AssertException::class);
+        Assert::blank("0");
+    }
+
+    #[Test]
+    public function checkFalseIsNotBlank(): void
+    {
+        Assert::exception(Assert\State\AssertException::class);
+        Assert::blank(false);
+    }
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! -->

## What was changed

Added new `Assert::blank()` method. This method is successful if data is blank, .i.e. - empty array, empty string, null or countable object with no elements. It throws exception if non-blank data is present: any boolean data, any number (including 0), any string (including "0"), any countable object with 1 or more elements.

See commit history for details.

## Why?

In order to fill `Assert` methods library

## Checklist

- Tested
  - [x] Tested manually
  - [x] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->
