### PR TITLE
Add class-level #[Test] attribute support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: Tests
+
+on: [ 'push', 'pull_request' ]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ 8.1, 8.2, 8.3, 8.4, 8.5 ]
+      max-parallel: 2
+
+    name: Tests PHP${{ matrix.php }}
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache/files
+          key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer update --no-interaction --prefer-dist
+
+      - name: Run Tests
+        run: composer test

--- a/src/Assert/Api/Builtin/ArrayType.php
+++ b/src/Assert/Api/Builtin/ArrayType.php
@@ -22,6 +22,14 @@ interface ArrayType extends IterableType
     public function hasKeys(int|string ...$keys): static;
 
     /**
+     * Asserts that the array does not contain given key.
+     *
+     * @param int|string ...$keys The keys to check for non-existence in the array.
+     * @throws AssertionException when the assertion fails.
+     */
+    public function doesNotHaveKeys(int|string ...$keys): static;
+
+    /**
      * Asserts that the array is a list.
      *
      * A list is an array with sequential integer keys starting from 0.

--- a/src/Assert/Api/Builtin/ArrayType.php
+++ b/src/Assert/Api/Builtin/ArrayType.php
@@ -22,7 +22,7 @@ interface ArrayType extends IterableType
     public function hasKeys(int|string ...$keys): static;
 
     /**
-     * Asserts that the array does not contain given key.
+     * Asserts that the array does not contain given keys.
      *
      * @param int|string ...$keys The keys to check for non-existence in the array.
      * @throws AssertionException when the assertion fails.

--- a/src/Assert/Internal/Assertion/AssertArray.php
+++ b/src/Assert/Internal/Assertion/AssertArray.php
@@ -71,6 +71,37 @@ class AssertArray implements ArrayType
     }
 
     #[\Override]
+    public function doesNotHaveKeys(string|int ...$keys): static
+    {
+        if ($keys === []) {
+            return $this;
+        }
+
+        $foundKeys = [];
+        foreach ($keys as $k => $key) {
+            $keys[$k] = "`$key`";
+            if (!\array_key_exists($key, $this->value)) {
+                continue;
+            }
+
+            $foundKeys[] = "`$key`";
+        }
+
+        $m = \count($keys) === 1 ? '' : 's';
+        $str = "does not have key$m " . \implode(', ', $keys);
+        if ($foundKeys === []) {
+            $this->parent->success($str);
+            return $this;
+        }
+
+        $m = \count($foundKeys) === 1 ? '' : 's';
+        throw $this->parent->fail(
+            assertion: $str,
+            reason: "found key$m: " . \implode(', ', $foundKeys),
+        );
+    }
+
+    #[\Override]
     public function isList(string $message = ''): static
     {
         if (\array_is_list($this->value)) {

--- a/src/Attribute/Test.php
+++ b/src/Attribute/Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Testo\Attribute;
 
 /**
- * Marks a method or a function as a test.
+ * Marks a class (public methods), or a method or a function as a test.
  */
