### PR TITLE
feat(assert): add new assert Interfaces and methods for data types

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -15,6 +15,7 @@ use Testo\Assert\Api\Json\JsonAbstract;
 use Testo\Assert\Internal\Assertion\AssertFloat;
 use Testo\Assert\Internal\Assertion\AssertInt;
 use Testo\Assert\Internal\Assertion\AssertJson;
+use Testo\Assert\Internal\Assertion\AssertObject;
 use Testo\Assert\Internal\Assertion\AssertString;
 use Testo\Assert\State\AssertException;
 use Testo\Assert\State\AssertTypeFailure;
@@ -144,21 +145,19 @@ final class Assert
     /**
      * Asserts that the actual object is an instance of the expected class/interface.
      *
-     * @param string $expected Expected class/interface (class-string).
-     * @param mixed $actual The actual value to compare against the expected value.
-     * @param string $message Short description about what exactly is being asserted.
+     * @template ExpectedType
+     *
+     * @param class-string<ExpectedType> $expected Fully-qualified class or interface name.
+     * @param mixed $actual The actual object to check.
+     * @param string $message Optional message for the assertion.
      * @throws AssertException when the assertion fails.
+     *
+     * @psalm-assert ExpectedType $actual
+     * @phpstan-assert ExpectedType $actual
      */
-    public static function instanceOf(string $expected, mixed $actual, string $message = ''): void
+    public static function instanceOf(string $expected, mixed $actual, string $message = ''): ObjectType
     {
-        $actual instanceof $expected
-            ? StaticState::log('Assert instance of `' . $expected . '`', $message)
-            : StaticState::fail(AssertException::compare(
-                $expected,
-                $actual,
-                $message,
-                'Expected instance of `%1$s`, got `%2$s`',
-            ));
+        return AssertObject::validateAndCreate($actual)->instanceOf($expected, $message);
     }
 
     /**

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Testo;
 
+use Testo\Assert\Api\Builtin\ArrayType;
 use Testo\Assert\Api\Builtin\FloatType;
 use Testo\Assert\Api\Builtin\IntType;
+use Testo\Assert\Api\Builtin\IterableType;
 use Testo\Assert\Api\Builtin\NumericType;
+use Testo\Assert\Api\Builtin\ObjectType;
 use Testo\Assert\Api\Builtin\StringType;
 use Testo\Assert\Api\Json\JsonAbstract;
 use Testo\Assert\Internal\Assertion\AssertFloat;
@@ -283,6 +286,45 @@ final class Assert
     public static function json(string $actual): JsonAbstract
     {
         return new AssertJson($actual);
+    }
+
+    /**
+     * Asserts that the given value is of `iterable` data type.
+     *
+     * Iterables include arrays and objects implementing iterable interface.
+     * Does not work with Generators.
+     *
+     * @throws AssertTypeFailure
+     *
+     * @deprecated To be implemented
+     */
+    public static function iterable(mixed $actual): IterableType
+    {
+        throw new \LogicException('Not implemented yet');
+    }
+
+    /**
+     * Asserts that the given value is of `array` data type.
+     *
+     * @throws AssertTypeFailure
+     *
+     * @deprecated To be implemented
+     */
+    public static function array(mixed $actual): ArrayType
+    {
+        throw new \LogicException('Not implemented yet');
+    }
+
+    /**
+     * Asserts that the given value is of `object` data type.
+     *
+     * @throws AssertTypeFailure
+     *
+     * @deprecated To be implemented
+     */
+    public static function object(mixed $actual): ObjectType
+    {
+        throw new \LogicException('Not implemented yet');
     }
 
     /**

--- a/src/Assert/Api/Builtin/ArrayType.php
+++ b/src/Assert/Api/Builtin/ArrayType.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Assert\Api\Builtin;
+
+use Testo\Assert\State\AssertException;
+
+/**
+ * Assertion utilities for array-like data type.
+ */
+interface ArrayType extends IterableType
+{
+    /**
+     * Asserts that the array contains given key.
+     * @param string $message Optional message for the assertion.
+     * @throws AssertException when the assertion fails.
+     */
+    public function hasKey(mixed $key, string $message = ''): self;
+}

