### PR TITLE
feat(assert): implement `AssertIterable` methods

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -21,6 +21,7 @@ use Testo\Assert\State\AssertException;
 use Testo\Assert\State\AssertTypeFailure;
 use Testo\Assert\StaticState;
 use Testo\Assert\Support;
+use Testo\Assert\Internal\Assertion\AssertIterable;
 
 /**
  * Assertion utilities.
@@ -294,12 +295,10 @@ final class Assert
      * Does not work with Generators.
      *
      * @throws AssertTypeFailure
-     *
-     * @deprecated To be implemented
      */
     public static function iterable(mixed $actual): IterableType
     {
-        throw new \LogicException('Not implemented yet');
+        return AssertIterable::validateAndCreate($actual);
     }
 
     /**

--- a/src/Assert/Api/Builtin/IterableType.php
+++ b/src/Assert/Api/Builtin/IterableType.php
@@ -21,8 +21,6 @@ interface IterableType
      * @param mixed $needle The value to look for within the iterable.
      * @param string $message Optional message for the assertion.
      * @throws AssertException when the assertion fails.
-     *
-     * @deprecated To be implemented
      */
     public function contains(mixed $needle, string $message = ''): self;
 
@@ -32,19 +30,24 @@ interface IterableType
      * @param iterable $expected The iterable to compare size against.
      * @param string $message Optional message for the assertion.
      * @throws AssertException when the assertion fails.
-     *
-     * @deprecated To be implemented
      */
     public function sameSizeAs(iterable $expected, string $message = ''): self;
 
     /**
+     * Asserts that the iterable has the expected number of elements.
+     *
+     * @param int $expected The expected count of elements.
+     * @throws AssertException when the assertion fails.
+     */
+    public function hasCount(int $expected): self;
+
+    /**
      * Asserts that all values in the iterable are of the specified type.
      *
-     * @param non-empty-string $type The expected type name (e.g., 'int', 'string', 'object', class name).
+     * @param non-empty-string $type The expected type name (e.g., 'int', 'string', 'object', class name)
+     *        considered valid by {@see \get_debug_type()}.
      * @param string $message Optional message for the assertion.
      * @throws AssertException when the assertion fails.
-     *
-     * @deprecated To be implemented
      */
     public function allOf(string $type, string $message = ''): self;
 }

