### PR TITLE
feat(assert): Add `every()` assertion method for iterables

### DIFF
--- a/src/Assert/Api/Builtin/IterableType.php
+++ b/src/Assert/Api/Builtin/IterableType.php
@@ -50,4 +50,13 @@ interface IterableType
      * @throws AssertException when the assertion fails.
      */
     public function allOf(string $type, string $message = ''): static;
+
+    /**
+     * Asserts that every element in the iterable satisfies the given callback predicate.
+     *
+     * @param callable(mixed): bool $callback A predicate function that receives each element and returns true if it satisfies the condition.
+     * @param string $message Optional message for the assertion.
+     * @throws AssertException when the assertion fails.
+     */
+    public function every(callable $callback, string $message = ''): static;
 }

--- a/src/Assert/Internal/Assertion/Traits/IterableTrait.php
+++ b/src/Assert/Internal/Assertion/Traits/IterableTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Testo\Assert\Internal\Assertion\Traits;
 
 use Testo\Assert\State\Assertion\AssertionComposite;
+use Testo\Assert\State\Assertion\AssertionException;
 use Testo\Assert\Support;
 
 /**
@@ -31,6 +32,25 @@ trait IterableTrait
             reason: 'element not found',
             context: $message,
         );
+    }
+
+    #[\Override]
+    public function every(callable $callback, string $message = ''): static
+    {
+        $str = 'every element matches callback';
+        foreach ($this->value as $key => $item) {
+            if (! $callback($item)) {
+                throw $this->parent->fail(
+                    assertion: $str,
+                    reason: "element at `{$key}` failed: `" . Support::stringify($item) . '`',
+                    context: $message,
+                );
+            }
+        }
+
+        $this->parent->success($str);
+
+        return $this;
     }
 
     #[\Override]

--- a/tests/Assert/Self/AssertArray.php
+++ b/tests/Assert/Self/AssertArray.php
@@ -44,4 +44,13 @@ final class AssertArray
         Expect::exception(Assert\State\Assertion\AssertionException::class);
         Assert::array(['key' => 'value', 'abc' => 'value2'])->isList();
     }
+
+    #[Test]
+    public function assertEvery(): void
+    {
+        Assert::array([1, 2, 3])->every(fn ($value) => is_int($value));
+
+        Expect::exception(Assert\State\Assertion\AssertionException::class);
+        Assert::array([1, 2, 3, 'testo'])->every(fn ($value) => is_int($value));
+    }
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! -->

## What was changed

Added a new `every()` method to verify that all elements in an iterable satisfy a given condition through a callback function.


## Usage Example
```php
Assert::array([1, 2, 3])->every(fn ($value) => is_int($value));
```

## Checklist

- Tested
  - [x] Tested manually
  - [x] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->