--- a/src/Assert/Api/Builtin/ArrayType.php
+++ b/src/Assert/Api/Builtin/ArrayType.php
@@ -23,4 +23,17 @@ interface ArrayType extends IterableType
      * @deprecated To be implemented
      */
     public function hasKey(mixed $key, string $message = ''): self;
+
+    /**
+     * Asserts that the array is a list.
+     *
+     * A list is an array with sequential integer keys starting from 0.
+     * Equivalent to {@see array_is_list()} in PHP 8.1+.
+     *
+     * @param string $message Optional message for the assertion.
+     * @throws AssertException when the assertion fails.
+     *
+     * @deprecated To be implemented
+     */
+    public function isList(string $message = ''): self;
 }

--- a/src/Assert/Api/Builtin/ArrayType.php
+++ b/src/Assert/Api/Builtin/ArrayType.php
@@ -8,13 +8,19 @@ use Testo\Assert\State\AssertException;
 
 /**
  * Assertion utilities for array-like data type.
+ *
+ * Applicable to {@see array} and {@see \ArrayAccess} implementations.
  */
 interface ArrayType extends IterableType
 {
     /**
      * Asserts that the array contains given key.
+     *
+     * @param mixed $key The key to check for in the array.
      * @param string $message Optional message for the assertion.
      * @throws AssertException when the assertion fails.
+     *
+     * @deprecated To be implemented
      */
     public function hasKey(mixed $key, string $message = ''): self;
 }

--- a/src/Assert/Api/Builtin/IterableType.php
+++ b/src/Assert/Api/Builtin/IterableType.php
@@ -36,4 +36,15 @@ interface IterableType
      * @deprecated To be implemented
      */
     public function sameSizeAs(iterable $expected, string $message = ''): self;
+
+    /**
+     * Asserts that all values in the iterable are of the specified type.
+     *
+     * @param non-empty-string $type The expected type name (e.g., 'int', 'string', 'object', class name).
+     * @param string $message Optional message for the assertion.
+     * @throws AssertException when the assertion fails.
+     *
+     * @deprecated To be implemented
+     */
+    public function allOf(string $type, string $message = ''): self;
 }

--- a/src/Assert/Api/Builtin/IterableType.php
+++ b/src/Assert/Api/Builtin/IterableType.php
@@ -9,24 +9,31 @@ use Testo\Assert\State\AssertException;
 /**
  * Assertion utilities for iterables.
  *
- * Iterables include arrays and objects implementing iterable interface.
- * Does not work with Generators.
+ * The {@see iterable} type includes {@see array} and objects implementing {@see \Traversable} interface.
+ *
+ * @note A {@see \Generator} can be iterated only once. Using this interface on a generator will exhaust it.
  */
 interface IterableType
 {
     /**
      * Asserts that the iterable contains the given needle.
+     *
      * @param mixed $needle The value to look for within the iterable.
      * @param string $message Optional message for the assertion.
      * @throws AssertException when the assertion fails.
+     *
+     * @deprecated To be implemented
      */
     public function contains(mixed $needle, string $message = ''): self;
 
     /**
      * Asserts that the iterable has the same number of elements as the expected iterable.
+     *
      * @param iterable $expected The iterable to compare size against.
      * @param string $message Optional message for the assertion.
      * @throws AssertException when the assertion fails.
+     *
+     * @deprecated To be implemented
      */
     public function sameSizeAs(iterable $expected, string $message = ''): self;
 }

--- a/src/Assert/Api/Builtin/IterableType.php
+++ b/src/Assert/Api/Builtin/IterableType.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Assert\Api\Builtin;
+
+use Testo\Assert\State\AssertException;
+
+/**
+ * Assertion utilities for iterables.
+ *
+ * Iterables include arrays and objects implementing iterable interface.
+ * Does not work with Generators.
+ */
+interface IterableType
+{
+    /**
+     * Asserts that the iterable contains the given needle.
+     * @param mixed $needle The value to look for within the iterable.
+     * @param string $message Optional message for the assertion.
+     * @throws AssertException when the assertion fails.
+     */
+    public function contains(mixed $needle, string $message = ''): self;
+
+    /**
+     * Asserts that the iterable has the same number of elements as the expected iterable.
+     * @param iterable $expected The iterable to compare size against.
+     * @param string $message Optional message for the assertion.
+     * @throws AssertException when the assertion fails.
+     */
+    public function sameSizeAs(iterable $expected, string $message = ''): self;
+}