--- a/src/Assert/Internal/Assertion/AssertIterable.php
+++ b/src/Assert/Internal/Assertion/AssertIterable.php
@@ -24,11 +24,11 @@ class AssertIterable implements IterableType
     ) {}
 
     /**
-     * Validate that the given value is a float and return an AssertFloat instance.
+     * Validate that the given value is an iterable and return an AssertIterable instance.
      *
-     * @param mixed $value The value to be asserted as float.
-     * @return self An instance of AssertFloat.
-     * @throws AssertTypeFailure when the value is not a float.
+     * @param mixed $value The value to be asserted as an iterable.
+     * @return self An instance of AssertIterable.
+     * @throws AssertTypeFailure when the value is not an iterable.
      */
     public static function validateAndCreate(mixed $value): self
     {

--- a/src/Assert/Internal/Assertion/AssertIterable.php
+++ b/src/Assert/Internal/Assertion/AssertIterable.php
@@ -27,7 +27,7 @@ class AssertIterable implements IterableType
      * Validate that the given value is an iterable and return an AssertIterable instance.
      *
      * @param mixed $value The value to be asserted as an iterable.
-     * @return self An instance of AssertIterable.
+     *
      * @throws AssertTypeFailure when the value is not an iterable.
      */
     public static function validateAndCreate(mixed $value): self

--- a/src/Assert/Internal/Assertion/Traits/IterableTrait.php
+++ b/src/Assert/Internal/Assertion/Traits/IterableTrait.php
@@ -10,84 +10,121 @@ use Testo\Assert\Support;
 
 /**
  * Contains assertion methods for iterable values.
+ *
  * @property iterable $value
  */
 trait IterableTrait
 {
-    /**
-     * Asserts that the iterable contains the given needle (strict comparison).
-     * @param mixed $needle The value to look for within the iterable.
-     * @param string $message Optional message for the assertion.
-     *
-     * @throws AssertException when the assertion fails.
-     */
+    #[\Override]
     public function contains(mixed $needle, string $message = ''): self
     {
         foreach ($this->value as $item) {
             if ($item === $needle) {
-                StaticState::log(
-                    'Assert that iterable: ' . Support::stringify($this->value) . ' contains ' . Support::stringify($needle),
-                );
+                StaticState::log('Assert contains: ' . Support::stringify($needle) . '.');
                 return new self($this->value);
             }
         }
+
         StaticState::fail(
             AssertException::fail(
-                'Failed to assert that iterable ' . Support::stringify($this->value) . ' contains ' . Support::stringify($needle),
+                \sprintf(
+                    'Failed to assert that %s contains %s.',
+                    Support::stringify($this->value),
+                    Support::stringify($needle),
+                ),
             ),
         );
     }
 
-    /**
-     * Asserts that the iterable has the same number of elements as the expected iterable.
-     *
-     * @param iterable $expected The iterable to compare size against.
-     * @param string $message Optional message for the assertion.
-     *
-     * @throws AssertException When the iterables do not have the same size.
-     */
+    #[\Override]
     public function sameSizeAs(iterable $expected, string $message = ''): self
     {
-        if (Support::countIterable($this->value) === Support::countIterable($expected)) {
-            StaticState::log(
-                'Assert that iterable: ' . Support::stringify($this->value) . ' has the same number of elements as ' . Support::stringify($expected),
-            );
+        if (self::countIterable($this->value) === self::countIterable($expected)) {
+            StaticState::log('Assert same size as: ' . Support::stringify($expected) . '.');
             return new self($this->value);
         }
+
         StaticState::fail(
             AssertException::fail(
-                'Failed to assert that iterable ' . Support::stringify($this->value) . ' has the same number of elements as ' . Support::stringify($expected),
+                \sprintf(
+                    'Failed to assert that iterable %s has the same number of elements as %s.',
+                    Support::stringify($this->value),
+                    Support::stringify($expected),
+                ),
+            ),
+        );
+    }
+
+    #[\Override]
+    public function allOf(string $type, string $message = ''): self
+    {
+        $type = \strtolower($type);
+        $type = match ($type) {
+            'integer' => 'int',
+            'double' => 'float',
+            'boolean' => 'bool',
+            default => $type,
+        };
+        foreach ($this->value as $element) {
+            $actualType = \strtolower(\get_debug_type($element));
+            $actualType === $type or StaticState::fail(
+                AssertException::fail(
+                    \sprintf(
+                        'Failed to assert that all elements of iterable %s have type %s (found %s instead).',
+                        Support::stringify($this->value),
+                        Support::stringify($type),
+                        Support::stringify($actualType),
+                    ),
+                ),
+            );
+        }
+
+        StaticState::log(
+            \sprintf(
+                'Assert all elements are of type %s.',
+                Support::stringify($type),
+            ),
+        );
+        return new self($this->value);
+    }
+
+    #[\Override]
+    public function hasCount(int $expected): self
+    {
+        $count = self::countIterable($this->value);
+        if ($count === $expected) {
+            StaticState::log("Assert count: {$count}.");
+            return new self($this->value);
+        }
+
+        StaticState::fail(
+            AssertException::fail(
+                \sprintf(
+                    'Failed to assert that %s has %d elements (found %d instead).',
+                    Support::stringify($this->value),
+                    $expected,
+                    $count,
+                ),
             ),
         );
     }
 
     /**
-     * Asserts that all elements of the iterable have the given PHP type.
-     *
-     * The $type parameter uses PHP internal type names (compatible with gettype()),
-     * e.g.: "integer", "double", "boolean", "string", "array", "object", "resource", "null".
-     *
-     * @param non-empty-string $type Expected PHP type name for all elements.
-     * @param string $message Optional message for the assertion.
-     *
-     * @throws AssertException When at least one element has a different type.
+     * Counts the number of elements in the given iterable.
      */
-    public function allOf(string $type, string $message = ''): self
+    private static function countIterable(iterable $value): int
     {
-        foreach ($this->value as $element) {
-            $actualType = \gettype($element);
-            if ($actualType !== $type) {
-                StaticState::fail(
-                    AssertException::fail(
-                        'Failed to assert that all elements of iterable ' . Support::stringify($this->value) . ' have type ' . Support::stringify($type) .
-                        ' (found ' . Support::stringify($actualType) . ' instead)',
-                    ),
-                );
-            }
+        // if Countable
+        if (\is_array($value) || $value instanceof \Countable) {
+            return \count($value);
         }
-        StaticState::log(
-            'Assert that all elements of iterable ' . Support::stringify($this->value) . ' have type ' . Support::stringify($type),
-        );
-        return new self($this->value);
+
+        // if Traversable
+        $count = 0;
+        foreach ($value as $_) {
+            $count++;
+        }
+
+        return $count;
     }
 }

--- a/src/Assert/Internal/Assertion/Traits/IterableTrait.php
+++ b/src/Assert/Internal/Assertion/Traits/IterableTrait.php
@@ -5,36 +5,89 @@ declare(strict_types=1);
 namespace Testo\Assert\Internal\Assertion\Traits;
 
 use Testo\Assert\State\AssertException;
+use Testo\Assert\StaticState;
+use Testo\Assert\Support;
 
 /**
- * Contains methods for comparing numeric values
+ * Contains assertion methods for iterable values.
+ * @property iterable $value
  */
 trait IterableTrait
 {
     /**
-     * Asserts that the iterable contains the given needle.
+     * Asserts that the iterable contains the given needle (strict comparison).
      * @param mixed $needle The value to look for within the iterable.
      * @param string $message Optional message for the assertion.
+     *
      * @throws AssertException when the assertion fails.
      */
     public function contains(mixed $needle, string $message = ''): self
     {
-        throw new \LogicException('Not implemented yet');
+        foreach ($this->value as $item) {
+            if ($item === $needle) {
+                StaticState::log(
+                    'Assert that iterable: ' . Support::stringify($this->value) . ' contains ' . Support::stringify($needle),
+                );
+                return new self($this->value);
+            }
+        }
+        StaticState::fail(
+            AssertException::fail(
+                'Failed to assert that iterable ' . Support::stringify($this->value) . ' contains ' . Support::stringify($needle),
+            ),
+        );
     }
 
     /**
      * Asserts that the iterable has the same number of elements as the expected iterable.
+     *
      * @param iterable $expected The iterable to compare size against.
      * @param string $message Optional message for the assertion.
-     * @throws AssertException when the assertion fails.
+     *
+     * @throws AssertException When the iterables do not have the same size.
      */
     public function sameSizeAs(iterable $expected, string $message = ''): self
     {
-        throw new \LogicException('Not implemented yet');
+        if (Support::countIterable($this->value) === Support::countIterable($expected)) {
+            StaticState::log(
+                'Assert that iterable: ' . Support::stringify($this->value) . ' has the same number of elements as ' . Support::stringify($expected),
+            );
+            return new self($this->value);
+        }
+        StaticState::fail(
+            AssertException::fail(
+                'Failed to assert that iterable ' . Support::stringify($this->value) . ' has the same number of elements as ' . Support::stringify($expected),
+            ),
+        );
     }
 
-    public function allOf(string $type, string $message = ''): \Testo\Assert\Api\Builtin\IterableType
+    /**
+     * Asserts that all elements of the iterable have the given PHP type.
+     *
+     * The $type parameter uses PHP internal type names (compatible with gettype()),
+     * e.g.: "integer", "double", "boolean", "string", "array", "object", "resource", "null".
+     *
+     * @param non-empty-string $type Expected PHP type name for all elements.
+     * @param string $message Optional message for the assertion.
+     *
+     * @throws AssertException When at least one element has a different type.
+     */
+    public function allOf(string $type, string $message = ''): self
     {
-        throw new \LogicException('Not implemented yet');
+        foreach ($this->value as $element) {
+            $actualType = \gettype($element);
+            if ($actualType !== $type) {
+                StaticState::fail(
+                    AssertException::fail(
+                        'Failed to assert that all elements of iterable ' . Support::stringify($this->value) . ' have type ' . Support::stringify($type) .
+                        ' (found ' . Support::stringify($actualType) . ' instead)',
+                    ),
+                );
+            }
+        }
+        StaticState::log(
+            'Assert that all elements of iterable ' . Support::stringify($this->value) . ' have type ' . Support::stringify($type),
+        );
+        return new self($this->value);
     }
 }

--- a/src/Assert/Internal/Assertion/Traits/NumericTrait.php
+++ b/src/Assert/Internal/Assertion/Traits/NumericTrait.php
@@ -23,7 +23,7 @@ trait NumericTrait
     public function greaterThan(int|float $min, string $message = ''): self
     {
         if ($this->value > $min) {
-            StaticState::log('Assert `' . $this->value . '` is greater than `' . $min . '`', $message);
+            StaticState::log('Assert `' . $this->value . ' > ' . $min . '`', $message);
             return $this;
         }
 
@@ -31,7 +31,7 @@ trait NumericTrait
             $min,
             $this->value,
             $message,
-            pattern: 'Failed asserting that value `%2$s` is greater than `%1$s`.',
+            pattern: 'Failed asserting that `%2$s > %1$s`.',
             showDiff: false,
         ));
     }
@@ -46,7 +46,7 @@ trait NumericTrait
     public function greaterThanOrEqual(int|float $min, string $message = ''): self
     {
         if ($this->value >= $min) {
-            StaticState::log('Assert `' . $this->value . '` is greater than or equal to `' . $min . '`', $message);
+            StaticState::log('Assert `' . $this->value . ' >= ' . $min . '`', $message);
             return $this;
         }
 
@@ -54,7 +54,7 @@ trait NumericTrait
             $min,
             $this->value,
             $message,
-            pattern: 'Failed asserting that value `%2$s` is greater than or equal to `%1$s`.',
+            pattern: 'Failed asserting that `%2$s >= %1$s`.',
             showDiff: false,
         ));
     }
