### PR TITLE
fix: symfony console 8 support

### DIFF
--- a/bin/testo
+++ b/bin/testo
@@ -46,10 +46,10 @@ use Testo\Common\Command;
     $application = new Application();
     $application->setCommandLoader(
         new FactoryCommandLoader([
-            Command\Run::getDefaultName() => static fn() => new Command\Run(),
+            'run' => static fn() => new Command\Run(),
         ]),
     );
-    $application->setDefaultCommand(Command\Run::getDefaultName(), false);
+    $application->setDefaultCommand('run', false);
     $application->setVersion(Info::version());
     $application->setName(Info::NAME);
     $application->run();


### PR DESCRIPTION
## What was changed

Updated console application initialization to support Symfony Console 8, which removed the deprecated `getDefaultName()` method.

See commit history for details.

## Why?

Symfony Console 8 removed the getDefaultName() static method in favor of the #[AsCommand] attribute, which is already used in the Run command class. The command name is now explicitly specified as a string constant.

## Checklist

- Tested
  - [x] Tested manually
  - [ ] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->