-#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION)]
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION | \Attribute::TARGET_CLASS)]
 final class Test
 {
     public function __construct(

--- a/src/Interceptor/Locator/TestoAttributesLocatorInterceptor.php
+++ b/src/Interceptor/Locator/TestoAttributesLocatorInterceptor.php
@@ -32,6 +32,18 @@ final class TestoAttributesLocatorInterceptor implements FileLocatorInterceptor,
                 continue;
             }
 
+            // Check if the class has attribute Test, if so define a case for all its public methods
+            if (Reflection::fetchClassAttributes($class, attributeClass: Test::class) !== []) {
+                foreach ($class->getMethods() as $method) {
+                    if ($method->isPublic()) {
+                        $file->cases->define($class, $file)->tests->define($method);
+                    }
+                }
+
+                continue;
+            }
+
+            // Otherwise, define a test for each public method with attribute Test
             foreach ($class->getMethods() as $method) {
                 if ($method->isPublic() && Reflection::fetchFunctionAttributes($method, attributeClass: Test::class)) {
                     $file->cases->define($class, $file)->tests->define($method);

--- a/src/Interceptor/Reflection/Reflection.php
+++ b/src/Interceptor/Reflection/Reflection.php
@@ -49,7 +49,7 @@ final class Reflection
      *
      * @template T
      *
-     * @param class-string $class
+     * @param \ReflectionClass|class-string $class
      * @param bool $includeParents Whether to include attributes from parent classes.
      * @param bool $includeTraits Whether to include attributes from traits.
      * @param class-string<T>|null $attributeClass If provided, only attributes of this class will be returned.

--- a/tests/Fixture/Interceptor/PlainClassWithoutTestAttributes.php
+++ b/tests/Fixture/Interceptor/PlainClassWithoutTestAttributes.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixture\Interceptor;
+
+final class PlainClassWithoutTestAttributes
+{
+    public function methodOne(): void {}
+
+    protected function protectedMethod(): void {}
+
+    public function methodTwo(): void {}
+
+    private function privateMethod(): void {}
+}

--- a/tests/Fixture/Interceptor/TestClassWithClassLevelAttribute.php
+++ b/tests/Fixture/Interceptor/TestClassWithClassLevelAttribute.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixture\Interceptor;
+
+use Testo\Attribute\Test;
+
+#[Test]
+final class TestClassWithClassLevelAttribute
+{
+    public function methodOne(): void {}
+
+    protected function protectedMethod(): void {}
+
+    public function methodTwo(): void {}
+
+    private function privateMethod(): void {}
+}

--- a/tests/Fixture/Interceptor/TestClassWithMethodLevelAttributes.php
+++ b/tests/Fixture/Interceptor/TestClassWithMethodLevelAttributes.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixture\Interceptor;
+
+use Testo\Attribute\Test;
+
+final class TestClassWithMethodLevelAttributes
+{
+    #[Test]
+    public function methodOne(): void {}
+
+    #[Test]
+    protected function nonTestMethodOne(): void {}
+
+    public function nonTestMethodTwo(): void {}
+
+    #[Test]
+    private function nonTestMethodThree(): void {}
+
+    #[Test]
+    public function methodTwo(): void {}
+}

--- a/tests/Testo/Interceptor/TestoAttributesLocatorInterceptorTest.php
+++ b/tests/Testo/Interceptor/TestoAttributesLocatorInterceptorTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Interceptor;
+
+use Testo\Assert;
+use Testo\Attribute\Test;
+use Testo\Interceptor\Locator\TestoAttributesLocatorInterceptor;
+use Testo\Module\Tokenizer\Reflection\FileDefinitions;
+use Testo\Module\Tokenizer\Reflection\TokenizedFile;
+use Tests\Fixture\Interceptor\TestClassWithClassLevelAttribute;
+use Tests\Fixture\Interceptor\TestClassWithMethodLevelAttributes;
+
+final class TestoAttributesLocatorInterceptorTest
+{
+    private string $fixturesDir = __DIR__ . '/../../Fixture/Interceptor/';
+    private TestoAttributesLocatorInterceptor $interceptor;
+
+    public function __construct()
+    {
+        $this->interceptor = new TestoAttributesLocatorInterceptor();
+    }
+
+    #[Test]
+    /**
+     * Locates test cases when individual methods have #[Test] attributes.
+     *
+     * Verifies that the interceptor correctly:
+     * - Finds methods with #[Test] attribute (methodOne, methodTwo)
+     * - Excludes methods without #[Test] attribute (nonTestMethodOne, nonTestMethodTwo)
+     * - Excludes non-public methods with #[Test] attribute (nonTestMethodThree)
+     */
+    public function itLocatesTestCasesFromClassWithTestAttributesOnMethods(): void
+    {
+        $path = $this->fixturesDir . 'TestClassWithMethodLevelAttributes.php';
+        $definition = new FileDefinitions(
+            $file = new TokenizedFile(
+                file: new \SplFileInfo($path),
+                path: $path,
+            ),
+        );
+
+        Assert::true($this->interceptor->locateFile($file, fn($f) => true));
+        $this->interceptor->locateTestCases($definition, fn(FileDefinitions $f) => $f->cases);
+
+        $case = $definition->cases->getCases()[0];
+        $tests = $case->tests->getTests();
+
+        Assert::same(TestClassWithMethodLevelAttributes::class, $case->reflection->name);
+
+        Assert::array($tests)
+            ->hasCount(2)
+            ->hasKeys('methodOne', 'methodTwo')
+            ->doesNotHaveKeys('nonTestMethodOne', 'nonTestMethodTwo', 'nonTestMethodThree');
+    }
+
+    #[Test]
+    /**
+     * Locates all public methods as tests when the class has #[Test] attribute.
+     *
+     * Verifies that the interceptor correctly:
+     * - Treats all public methods as tests when #[Test] is on the class
+     * - Excludes protected and private methods
+     */
+    public function itLocatesAllPublicMethodsAsTestsWhenClassHasTestAttribute(): void
+    {
+        $path = $this->fixturesDir . 'TestClassWithClassLevelAttribute.php';
+        $definition = new FileDefinitions(
+            $file = new TokenizedFile(
+                file: new \SplFileInfo($path),
+                path: $path,
+            ),
+        );
+
+        Assert::true($this->interceptor->locateFile($file, fn($f) => true));
+        $this->interceptor->locateTestCases($definition, fn(FileDefinitions $f) => $f->cases);
+
+        $case = $definition->cases->getCases()[0];
+        $tests = $case->tests->getTests();
+
+        Assert::same(TestClassWithClassLevelAttribute::class, $case->reflection->name);
+
+        Assert::string(TestClassWithClassLevelAttribute::class);
+
+        Assert::array($tests)
+            ->hasCount(2)
+            ->hasKeys('methodOne', 'methodTwo')
+            ->doesNotHaveKeys('protectedMethod', 'privateMethod');
+    }
+
+    #[Test]
+    /**
+     * Verifies that classes without #[Test] attributes (neither on class nor methods)
+     * are ignored by the interceptor.
+     */
+    public function itReturnsNoTestCasesWhenClassHasNoTestAttributes(): void
+    {
+        $path = $this->fixturesDir . 'PlainClassWithoutTestAttributes.php';
+        $definition = new FileDefinitions(
+            $file = new TokenizedFile(
+                file: new \SplFileInfo($path),
+                path: $path,
+            ),
+        );
+
+        Assert::true($this->interceptor->locateFile($file, fn($f) => true));
+        Assert::array($definition->cases->getCases())->hasCount(0);
+    }
+}

--- a/tests/Testo/Interceptor/TestoAttributesLocatorInterceptorTest.php
+++ b/tests/Testo/Interceptor/TestoAttributesLocatorInterceptorTest.php
@@ -81,8 +81,6 @@ final class TestoAttributesLocatorInterceptorTest
 
         Assert::same(TestClassWithClassLevelAttribute::class, $case->reflection->name);
 
-        Assert::string(TestClassWithClassLevelAttribute::class);
-
         Assert::array($tests)
             ->hasCount(2)
             ->hasKeys('methodOne', 'methodTwo')


### PR DESCRIPTION
  - Classes marked with #[Test] now treat all public methods as tests
  - Add `AssertArray::doesNotHaveKeys()` assertion method
  - Fix `Reflection::fetchClassAttributes()` type hint to accept ReflectionClass
  - Add GitHub Actions workflow for running tests
  - Add comprehensive test coverage for class and method-level attributes

  fixes #33