@@ -69,7 +69,7 @@ trait NumericTrait
     public function lessThan(int|float $max, string $message = ''): self
     {
         if ($this->value < $max) {
-            StaticState::log('Assert `' . $this->value . '` is less than `' . $max . '`', $message);
+            StaticState::log('Assert `' . $this->value . ' < ' . $max . '`', $message);
             return $this;
         }
 
@@ -77,7 +77,7 @@ trait NumericTrait
             $max,
             $this->value,
             $message,
-            pattern: 'Failed asserting that value `%2$s` is less than `%1$s`.',
+            pattern: 'Failed asserting that `%2$s < %1$s`.',
             showDiff: false,
         ));
     }
@@ -92,7 +92,7 @@ trait NumericTrait
     public function lessThanOrEqual(int|float $max, string $message = ''): self
     {
         if ($this->value <= $max) {
-            StaticState::log('Assert `' . $this->value . '` is less than or equal to `' . $max . '`', $message);
+            StaticState::log('Assert `' . $this->value . ' <= ' . $max . '`', $message);
             return $this;
         }
 
@@ -100,7 +100,7 @@ trait NumericTrait
             $max,
             $this->value,
             $message,
-            pattern: 'Failed asserting that value `%2$s` is less than or equal to `%1$s`.',
+            pattern: 'Failed asserting that `%2$s <= %1$s`.',
             showDiff: false,
         ));
     }

