### PR TITLE
feat(assert): implement `AssertArray` methods

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -17,6 +17,7 @@ use Testo\Assert\Internal\Assertion\AssertInt;
 use Testo\Assert\Internal\Assertion\AssertJson;
 use Testo\Assert\Internal\Assertion\AssertObject;
 use Testo\Assert\Internal\Assertion\AssertString;
+use Testo\Assert\Internal\Assertion\AssertArray;
 use Testo\Assert\State\AssertException;
 use Testo\Assert\State\AssertTypeFailure;
 use Testo\Assert\StaticState;
@@ -305,12 +306,10 @@ final class Assert
      * Asserts that the given value is of `array` data type.
      *
      * @throws AssertTypeFailure
-     *
-     * @deprecated To be implemented
      */
     public static function array(mixed $actual): ArrayType
     {
-        throw new \LogicException('Not implemented yet');
+        return AssertArray::validateAndCreate($actual);
     }
 
     /**

--- a/src/Assert/Api/Builtin/ArrayType.php
+++ b/src/Assert/Api/Builtin/ArrayType.php
@@ -16,13 +16,12 @@ interface ArrayType extends IterableType
     /**
      * Asserts that the array contains given key.
      *
-     * @param mixed $key The key to check for in the array.
+     * @param int|string $key The key to check for in the array.
      * @param string $message Optional message for the assertion.
      * @throws AssertException when the assertion fails.
      *
-     * @deprecated To be implemented
      */
-    public function hasKey(mixed $key, string $message = ''): self;
+    public function hasKey(int|string $key, string $message = ''): self;
 
     /**
      * Asserts that the array is a list.
@@ -33,7 +32,6 @@ interface ArrayType extends IterableType
      * @param string $message Optional message for the assertion.
      * @throws AssertException when the assertion fails.
      *
-     * @deprecated To be implemented
      */
     public function isList(string $message = ''): self;
 }

--- a/src/Assert/Internal/Assertion/AssertArray.php
+++ b/src/Assert/Internal/Assertion/AssertArray.php
@@ -13,7 +13,7 @@ use Testo\Assert\StaticState;
 use Testo\Assert\Support;
 
 /**
- * Assertion utilities for iterables.
+ * Assertion utilities for arrays.
  *
  * @internal
  */
@@ -27,11 +27,11 @@ class AssertArray implements ArrayType
     ) {}
 
     /**
-     * Validate that the given value is a float and return an AssertFloat instance.
+     * Validate that the given value is an array and return an AssertArray instance.
      *
-     * @param mixed $value The value to be asserted as float.
-     * @return self An instance of AssertFloat.
-     * @throws AssertTypeFailure when the value is not a float.
+     * @param mixed $value The value to be asserted as array.
+     *
+     * @throws AssertTypeFailure when the value is not an array.
      */
     public static function validateAndCreate(mixed $value): self
     {
@@ -41,18 +41,45 @@ class AssertArray implements ArrayType
         return new self($value, $parent);
     }
 
-    /**
-     * Asserts that the array contains given key.
-     * @param string $message Optional message for the assertion.
-     * @throws AssertException when the assertion fails.
-     */
-    public function hasKey(mixed $key, string $message = ''): self
+    #[\Override]
+    public function hasKey(int|string $key, string $message = ''): self
     {
-        throw new \LogicException('Not implemented yet');
+        if (\array_key_exists($key, $this->value)) {
+            $this->parent->log(
+                \sprintf(
+                    'Assert has key: %s.',
+                    Support::stringify($key),
+                ),
+            );
+            return $this;
+        }
+        $this->parent->fail(
+            AssertException::fail(
+                \sprintf(
+                    'Failed to assert that array %s has key %s.',
+                    Support::stringify($this->value),
+                    Support::stringify($key),
+                ),
+            ),
+        );
     }
 
+    #[\Override]
     public function isList(string $message = ''): ArrayType
     {
-        throw new \LogicException('Not implemented yet');
+        if (\array_is_list($this->value)) {
+            $this->parent->log('Assert array is list.');
+
+            return $this;
+        }
+
+        $this->parent->fail(
+            AssertException::fail(
+                \sprintf(
+                    'Failed to assert that array %s is a list.',
+                    Support::stringify($this->value),
+                ),
+            ),
+        );
     }
 }

--- a/tests/Assert/Self/AssertArray.php
+++ b/tests/Assert/Self/AssertArray.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Assert\Self;
+
+use Testo\Assert;
+use Testo\Attribute\Test;
+use Testo\Expect;
+
+/**
+ * @see Assert::array()
+ */
+final class AssertArray
+{
+    #[Test]
+    public function checkArrayType(): void
+    {
+        // This assertion checks incoming data type
+        Assert::array([1, 2, 3]);
+        Assert::array([]);
+    }
+
+    #[Test]
+    public function checkIterableTraitMethods(): void
+    {
+        Assert::array([1, 2, 3])->contains(3)->allOf('int')->sameSizeAs([4,5,6])->hasCount(3);
+    }
+
+    #[Test]
+    public function checkHasKey(): void
+    {
+        Assert::array(['key' => 'value', 'abc' => 'value2'])->hasKey('key');
+
+        Expect::exception(Assert\State\AssertException::class);
+        Assert::array(['key' => 'value', 'abc' => 'value2'])->hasKey('key2');
+    }
+
+    #[Test]
+    public function assertIsList(): void
+    {
+        Assert::array([1, 2, 3])->isList();
+
+        Expect::exception(Assert\State\AssertException::class);
+        Assert::array(['key' => 'value', 'abc' => 'value2'])->isList();
+    }
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! -->

## What was changed
- add `AssertArray::hasKey()` method.
- add `AssertArray::isList` method
<!-- Describe what has changed in this PR -->

See commit history for details.

## Why?
People need these methods for asserting staff
<!-- Tell your future self why have you made these changes -->

## Checklist

- Closes #<!-- add issue number here -->
- Tested
  - [x] Tested manually
  - [x] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->

## Also
I can add more methods to `ArrayType` interface and `AssertArray` library within this PR.
Consider these methods please:
 - `hasNotKey($key)`
 - `hasKeys(iterable $keys)`
 - `isAssoc()`
 
 Or maybe they are not necessary right now, or you have other methods in mind. Let me know what you think.