--- a/src/Assert/Api/Builtin/ObjectType.php
+++ b/src/Assert/Api/Builtin/ObjectType.php
@@ -13,17 +13,26 @@ interface ObjectType
 {
     /**
      * Asserts that the object is an instance of the given class/interface.
-     * @param string $class Fully-qualified class or interface name.
+     *
+     * @template ExpectedType
+     *
+     * @param class-string<ExpectedType> $expected Fully-qualified class or interface name.
      * @param string $message Optional message for the assertion.
      * @throws AssertException when the assertion fails.
+     *
+     * @psalm-assert ExpectedType $actual
+     * @phpstan-assert ExpectedType $actual
      */
-    public function instanceOf(string $class, string $message = ''): self;
+    public function instanceOf(string $expected, string $message = ''): self;
 
     /**
      * Asserts that the object has the given property.
-     * @param string $propertyName The property name to check.
+     *
+     * @param non-empty-string $propertyName The property name to check.
      * @param string $message Optional message for the assertion.
      * @throws AssertException when the assertion fails.
+     *
+     * @deprecated To be implemented
      */
     public function hasProperty(string $propertyName, string $message = ''): self;
 }

--- a/src/Assert/Api/Builtin/ObjectType.php
+++ b/src/Assert/Api/Builtin/ObjectType.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Assert\Api\Builtin;
+
+use Testo\Assert\State\AssertException;
+
+/**
+ * Assertion utilities for objects.
+ */
+interface ObjectType
+{
+    /**
+     * Asserts that the object is an instance of the given class/interface.
+     * @param string $class Fully-qualified class or interface name.
+     * @param string $message Optional message for the assertion.
+     * @throws AssertException when the assertion fails.
+     */
+    public function instanceOf(string $class, string $message = ''): self;
+
+    /**
+     * Asserts that the object has the given property.
+     * @param string $propertyName The property name to check.
+     * @param string $message Optional message for the assertion.
+     * @throws AssertException when the assertion fails.
+     */
+    public function hasProperty(string $propertyName, string $message = ''): self;
+}

--- a/src/Assert/Internal/Assertion/AssertArray.php
+++ b/src/Assert/Internal/Assertion/AssertArray.php
@@ -21,7 +21,7 @@ class AssertArray implements ArrayType
     use IterableTrait;
 
     public function __construct(
-        private readonly float $value,
+        private readonly array $value,
     ) {}
 
     /**

--- a/src/Assert/Internal/Assertion/AssertArray.php
+++ b/src/Assert/Internal/Assertion/AssertArray.php
@@ -48,4 +48,9 @@ class AssertArray implements ArrayType
     {
         throw new \LogicException('Not implemented yet');
     }
+
+    public function isList(string $message = ''): ArrayType
+    {
+        throw new \LogicException('Not implemented yet');
+    }
 }

--- a/src/Assert/Internal/Assertion/AssertArray.php
+++ b/src/Assert/Internal/Assertion/AssertArray.php
@@ -33,9 +33,9 @@ class AssertArray implements ArrayType
      */
     public static function validateAndCreate(mixed $value): self
     {
-        \is_array($value) or StaticState::fail(AssertTypeFailure::create('iterable', $value));
+        \is_array($value) or StaticState::fail(AssertTypeFailure::create('array', $value));
 
-        StaticState::log('Assert iterable: ' . Support::stringify($value));
+        StaticState::log('Assert array: ' . Support::stringify($value));
         return new self($value);
     }
 
@@ -46,7 +46,6 @@ class AssertArray implements ArrayType
      */
     public function hasKey(mixed $key, string $message = ''): self
     {
-        // @todo
-        return new self($this->value);
+        throw new \LogicException('Not implemented yet');
     }
 }