--- a/src/Assert/State/AssertException.php
+++ b/src/Assert/State/AssertException.php
@@ -90,16 +90,19 @@ class AssertException extends \Exception implements Record
         );
     }
 
+    #[\Override]
     final public function isSuccess(): bool
     {
         return false;
     }
 
+    #[\Override]
     final public function getContext(): ?string
     {
         return $this->context !== '' ? $this->context : null;
     }
 
+    #[\Override]
     final public function __toString(): string
     {
         return $this->assertion;

--- a/src/Assert/Support.php
+++ b/src/Assert/Support.php
@@ -24,23 +24,4 @@ final class Support
             default => (string) $value,
         };
     }
-
-    /**
-     * Counts the number of elements in the given iterable.
-     */
-    public static function countIterable(iterable $value): int
-    {
-        // if Countable
-        if (\is_array($value) || $value instanceof \Countable) {
-            return \count($value);
-        }
-
-        // if Traversable
-        $count = 0;
-        foreach ($value as $_) {
-            $count++;
-        }
-
-        return $count;
-    }
 }

--- a/src/Assert/Support.php
+++ b/src/Assert/Support.php
@@ -24,4 +24,23 @@ final class Support
             default => (string) $value,
         };
     }
+
+    /**
+     * Counts the number of elements in the given iterable.
+     */
+    public static function countIterable(iterable $value): int
+    {
+        // if Countable
+        if (\is_array($value) || $value instanceof \Countable) {
+            return \count($value);
+        }
+
+        // if Traversable
+        $count = 0;
+        foreach ($value as $_) {
+            $count++;
+        }
+
+        return $count;
+    }
 }

