### PR TITLE
feat(assert): implement `AssertObject` methods

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -153,7 +153,7 @@ final class Assert
      * @param class-string<ExpectedType> $expected Fully-qualified class or interface name.
      * @param mixed $actual The actual object to check.
      * @param string $message Optional message for the assertion.
-     * @throws AssertException when the assertion fails.
+     * @throws AssertionException when the assertion fails.
      *
      * @psalm-assert ExpectedType $actual
      * @phpstan-assert ExpectedType $actual
@@ -318,11 +318,10 @@ final class Assert
      *
      * @throws AssertionException
      *
-     * @deprecated To be implemented
      */
     public static function object(mixed $actual): ObjectType
     {
-        throw new \LogicException('Not implemented yet');
+        return AssertObject::validateAndCreate($actual);
     }
 
     /**

--- a/src/Assert/Api/Builtin/ArrayType.php
+++ b/src/Assert/Api/Builtin/ArrayType.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Testo\Assert\Api\Builtin;
 
-use Testo\Assert\State\AssertException;
+use Testo\Assert\State\Assertion\AssertionException;
 
 /**
  * Assertion utilities for array-like data type.
@@ -17,7 +17,7 @@ interface ArrayType extends IterableType
      * Asserts that the array contains given key.
      *
      * @param int|string ...$keys The keys to check for existence in the array.
-     * @throws AssertException when the assertion fails.
+     * @throws AssertionException when the assertion fails.
      */
     public function hasKeys(int|string ...$keys): static;
 
@@ -28,7 +28,7 @@ interface ArrayType extends IterableType
      * Equivalent to {@see array_is_list()} in PHP 8.1+.
      *
      * @param string $message Optional message for the assertion.
-     * @throws AssertException when the assertion fails.
+     * @throws AssertionException when the assertion fails.
      */
     public function isList(string $message = ''): static;
 }

--- a/src/Assert/Api/Builtin/IterableType.php
+++ b/src/Assert/Api/Builtin/IterableType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Testo\Assert\Api\Builtin;
 
 use Testo\Assert\State\AssertException;
+use Testo\Assert\State\Assertion\AssertionException;
 
 /**
  * Assertion utilities for iterables.
@@ -20,7 +21,7 @@ interface IterableType
      *
      * @param mixed $needle The value to look for within the iterable.
      * @param string $message Optional message for the assertion.
-     * @throws AssertException when the assertion fails.
+     * @throws AssertionException when the assertion fails.
      */
     public function contains(mixed $needle, string $message = ''): static;
 
@@ -29,7 +30,7 @@ interface IterableType
      *
      * @param iterable $expected The iterable to compare size against.
      * @param string $message Optional message for the assertion.
-     * @throws AssertException when the assertion fails.
+     * @throws AssertionException when the assertion fails.
      */
     public function sameSizeAs(iterable $expected, string $message = ''): static;
 
@@ -37,7 +38,7 @@ interface IterableType
      * Asserts that the iterable has the expected number of elements.
      *
      * @param int $expected The expected count of elements.
-     * @throws AssertException when the assertion fails.
+     * @throws AssertionException when the assertion fails.
      */
     public function hasCount(int $expected): static;
 
@@ -47,7 +48,7 @@ interface IterableType
      * @param non-empty-string $type The expected type name (e.g., 'int', 'string', 'object', class name)
      *        considered valid by {@see \get_debug_type()}.
      * @param string $message Optional message for the assertion.
-     * @throws AssertException when the assertion fails.
+     * @throws AssertionException when the assertion fails.
      */
     public function allOf(string $type, string $message = ''): static;
 

--- a/src/Assert/Api/Builtin/NumericType.php
+++ b/src/Assert/Api/Builtin/NumericType.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Testo\Assert\Api\Builtin;
 
-use Testo\Assert\State\AssertException;
+use Testo\Assert\State\Assertion\AssertionException;
 
 /**
  * Assertion utilities for numeric data types.
@@ -18,7 +18,7 @@ interface NumericType
      *
      * @param int|float $min Minimum threshold to compare with.
      * @param string $message Optional message for the assertion.
-     * @throws AssertException when the assertion fails.
+     * @throws AssertionException when the assertion fails.
      */
     public function greaterThan(int|float $min, string $message = ''): static;
 