--- a/src/Assert/Internal/Assertion/AssertArray.php
+++ b/src/Assert/Internal/Assertion/AssertArray.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Assert\Internal\Assertion;
+
+use Testo\Assert\Api\Builtin\ArrayType;
+use Testo\Assert\Internal\Assertion\Traits\IterableTrait;
+use Testo\Assert\State\AssertException;
+use Testo\Assert\State\AssertTypeFailure;
+use Testo\Assert\StaticState;
+use Testo\Assert\Support;
+
+/**
+ * Assertion utilities for iterables.
+ *
+ * @internal
+ */
+class AssertArray implements ArrayType
+{
+    use IterableTrait;
+
+    public function __construct(
+        private readonly float $value,
+    ) {}
+
+    /**
+     * Validate that the given value is a float and return an AssertFloat instance.
+     *
+     * @param mixed $value The value to be asserted as float.
+     * @return self An instance of AssertFloat.
+     * @throws AssertTypeFailure when the value is not a float.
+     */
+    public static function validateAndCreate(mixed $value): self
+    {
+        \is_array($value) or StaticState::fail(AssertTypeFailure::create('iterable', $value));
+
+        StaticState::log('Assert iterable: ' . Support::stringify($value));
+        return new self($value);
+    }
+
+    /**
+     * Asserts that the array contains given key.
+     * @param string $message Optional message for the assertion.
+     * @throws AssertException when the assertion fails.
+     */
+    public function hasKey(mixed $key, string $message = ''): self
+    {
+        // @todo
+        return new self($this->value);
+    }
+}

--- a/src/Assert/Internal/Assertion/AssertIterable.php
+++ b/src/Assert/Internal/Assertion/AssertIterable.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Assert\Internal\Assertion;
+
+use Testo\Assert\Api\Builtin\IterableType;
+use Testo\Assert\Internal\Assertion\Traits\IterableTrait;
+use Testo\Assert\State\AssertTypeFailure;
+use Testo\Assert\StaticState;
+use Testo\Assert\Support;
+
+/**
+ * Assertion utilities for iterables.
+ *
+ * @internal
+ */
+class AssertIterable implements IterableType
+{
+    use IterableTrait;
+
+    public function __construct(
+        private readonly float $value,
+    ) {}
+
+    /**
+     * Validate that the given value is a float and return an AssertFloat instance.
+     *
+     * @param mixed $value The value to be asserted as float.
+     * @return self An instance of AssertFloat.
+     * @throws AssertTypeFailure when the value is not a float.
+     */
+    public static function validateAndCreate(mixed $value): self
+    {
+        \is_iterable($value) or StaticState::fail(AssertTypeFailure::create('iterable', $value));
+
+        StaticState::log('Assert iterable: ' . Support::stringify($value));
+        return new self($value);
+    }
+}

--- a/src/Assert/Internal/Assertion/AssertIterable.php
+++ b/src/Assert/Internal/Assertion/AssertIterable.php
@@ -20,7 +20,7 @@ class AssertIterable implements IterableType
     use IterableTrait;
 
     public function __construct(
-        private readonly float $value,
+        private readonly iterable $value,
     ) {}
 
     /**

--- a/src/Assert/Internal/Assertion/AssertNumeric.php
+++ b/src/Assert/Internal/Assertion/AssertNumeric.php
@@ -17,6 +17,6 @@ class AssertNumeric implements IntType
     use NumericTrait;
 
     public function __construct(
-        public int $value,
+        public int|float $value,
     ) {}
 }

--- a/src/Assert/Internal/Assertion/AssertObject.php
+++ b/src/Assert/Internal/Assertion/AssertObject.php
@@ -15,48 +15,46 @@ use Testo\Assert\Support;
  *
  * @internal
  */
-class AssertObject implements ObjectType
+final class AssertObject implements ObjectType
 {
     public function __construct(
         private readonly object $value,
     ) {}
 
     /**
-     * Validate that the given value is a float and return an AssertFloat instance.
+     * @template ValueType
      *
-     * @param mixed $value The value to be asserted as float.
-     * @return self An instance of AssertFloat.
-     * @throws AssertTypeFailure when the value is not a float.
+     * @param ValueType $value The value to be asserted as float.
+     * @throws AssertException
+     *
+     * @psalm-assert object $value
+     * @phpstan-assert object $value
      */
     public static function validateAndCreate(mixed $value): self
     {
-        \is_object($value) or StaticState::fail(AssertTypeFailure::create('iterable', $value));
+        \is_object($value) or StaticState::fail(AssertTypeFailure::create('object', $value));
 
-        StaticState::log('Assert iterable: ' . Support::stringify($value));
+        StaticState::log('Assert object: ' . Support::stringify($value));
         return new self($value);
     }
 
-    /**
-     * Asserts that the object is an instance of the given class/interface.
-     * @param string $class Fully-qualified class or interface name.
-     * @param string $message Optional message for the assertion.
-     * @throws AssertException when the assertion fails.
-     */
-    public function instanceOf(string $class, string $message = ''): self
+    #[\Override]
+    public function instanceOf(string $expected, string $message = ''): self
     {
-        // @todo
-        return new self($this->value);
+        $this->value instanceof $expected
+            ? StaticState::log('Assert instance of `' . $expected . '`', $message)
+            : StaticState::fail(AssertException::compare(
+                $expected,
+                $this->value,
+                $message,
+                'Expected instance of `%1$s`, got `%2$s`',
+            ));
+        return $this;
     }
 
-    /**
-     * Asserts that the object has the given property.
-     * @param string $propertyName The property name to check.
-     * @param string $message Optional message for the assertion.
-     * @throws AssertException when the assertion fails.
-     */
+    #[\Override]
     public function hasProperty(string $propertyName, string $message = ''): self
     {
-        // @todo
-        return new self($this->value);
+        throw new \LogicException('Not implemented yet');
     }
 }

