### PR TITLE
feat(assert): add `Assert::int()` with `greaterThan` and `greaterThanOrEqual`

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Testo;
 
+use Testo\Assert\DataType\AssertInt;
 use Testo\Assert\DataType\AssertString;
 use Testo\Assert\State\AssertException;
 use Testo\Assert\State\AssertTypeFailure;
@@ -233,6 +234,21 @@ final class Assert
 
         StaticState::log('Assert type string for ' . Support::stringify($actual));
         return new AssertString($actual);
+    }
+
+    /**
+     * Asserts that the given value is of `int` data type.
+     *
+     * @param mixed $actual The actual value to check for `int` data type.
+     * @throws AssertException when the assertion fails.
+     */
+    public static function int(
+        mixed $actual,
+    ): AssertInt {
+        \is_int($actual) or StaticState::fail(AssertTypeFailure::create('int', $actual));
+
+        StaticState::log('Assert type int for ' . Support::stringify($actual));
+        return new AssertInt($actual);
     }
 
     /**

--- a/src/Assert/DataType/AssertInt.php
+++ b/src/Assert/DataType/AssertInt.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Assert\DataType;
+
+use Testo\Assert\State\AssertException;
+use Testo\Assert\StaticState;
+
+/**
+ * Assertion utilities for integer data type.
+ */
+class AssertInt
+{
+    public function __construct(
+        public int $value,
+    ) {}
+
+    /**
+     * Asserts that the integer value is greater than given value.
+     *
+     * @param int $min Minimum threshold to compare with.
+     * @param string $message Optional message for the assertion.
+     * @throws AssertException when the assertion fails.
+     */
+    public function greaterThan(int $min, string $message = ''): void
+    {
+        if ($this->value > $min) {
+            StaticState::log('Assert int greater than `' . $min . '`', $message);
+            return;
+        }
+
+        StaticState::fail(AssertException::compare(
+            $min,
+            $this->value,
+            $message,
+            pattern: 'Failed asserting that value `%2$s` is greater than `%1$s`.',
+            showDiff: false,
+        ));
+    }
+
+    /**
+     * Asserts that the integer value is greater than or equal to given value.
+     *
+     * @param int $min Minimum threshold to compare with.
+     * @param string $message Optional message for the assertion.
+     * @throws AssertException when the assertion fails.
+     */
+    public function greaterThanOrEqual(int $min, string $message = ''): void
+    {
+        if ($this->value >= $min) {
+            StaticState::log('Assert int greater than or equal to `' . $min . '`', $message);
+            return;
+        }
+
+        StaticState::fail(AssertException::compare(
+            $min,
+            $this->value,
+            $message,
+            pattern: 'Failed asserting that value `%2$s` is greater than or equal to `%1$s`.',
+            showDiff: false,
+        ));
+    }
+}

--- a/src/Assert/DataType/AssertInt.php
+++ b/src/Assert/DataType/AssertInt.php
@@ -4,61 +4,16 @@ declare(strict_types=1);
 
 namespace Testo\Assert\DataType;
 
-use Testo\Assert\State\AssertException;
-use Testo\Assert\StaticState;
+use Testo\Assert\Traits\NumericTrait;
 
 /**
  * Assertion utilities for integer data type.
  */
 class AssertInt
 {
+    use NumericTrait;
+
     public function __construct(
         public int $value,
     ) {}
-
-    /**
-     * Asserts that the integer value is greater than given value.
-     *
-     * @param int $min Minimum threshold to compare with.
-     * @param string $message Optional message for the assertion.
-     * @throws AssertException when the assertion fails.
-     */
-    public function greaterThan(int $min, string $message = ''): void
-    {
-        if ($this->value > $min) {
-            StaticState::log('Assert int greater than `' . $min . '`', $message);
-            return;
-        }
-
-        StaticState::fail(AssertException::compare(
-            $min,
-            $this->value,
-            $message,
-            pattern: 'Failed asserting that value `%2$s` is greater than `%1$s`.',
-            showDiff: false,
-        ));
-    }
-
-    /**
-     * Asserts that the integer value is greater than or equal to given value.
-     *
-     * @param int $min Minimum threshold to compare with.
-     * @param string $message Optional message for the assertion.
-     * @throws AssertException when the assertion fails.
-     */
-    public function greaterThanOrEqual(int $min, string $message = ''): void
-    {
-        if ($this->value >= $min) {
-            StaticState::log('Assert int greater than or equal to `' . $min . '`', $message);
-            return;
-        }
-
-        StaticState::fail(AssertException::compare(
-            $min,
-            $this->value,
-            $message,
-            pattern: 'Failed asserting that value `%2$s` is greater than or equal to `%1$s`.',
-            showDiff: false,
-        ));
-    }
 }