@@ -27,7 +27,7 @@ interface NumericType
      *
      * @param int|float $min Minimum threshold to compare with.
      * @param string $message Optional message for the assertion.
-     * @throws AssertException when the assertion fails.
+     * @throws AssertionException when the assertion fails.
      */
     public function greaterThanOrEqual(int|float $min, string $message = ''): static;
 
@@ -36,7 +36,7 @@ interface NumericType
      *
      * @param int|float $max Maximum threshold to compare with.
      * @param string $message Optional message for the assertion.
-     * @throws AssertException when the assertion fails.
+     * @throws AssertionException when the assertion fails.
      */
     public function lessThan(int|float $max, string $message = ''): static;
 
@@ -45,7 +45,7 @@ interface NumericType
      *
      * @param int|float $max Maximum threshold to compare with.
      * @param string $message Optional message for the assertion.
-     * @throws AssertException when the assertion fails.
+     * @throws AssertionException when the assertion fails.
      */
     public function lessThanOrEqual(int|float $max, string $message = ''): static;
 }

--- a/src/Assert/Api/Builtin/ObjectType.php
+++ b/src/Assert/Api/Builtin/ObjectType.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Testo\Assert\Api\Builtin;
 
-use Testo\Assert\State\AssertException;
+use Testo\Assert\State\Assertion\AssertionException;
 
 /**
  * Assertion utilities for objects.
@@ -18,7 +18,7 @@ interface ObjectType
      *
      * @param class-string<ExpectedType> $expected Fully-qualified class or interface name.
      * @param string $message Optional message for the assertion.
-     * @throws AssertException when the assertion fails.
+     * @throws AssertionException when the assertion fails.
      *
      * @psalm-assert ExpectedType $actual
      * @phpstan-assert ExpectedType $actual
@@ -30,9 +30,8 @@ interface ObjectType
      *
      * @param non-empty-string $propertyName The property name to check.
      * @param string $message Optional message for the assertion.
-     * @throws AssertException when the assertion fails.
+     * @throws AssertionException when the assertion fails.
      *
-     * @deprecated To be implemented
      */
     public function hasProperty(string $propertyName, string $message = ''): static;
 }

--- a/src/Assert/Api/Builtin/StringType.php
+++ b/src/Assert/Api/Builtin/StringType.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Testo\Assert\Api\Builtin;
 
-use Testo\Assert\State\AssertException;
+use Testo\Assert\State\Assertion\AssertionException;
 
 /**
  * Assertion utilities for string data type.
@@ -16,7 +16,7 @@ interface StringType
      *
      * @param string $needle Substring to search for.
      * @param string $message Optional message for the assertion.
-     * @throws AssertException when the assertion fails.
+     * @throws AssertionException when the assertion fails.
      */
     public function contains(string $needle, string $message = ''): static;
 
@@ -25,7 +25,7 @@ interface StringType
      *
      * @param string $needle Substring to search for.
      * @param string $message Optional message for the assertion.
-     * @throws AssertException when the assertion fails.
+     * @throws AssertionException when the assertion fails.
      */
     public function notContains(string $needle, string $message = ''): static;
 }

--- a/src/Assert/Internal/Assertion/AssertArray.php
+++ b/src/Assert/Internal/Assertion/AssertArray.php
@@ -9,7 +9,6 @@ use Testo\Assert\Internal\Assertion\Traits\IterableTrait;
 use Testo\Assert\State\Assertion\AssertionComposite;
 use Testo\Assert\State\Assertion\AssertionException;
 use Testo\Assert\StaticState;