--- a/src/Assert/Internal/Assertion/AssertObject.php
+++ b/src/Assert/Internal/Assertion/AssertObject.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Assert\Internal\Assertion;
+
+use Testo\Assert\Api\Builtin\ObjectType;
+use Testo\Assert\State\AssertException;
+use Testo\Assert\State\AssertTypeFailure;
+use Testo\Assert\StaticState;
+use Testo\Assert\Support;
+
+/**
+ * Assertion utilities for iterables.
+ *
+ * @internal
+ */
+class AssertObject implements ObjectType
+{
+    public function __construct(
+        private readonly float $value,
+    ) {}
+
+    /**
+     * Validate that the given value is a float and return an AssertFloat instance.
+     *
+     * @param mixed $value The value to be asserted as float.
+     * @return self An instance of AssertFloat.
+     * @throws AssertTypeFailure when the value is not a float.
+     */
+    public static function validateAndCreate(mixed $value): self
+    {
+        \is_object($value) or StaticState::fail(AssertTypeFailure::create('iterable', $value));
+
+        StaticState::log('Assert iterable: ' . Support::stringify($value));
+        return new self($value);
+    }
+
+    /**
+     * Asserts that the object is an instance of the given class/interface.
+     * @param string $class Fully-qualified class or interface name.
+     * @param string $message Optional message for the assertion.
+     * @throws AssertException when the assertion fails.
+     */
+    public function instanceOf(string $class, string $message = ''): self
+    {
+        // @todo
+        return new self($this->value);
+    }
+
+    /**
+     * Asserts that the object has the given property.
+     * @param string $propertyName The property name to check.
+     * @param string $message Optional message for the assertion.
+     * @throws AssertException when the assertion fails.
+     */
+    public function hasProperty(string $propertyName, string $message = ''): self
+    {
+        // @todo
+        return new self($this->value);
+    }
+}

--- a/src/Assert/Internal/Assertion/AssertObject.php
+++ b/src/Assert/Internal/Assertion/AssertObject.php
@@ -18,7 +18,7 @@ use Testo\Assert\Support;
 class AssertObject implements ObjectType
 {
     public function __construct(
-        private readonly float $value,
+        private readonly object $value,
     ) {}
 
     /**

--- a/src/Assert/Internal/Assertion/Traits/IterableTrait.php
+++ b/src/Assert/Internal/Assertion/Traits/IterableTrait.php
@@ -20,8 +20,7 @@ trait IterableTrait
      */
     public function contains(mixed $needle, string $message = ''): self
     {
-        // @todo
-        return new self($this->value);
+        throw new \LogicException('Not implemented yet');
     }
 
     /**
@@ -32,7 +31,6 @@ trait IterableTrait
      */
     public function sameSizeAs(iterable $expected, string $message = ''): self
     {
-        // @todo
-        return new self($this->value);
+        throw new \LogicException('Not implemented yet');
     }
 }