--- a/src/Assert/Traits/NumericTrait.php
+++ b/src/Assert/Traits/NumericTrait.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Assert\Traits;
+
+use Testo\Assert\DataType\AssertInt;
+use Testo\Assert\State\AssertException;
+use Testo\Assert\StaticState;
+
+/**
+ * Contains methods for comparing numeric values
+ * @property int|float $value
+ */
+trait NumericTrait
+{
+    /**
+     * Asserts that numeric value is greater than the given minimum.
+     *
+     * @param int|float $min Minimum threshold to compare with.
+     * @param string $message Optional message for the assertion.
+     * @throws AssertException when the assertion fails.
+     */
+    public function greaterThan(int|float $min, string $message = ''): self
+    {
+        if ($this->value > $min) {
+            StaticState::log('Assert `' . $this->value . '` is greater than `' . $min . '`', $message);
+            return $this;
+        }
+
+        StaticState::fail(AssertException::compare(
+            $min,
+            $this->value,
+            $message,
+            pattern: 'Failed asserting that value `%2$s` is greater than `%1$s`.',
+            showDiff: false,
+        ));
+    }
+
+    /**
+     * Asserts that the numeric value is greater than or equal to given minimum.
+     *
+     * @param int|float $min Minimum threshold to compare with.
+     * @param string $message Optional message for the assertion.
+     * @throws AssertException when the assertion fails.
+     */
+    public function greaterThanOrEqual(int|float $min, string $message = ''): self
+    {
+        if ($this->value >= $min) {
+            StaticState::log('Assert `' . $this->value . '` is greater than or equal to `' . $min . '`', $message);
+            return $this;
+        }
+
+        StaticState::fail(AssertException::compare(
+            $min,
+            $this->value,
+            $message,
+            pattern: 'Failed asserting that value `%2$s` is greater than or equal to `%1$s`.',
+            showDiff: false,
+        ));
+    }
+}

--- a/tests/Assert/Self/AssertInt.php
+++ b/tests/Assert/Self/AssertInt.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Assert\Self;
+
+use Testo\Assert;
+use Testo\Assert\State\AssertException;
+use Testo\Attribute\Test;
+use Testo\Expect;
+
+/**
+ * Assertion examples.
+ */
+final class AssertInt
+{
+    #[Test]
+    public function checkIntDataType(): void
+    {
+        // This assertion checks incoming data type
+        Assert::int(42);
+
+        Expect::exception(Assert\State\AssertTypeFailure::class);
+        Assert::int('42');
+    }
+
+    #[Test]
+    public function checkIntGreaterThan(): void
+    {
+        // actual is greater than min threshold
+        Assert::int(42)->greaterThan(41);
+
+        Expect::exception(Assert\State\AssertException::class);
+        Assert::int(42)->greaterThan(43);
+    }
+
+    #[Test]
+    public function checkIntGreaterThanOrEqual(): void
+    {
+        // actual is greater than or equal to min threshold
+        Assert::int(42)->greaterThanOrEqual(41);
+        Assert::int(42)->greaterThanOrEqual(42);
+
+        Expect::exception(Assert\State\AssertException::class);
+        Assert::int(42)->greaterThan(43);
+    }
+}


### PR DESCRIPTION

<!-- Thanks for opening a PR! -->

## What was changed
It was easier to start anew with `greaterThan` and `greaterThanOrEqual` methods.
- add `Assert::int()` method to base Assert
- add new AssertInt class for int assertion methods
- add methods `AssertInt::greaterThan()` and `AssertInt::greaterThanOrEqal()`

All analogous to string type assertion and new AssertString class. See commit history for details.

## Why?

Filling Assert library with new methods

## Checklist

- Closes #<!-- add issue number here -->
- Tested
  - [x] Tested manually
  - [x] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->