--- a/tests/Assert/Self/AssertIterable.php
+++ b/tests/Assert/Self/AssertIterable.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Assert\Self;
+
+use Testo\Assert;
+use Testo\Attribute\ExpectException;
+use Testo\Attribute\Test;
+use Testo\Expect;
+
+/**
+ * @see Assert::iterable()
+ */
+final class AssertIterable
+{
+    #[Test]
+    public function checkIterableType(): void
+    {
+        // This assertion checks incoming data type
+        Assert::iterable(new \ArrayIterator([1, 2, 3]));
+        Assert::iterable([]);
+    }
+
+    #[Test]
+    public function checkContains(): void
+    {
+        Assert::iterable(new \ArrayIterator([1, 2, 3]))->contains(3);
+        Assert::iterable([1, 2, 3])->contains(3);
+    }
+
+    #[Test]
+    public function checkSameSizeAs(): void
+    {
+        Assert::iterable(new \ArrayIterator([1, 2, 3]))->sameSizeAs(new \ArrayIterator(['a', 'b', 'c']));
+        Assert::iterable(new \ArrayIterator([1, 2, 3]))->sameSizeAs(['a', 'b', 'c']);
+    }
+
+    #[Test]
+    public function checkAllOf(): void
+    {
+        Assert::iterable(new \ArrayIterator([1, 2, 3]))->allOf('integer');
+        Assert::iterable(['a', 'b', 'c'])->allOf('string');
+
+        Expect::exception(Assert\State\AssertException::class);
+        Assert::iterable([true, false, 'true'])->allOf('bool');
+    }
+}

--- a/tests/Assert/Self/AssertIterable.php
+++ b/tests/Assert/Self/AssertIterable.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Assert\Self;
 
 use Testo\Assert;
-use Testo\Attribute\ExpectException;
 use Testo\Attribute\Test;
 use Testo\Expect;
 
@@ -34,6 +33,12 @@ final class AssertIterable
     {
         Assert::iterable(new \ArrayIterator([1, 2, 3]))->sameSizeAs(new \ArrayIterator(['a', 'b', 'c']));
         Assert::iterable(new \ArrayIterator([1, 2, 3]))->sameSizeAs(['a', 'b', 'c']);
+    }
+
+    #[Test]
+    public function assertCount(): void
+    {
+        Assert::iterable(new \ArrayIterator([1, 2, 3]))->hasCount(3);
     }
 
     #[Test]


### PR DESCRIPTION


<!-- Thanks for opening a PR! -->

## What was changed

<!-- Describe what has changed in this PR -->
- add `AssertIterable::contains()` method.
- add `AssertIterable::sameSizeAs()` method
- add `AssertIterable::allOf()` method

All of the base iterable methods should be covered with this PR. I have more incoming methods for iterable methods, like `isEmpty`/`isNotEmpty()`, `sizeEquals` or `count`, `allInstanceOf`, `anyOf`, we can discuss the necessity of their implementation elsewhere.
See commit history for details.

## Why?

<!-- Tell your future self why have you made these changes -->
It's time to make all these ready for implementation methods real.

## Checklist

- Closes #<!-- add issue number here -->
- Tested
  - [x] Tested manually
  - [x] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->