--- a/src/Assert/Internal/Assertion/Traits/IterableTrait.php
+++ b/src/Assert/Internal/Assertion/Traits/IterableTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Assert\Internal\Assertion\Traits;
+
+use Testo\Assert\State\AssertException;
+
+/**
+ * Contains methods for comparing numeric values
+ * @property int|float $value
+ */
+trait IterableTrait
+{
+    /**
+     * Asserts that the iterable contains the given needle.
+     * @param mixed $needle The value to look for within the iterable.
+     * @param string $message Optional message for the assertion.
+     * @throws AssertException when the assertion fails.
+     */
+    public function contains(mixed $needle, string $message = ''): self
+    {
+        // @todo
+        return new self($this->value);
+    }
+
+    /**
+     * Asserts that the iterable has the same number of elements as the expected iterable.
+     * @param iterable $expected The iterable to compare size against.
+     * @param string $message Optional message for the assertion.
+     * @throws AssertException when the assertion fails.
+     */
+    public function sameSizeAs(iterable $expected, string $message = ''): self
+    {
+        // @todo
+        return new self($this->value);
+    }
+}

--- a/src/Assert/Internal/Assertion/Traits/IterableTrait.php
+++ b/src/Assert/Internal/Assertion/Traits/IterableTrait.php
@@ -8,7 +8,6 @@ use Testo\Assert\State\AssertException;
 
 /**
  * Contains methods for comparing numeric values
- * @property int|float $value
  */
 trait IterableTrait
 {
@@ -30,6 +29,11 @@ trait IterableTrait
      * @throws AssertException when the assertion fails.
      */
     public function sameSizeAs(iterable $expected, string $message = ''): self
+    {
+        throw new \LogicException('Not implemented yet');
+    }
+
+    public function allOf(string $type, string $message = ''): \Testo\Assert\Api\Builtin\IterableType
     {
         throw new \LogicException('Not implemented yet');
     }

--- a/src/Assert/State/AssertException.php
+++ b/src/Assert/State/AssertException.php
@@ -43,7 +43,7 @@ class AssertException extends \Exception implements Record
      *
      * @param mixed $expected The expected value.
      * @param mixed $actual The actual value to compare against the expected value.
-     * @param non-empty-string $message Short description about what exactly is being asserted.
+     * @param string $message Short description about what exactly is being asserted.
      * @param non-empty-string $pattern The message pattern.
      * @param bool $showDiff Whether to generate a diff between expected and actual values.
      */

--- a/src/Assert/StaticState.php
+++ b/src/Assert/StaticState.php
@@ -43,7 +43,7 @@ final class StaticState
 
     /**
      * @param non-empty-string $assertion The assertion result (e.g., "Same: 42", "Assert `true`").
-     * @param non-empty-string $context Optional user-provided context describing what is being asserted.
+     * @param string $context Optional user-provided context describing what is being asserted.
      */
     public static function log(string $assertion, string $context = ''): void
     {

--- a/tests/Assert/Self/AssertNumeric.php
+++ b/tests/Assert/Self/AssertNumeric.php
@@ -7,6 +7,8 @@ namespace Tests\Assert\Self;
 use Testo\Assert;
 use Testo\Attribute\Test;
 use Testo\Expect;
+use function PHPUnit\Framework\lessThan;
+use Testo\Assert\Internal\Assertion\AssertInt;
 
 /**
  * Assertion examples.

--- a/tests/Assert/Self/AssertObject.php
+++ b/tests/Assert/Self/AssertObject.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Assert\Self;
+
+use Testo\Assert;
+use Testo\Attribute\Test;
+
+/**
+ * Assertion examples.
+ */
+final class AssertObject
+{
+    #[Test]
+    public function instanceOf(): void
+    {
+        $obj = new \DateTimeImmutable();
+
+        Assert::instanceOf(\DateTimeInterface::class, $obj);
+        Assert::instanceOf(\DateTimeImmutable::class, $obj);
+    }
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! -->

## What was changed

<!-- Describe what has changed in this PR -->
 - added `IterableType`, `ArrayType` and `ObjectType` Interfaces
 - implemented corresponding `Assert` classes: `AssertIterable`, `AssertArray`, `AssertObject`
 - Created `IterableTrait` for reusable iterable methods `contains`, `sameSizeAs`
 - Created `Assert::iterable`, `Assert::array`, `Assert::object` facade methods

See commit history for details.

## Why?

Trying to expand new Assert methods API and see how it looks like with these data types and methods for them

## Checklist

- Tested
  - [ ] Tested manually
  - [ ] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->

Note: since these methods are blank for now I did not write down tests