-use Testo\Assert\Support;
 
 /**
  * Assertion utilities for arrays.

--- a/src/Assert/Internal/Assertion/AssertObject.php
+++ b/src/Assert/Internal/Assertion/AssertObject.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Testo\Assert\Internal\Assertion;
 
 use Testo\Assert\Api\Builtin\ObjectType;
-use Testo\Assert\State\AssertException;
 use Testo\Assert\State\Assertion\AssertionComposite;
+use Testo\Assert\State\Assertion\AssertionException;
 use Testo\Assert\StaticState;
 
 /**
- * Assertion utilities for iterables.
+ * Assertion utilities for objects.
  *
  * @internal
  */
@@ -24,8 +24,8 @@ final class AssertObject implements ObjectType
     /**
      * @template ValueType
      *
-     * @param ValueType $value The value to be asserted as float.
-     * @throws AssertException
+     * @param ValueType $value The value to be asserted as object.
+     * @throws AssertionException when the value is not an object.
      *
      * @psalm-assert object $value
      * @phpstan-assert object $value
@@ -51,6 +51,10 @@ final class AssertObject implements ObjectType
     #[\Override]
     public function hasProperty(string $propertyName, string $message = ''): static
     {
-        throw new \LogicException('Not implemented yet');
+        $str = "has property `{$propertyName}`";
+        \property_exists($this->value, $propertyName)
+            ? $this->parent->success($str, $message)
+            : throw $this->parent->fail($str, 'does not have property `' . $propertyName . '`', $message);
+        return $this;
     }
 }

--- a/src/Assert/Internal/Assertion/Traits/IterableTrait.php
+++ b/src/Assert/Internal/Assertion/Traits/IterableTrait.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Testo\Assert\Internal\Assertion\Traits;
 
 use Testo\Assert\State\Assertion\AssertionComposite;
-use Testo\Assert\State\Assertion\AssertionException;
 use Testo\Assert\Support;
 
 /**

--- a/src/Common/CloneWith.php
+++ b/src/Common/CloneWith.php
@@ -13,6 +13,8 @@ trait CloneWith
 {
     /**
      * Return a new immutable instance with the specified property value.
+     * @param non-empty-string $key The property name to set.
+     *
      * @psalm-immutable
      */
     private function cloneWith(string $key, mixed $value): static

--- a/tests/Assert/Self/AssertObject.php
+++ b/tests/Assert/Self/AssertObject.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Assert\Self;
 
-use stdClass;
 use Testo\Assert;
 use Testo\Attribute\Test;
 use Testo\Expect;
@@ -28,9 +27,12 @@ final class AssertObject
     #[Test]
     public function hasProperty(): void
     {
-        $obj = new stdClass();
-        $obj->property = null;
-        Assert::object($obj)->hasProperty('property');
+        $obj = new class {
+            private int $private = 42;
+            public int $public = 42;
+        };
+        Assert::object($obj)->hasProperty('private');
+        Assert::object($obj)->hasProperty('public');
 
         Expect::exception(Assert\State\Assertion\AssertionException::class);
         Assert::object($obj)->hasProperty('wrongPropertyName');

--- a/tests/Assert/Self/AssertObject.php
+++ b/tests/Assert/Self/AssertObject.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Assert\Self;
 
+use stdClass;
 use Testo\Assert;
 use Testo\Attribute\Test;
+use Testo\Expect;
 
 /**
  * Assertion examples.
@@ -19,5 +21,18 @@ final class AssertObject
 
         Assert::instanceOf(\DateTimeInterface::class, $obj);
         Assert::instanceOf(\DateTimeImmutable::class, $obj);
+
+        Assert::object($obj)->instanceOf(\DateTimeInterface::class);
+    }
+
+    #[Test]
+    public function hasProperty(): void
+    {
+        $obj = new stdClass();
+        $obj->property = null;
+        Assert::object($obj)->hasProperty('property');
+
+        Expect::exception(Assert\State\Assertion\AssertionException::class);
+        Assert::object($obj)->hasProperty('wrongPropertyName');
     }
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! -->

## What was changed
- add `AssertObject::hasProperty()` method
- small naming fixes
<!-- Describe what has changed in this PR -->

See commit history for details.

## Why?
To make more methods for assertion API

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
  - [x] Tested manually
  - [x] Unit tests added
