### PR TITLE
TestCaseFactory for flexible test instantiation

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -15,41 +15,40 @@ use Testo\Test\Dto\RunResult;
 use Testo\Test\Dto\Status;
 use Testo\Test\Runner\SuiteRunner;
 use Testo\Test\SuiteProvider;
+use Testo\Test\TestCaseFactory;
+use Testo\Test\Factory;
 
 final class Application
 {
     private function __construct(
         private readonly ObjectContainer $container,
+        ?TestCaseFactory $testCaseFactory = null,
     ) {
         $config = $container->get(ApplicationConfig::class);
         $this->container->set($config);
         $this->applyPlugins($config->plugins);
+
+        $this->container->set(
+            service: $testCaseFactory ?? new Factory\ReflectionFactory(),
+            id: TestCaseFactory::class,
+        );
     }
 
-    /**
-     * Create the application instance with the provided configuration.
-     */
     public static function createFromConfig(
         ApplicationConfig $config,
+        ?TestCaseFactory $testCaseFactory = null,
     ): self {
         $container = new ObjectContainer();
         $container->set($config);
-        return new self($container);
+        return new self($container, $testCaseFactory);
     }
 
-    /**
-     * Create the application instance from ENV, CLI arguments, and config file.
-     *
-     * @param Path|null $configFile Path to config file
-     * @param array<string, mixed> $inputOptions Command-line options
-     * @param array<string, mixed> $inputArguments Command-line arguments
-     * @param array<string, string> $environment Environment variables
-     */
     public static function createFromInput(
         ?Path $configFile = null,
         array $inputOptions = [],
         array $inputArguments = [],
         array $environment = [],
+        ?TestCaseFactory $testCaseFactory = null,
     ): self {
         $container = new ObjectContainer();
         $args = [
@@ -77,7 +76,7 @@ final class Application
         $container->addInflector($container->make(ConfigInflector::class, $args));
         $container->bind(Filter::class, Filter::fromScope(...));
 
-        return new self($container);
+        return new self($container, $testCaseFactory);
     }
 
     public function run(?Filter $filter = null): RunResult

--- a/src/Interceptor/TestCaseCallInterceptor/InstantiateTestCase.php
+++ b/src/Interceptor/TestCaseCallInterceptor/InstantiateTestCase.php
@@ -8,19 +8,24 @@ use Testo\Interceptor\Exception\TestCaseInstantiationException;
 use Testo\Interceptor\TestCaseRunInterceptor;
 use Testo\Test\Dto\CaseInfo;
 use Testo\Test\Dto\CaseResult;
+use Testo\Test\TestCaseFactory;
 
 /**
  * Instantiate the test case class if not already instantiated.
  */
 final class InstantiateTestCase implements TestCaseRunInterceptor
 {
+    public function __construct(
+        private readonly TestCaseFactory $factory,
+    ) {}
+
     #[\Override]
     public function runTestCase(CaseInfo $info, callable $next): CaseResult
     {
         if ($info->instance === null && $info->definition->reflection !== null) {
             try {
                 # TODO don't instantiate if the test method is static
-                $instance = $info->definition->reflection->newInstance();
+                $instance = $this->factory->create($info->definition->reflection);
             } catch (\Throwable $e) {
                 throw new TestCaseInstantiationException(previous: $e);
             }

--- a/src/Module/Interceptor/InterceptorProvider.php
+++ b/src/Module/Interceptor/InterceptorProvider.php
@@ -56,7 +56,7 @@ final class InterceptorProvider
             FilterInterceptor::class,
             new FilePostfixTestLocatorInterceptor(),
             new TestoAttributesLocatorInterceptor(),
-            new InstantiateTestCase(),
+            InstantiateTestCase::class,
             new AssertCollectorInterceptor(),
             TestInlineFinder::class,
             AttributesInterceptor::class,

--- a/src/Test/Definition/TestDefinition.php
+++ b/src/Test/Definition/TestDefinition.php
@@ -4,9 +4,23 @@ declare(strict_types=1);
 
 namespace Testo\Test\Definition;
 
+use Testo\Attribute\Test;
+
 final class TestDefinition
 {
     public function __construct(
         public readonly \ReflectionFunctionAbstract $reflection,
     ) {}
+
+    public function getDescription(): ?string
+    {
+        $attributes = $this->reflection->getAttributes(Test::class);
+        if (\count($attributes) === 0) {
+            return null;
+        }
+
+        /** @var Test $testAttribute */
+        $testAttribute = $attributes[0]->newInstance();
+        return $testAttribute->description !== '' ? $testAttribute->description : null;
+    }
 }

--- a/src/Test/Definition/TestDefinition.php
+++ b/src/Test/Definition/TestDefinition.php
@@ -4,23 +4,9 @@ declare(strict_types=1);
 
 namespace Testo\Test\Definition;
 
-use Testo\Attribute\Test;
-
 final class TestDefinition
 {
     public function __construct(
         public readonly \ReflectionFunctionAbstract $reflection,
     ) {}
-
-    public function getDescription(): ?string
-    {
-        $attributes = $this->reflection->getAttributes(Test::class);
-        if (\count($attributes) === 0) {
-            return null;
-        }
-
-        /** @var Test $testAttribute */
-        $testAttribute = $attributes[0]->newInstance();
-        return $testAttribute->description !== '' ? $testAttribute->description : null;
-    }
 }

--- a/src/Test/Factory/CallableFactory.php
+++ b/src/Test/Factory/CallableFactory.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Test\Factory;
+
+use Testo\Test\TestCaseFactory;
+
+/**
+ * Factory that uses a custom callable for object creation.
+ *
+ * Provides maximum flexibility by delegating creation to a user-defined closure.
+ * This allows implementing custom creation logic such as:
+ * - Object pooling or caching
+ * - Conditional instantiation based on class attributes
+ * - Mock/stub injection for specific tests
+ * - Integration with custom DI systems
+ * - Lazy initialization patterns
+ * - Special constructor logic or factory methods
+ *
+ * The callable receives both the class reflection and constructor arguments,
+ * giving full control over the instantiation process.
+ *
+ * Example - Simple factory:
+ * ```php
+ * $factory = new CallableFactory(
+ *     fn(\ReflectionClass $class, array $args) => $class->newInstanceArgs($args)
+ * );
+ * ```
+ *
+ * Example - Conditional mock injection:
+ * ```php
+ * $factory = new CallableFactory(
+ *     function(\ReflectionClass $class, array $args) {
+ *         if ($class->implementsInterface(RequiresDatabaseInterface::class)) {
+ *             return new $class->name($mockDatabase, ...$args);
+ *         }
+ *         return $class->newInstanceArgs($args);
+ *     }
+ * );
+ * ```
+ *
+ * Example - Object pooling:
+ * ```php
+ * $pool = [];
+ * $factory = new CallableFactory(
+ *     function(\ReflectionClass $class, array $args) use (&$pool) {
+ *         $key = $class->getName();
+ *         return $pool[$key] ??= $class->newInstanceArgs($args);
+ *     }
+ * );
+ * ```
+ *
+ * Example - Integration with custom factory:
+ * ```php
+ * $customFactory = new TestCaseFactory();
+ * $factory = new CallableFactory(
+ *     fn(\ReflectionClass $class) => $customFactory->create($class->getName())
+ * );
+ * ```
+ *
+ * @template T of object
+ * @implements TestCaseFactory<T>
+ */
+final class CallableFactory implements TestCaseFactory
+{
+    /**
+     * @param \Closure(\ReflectionClass<T>, array<array-key, mixed>): T $callable
+     */
+    public function __construct(
+        private readonly \Closure $callable,
+    ) {}
+
+    #[\Override]
+    public function create(\ReflectionClass $class, array $args = []): object
+    {
+        return ($this->callable)($class, $args);
+    }
+}

--- a/src/Test/Factory/ContainerFactory.php
+++ b/src/Test/Factory/ContainerFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Test\Factory;
+
+use Psr\Container\ContainerInterface;
+use Testo\Test\TestCaseFactory;
+
+/**
+ * Factory that delegates object creation to a PSR-11 dependency injection container.
+ *
+ * Example:
+ * ```php
+ * // Setup container with test dependencies
+ * $container = new Container();
+ * $container->set(DatabaseConnection::class, $db);
+ * $container->set(UserRepository::class, fn() => new UserRepository($db));
+ *
+ * $factory = new ContainerFactory($container);
+ *
+ * // Test class constructor receives injected dependencies
+ * class UserTest {
+ *     public function __construct(
+ *         private UserRepository $users,
+ *         private DatabaseConnection $db
+ *     ) {}
+ * }
+ *
+ * $test = $factory->create(new \ReflectionClass(UserTest::class));
+ * // UserTest is created with injected UserRepository and DatabaseConnection
+ * ```
+ *
+ * @template T of object
+ * @implements TestCaseFactory<T>
+ */
+final class ContainerFactory implements TestCaseFactory
+{
+    /**
+     * @param ContainerInterface $container PSR-11 container for resolving dependencies
+     */
+    public function __construct(
+        private readonly ContainerInterface $container,
+    ) {}
+
+    /**
+     * @param \ReflectionClass<T> $class
+     * @param array<array-key, mixed> $args
+     *
+     * @return T
+     *
+     * @throws \Psr\Container\NotFoundExceptionInterface If the class is not found in the container
+     * @throws \Psr\Container\ContainerExceptionInterface If the container encounters an error during instantiation
+     */
+    #[\Override]
+    public function create(\ReflectionClass $class, array $args = []): object
+    {
+        return $this->container->get($class->getName());
+    }
+}

--- a/src/Test/Factory/ReflectionFactory.php
+++ b/src/Test/Factory/ReflectionFactory.php
@@ -46,7 +46,7 @@ final class ReflectionFactory implements TestCaseFactory
     public function create(\ReflectionClass $class, array $args = []): object
     {
         if ($class->hasMethod('__construct') && $class->getMethod('__construct')->isPublic()) {
-            return $class->newInstance($args);
+            return $class->newInstanceArgs($args);
         }
 
         return $class->newInstanceWithoutConstructor();

--- a/src/Test/Factory/ReflectionFactory.php
+++ b/src/Test/Factory/ReflectionFactory.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Test\Factory;
+
+use Testo\Test\TestCaseFactory;
+
+/**
+ * Basic factory using PHP reflection for object creation.
+ *
+ * Example:
+ * ```php
+ * $factory = new ReflectionFactory();
+ *
+ * // Simple class with no dependencies
+ * $test = $factory->create(new \ReflectionClass(SimpleTest::class));
+ *
+ * // Class with constructor parameters
+ * $test = $factory->create(
+ *     new \ReflectionClass(ParameterizedTest::class),
+ *     ['param1', 42]
+ * );
+ * ```
+ *
+ * @template T of object
+ * @implements TestCaseFactory<T>
+ */
+final class ReflectionFactory implements TestCaseFactory
+{
+    /**
+     * Creates an instance using reflection's newInstance method.
+     *
+     * @param \ReflectionClass<T> $class Reflection of the class to instantiate
+     * @param array<array-key, mixed> $args Constructor arguments in the order expected by the constructor
+     *
+     * @return T New instance of the class
+     *
+     * @throws \ReflectionException If the class cannot be instantiated:
+     *         - Class is abstract or an interface
+     *         - Constructor is not accessible
+     *         - Required constructor parameters are missing
+     *         - Constructor throws an exception
+     */
+    #[\Override]
+    public function create(\ReflectionClass $class, array $args = []): object
+    {
+        if ($class->hasMethod('__construct') && $class->getMethod('__construct')->isPublic()) {
+            return $class->newInstance($args);
+        }
+
+        return $class->newInstanceWithoutConstructor();
+    }
+}

--- a/src/Test/TestCaseFactory.php
+++ b/src/Test/TestCaseFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Test;
+
+/**
+ * Factory interface for creating test case class instances.
+ *
+ * Factories provide a flexible way to create test case instances, supporting
+ * different creation strategies such as reflection-based creation, dependency
+ * injection containers, or custom factory functions.
+ *
+ * Common use cases:
+ * - Simple creation via reflection ({@see Factory\ReflectionFactory})
+ * - DI container integration ({@see Factory\ContainerFactory})
+ * - Custom factory logic ({@see Factory\CallableFactory})
+ *
+ * Example usage:
+ * ```php
+ * $factory = new ReflectionFactory();
+ * $testCase = $factory->create(new \ReflectionClass(MyTest::class));
+ * ```
+ *
+ * @template T of object
+ */
+interface TestCaseFactory
+{
+    /**
+     * Creates an instance of the specified test case class.
+     *
+     * @param \ReflectionClass<T> $class Reflection of the class to create
+     * @param array<array-key, mixed> $args Optional constructor arguments (implementation-specific)
+     *
+     * @return T Instance of the requested class
+     */
+    public function create(\ReflectionClass $class, array $args = []): object;
+}

--- a/tests/Fixture/Factory/AbstractTestCase.php
+++ b/tests/Fixture/Factory/AbstractTestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixture\Factory;
+
+abstract class AbstractTestCase
+{
+    public function testSomething(): void {}
+}

--- a/tests/Fixture/Factory/Dependency.php
+++ b/tests/Fixture/Factory/Dependency.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixture\Factory;
+
+final class Dependency
+{
+    public function __construct(
+        public readonly string $status = 'initialized',
+    ) {}
+}

--- a/tests/Fixture/Factory/SimpleTestCase.php
+++ b/tests/Fixture/Factory/SimpleTestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixture\Factory;
+
+final class SimpleTestCase
+{
+    public string $status = 'created';
+}

--- a/tests/Fixture/Factory/TestCaseWithConstructor.php
+++ b/tests/Fixture/Factory/TestCaseWithConstructor.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixture\Factory;
+
+final class TestCaseWithConstructor
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly int $value,
+    ) {}
+}

--- a/tests/Fixture/Factory/TestCaseWithDependencies.php
+++ b/tests/Fixture/Factory/TestCaseWithDependencies.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixture\Factory;
+
+final class TestCaseWithDependencies
+{
+    public function __construct(
+        public readonly Dependency $dependency,
+    ) {}
+}

--- a/tests/Fixture/Factory/TestCaseWithPrivateConstructor.php
+++ b/tests/Fixture/Factory/TestCaseWithPrivateConstructor.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixture\Factory;
+
+final class TestCaseWithPrivateConstructor
+{
+    private function __construct()
+    {
+    }
+
+    public static function create(): self
+    {
+        return new self();
+    }
+}

--- a/tests/Testo/Factory/CallableFactoryTest.php
+++ b/tests/Testo/Factory/CallableFactoryTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Factory;
+
+use Testo\Assert;
+use Testo\Attribute\Test;
+use Testo\Test\Factory\CallableFactory;
+use Tests\Fixture\Factory\SimpleTestCase;
+
+final class CallableFactoryTest
+{
+    #[Test(description: 'Creates instance using custom callable.')]
+    public function itCreatesInstanceUsingCustomCallable(): void
+    {
+        $callable = fn(\ReflectionClass $class, array $args) => $class->newInstanceArgs($args);
+        $factory = new CallableFactory($callable);
+
+        $reflection = new \ReflectionClass(SimpleTestCase::class);
+        $instance = $factory->create($reflection);
+
+        Assert::object($instance)->instanceOf(SimpleTestCase::class);
+    }
+}

--- a/tests/Testo/Factory/ContainerFactoryTest.php
+++ b/tests/Testo/Factory/ContainerFactoryTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Factory;
+
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Testo\Assert;
+use Testo\Attribute\Test;
+use Testo\Expect;
+use Testo\Test\Factory\ContainerFactory;
+use Tests\Fixture\Factory\Dependency;
+use Tests\Fixture\Factory\SimpleTestCase;
+use Tests\Fixture\Factory\TestCaseWithDependencies;
+
+final class ContainerFactoryTest
+{
+    #[Test(description: 'Creates instance using PSR-11 container.')]
+    public function itCreatesInstanceUsingContainer(): void
+    {
+        $instance = new SimpleTestCase();
+        $container = new class($instance) implements ContainerInterface {
+            public function __construct(private readonly object $instance) {}
+
+            public function get(string $id): object
+            {
+                if ($id === SimpleTestCase::class) {
+                    return $this->instance;
+                }
+                throw new class extends \Exception implements NotFoundExceptionInterface {};
+            }
+
+            public function has(string $id): bool
+            {
+                return $id === SimpleTestCase::class;
+            }
+        };
+
+        $factory = new ContainerFactory($container);
+        $reflection = new \ReflectionClass(SimpleTestCase::class);
+        $result = $factory->create($reflection);
+
+        Assert::same($instance, $result);
+    }
+
+    #[Test(description: 'Creates instance with dependencies resolved from container.')]
+    public function itResolvesDependenciesFromContainer(): void
+    {
+        $dependency = new Dependency();
+        $testCase = new TestCaseWithDependencies($dependency);
+
+        $container = new class($dependency, $testCase) implements ContainerInterface {
+            public function __construct(
+                private readonly Dependency $dependency,
+                private readonly TestCaseWithDependencies $testCase,
+            ) {}
+
+            public function get(string $id): object
+            {
+                return match ($id) {
+                    Dependency::class => $this->dependency,
+                    TestCaseWithDependencies::class => $this->testCase,
+                    default => throw new class extends \Exception implements NotFoundExceptionInterface {},
+                };
+            }
+
+            public function has(string $id): bool
+            {
+                return in_array($id, [Dependency::class, TestCaseWithDependencies::class], true);
+            }
+        };
+
+        $factory = new ContainerFactory($container);
+        $reflection = new \ReflectionClass(TestCaseWithDependencies::class);
+        $result = $factory->create($reflection);
+
+        Assert::same($testCase, $result);
+        Assert::same($dependency, $result->dependency);
+    }
+
+    #[Test(description: 'Throws not found exception when class not in container.')]
+    public function itThrowsNotFoundExceptionWhenClassNotInContainer(): void
+    {
+        $container = new class implements ContainerInterface {
+            public function get(string $id): object
+            {
+                throw new class extends \Exception implements NotFoundExceptionInterface {};
+            }
+
+            public function has(string $id): bool
+            {
+                return false;
+            }
+        };
+
+        $factory = new ContainerFactory($container);
+        $reflection = new \ReflectionClass(SimpleTestCase::class);
+
+        Expect::exception(NotFoundExceptionInterface::class);
+        $factory->create($reflection);
+    }
+
+    #[Test(description: 'Throws container exception when container encounters error.')]
+    public function itThrowsContainerExceptionWhenContainerEncountersError(): void
+    {
+        $container = new class implements ContainerInterface {
+            public function get(string $id): object
+            {
+                throw new class extends \Exception implements \Psr\Container\ContainerExceptionInterface {};
+            }
+
+            public function has(string $id): bool
+            {
+                return true;
+            }
+        };
+
+        $factory = new ContainerFactory($container);
+        $reflection = new \ReflectionClass(SimpleTestCase::class);
+
+        Expect::exception(\Psr\Container\ContainerExceptionInterface::class);
+        $factory->create($reflection);
+    }
+
+    #[Test(description: 'Ignores constructor arguments as container resolves dependencies.')]
+    public function itIgnoresConstructorArguments(): void
+    {
+        $instance = new SimpleTestCase();
+        $container = new class($instance) implements ContainerInterface {
+            public function __construct(private readonly object $instance) {}
+
+            public function get(string $id): object
+            {
+                return $this->instance;
+            }
+
+            public function has(string $id): bool
+            {
+                return true;
+            }
+        };
+
+        $factory = new ContainerFactory($container);
+        $reflection = new \ReflectionClass(SimpleTestCase::class);
+        $result = $factory->create($reflection, ['ignored', 'args']);
+
+        Assert::same($instance, $result);
+    }
+}

--- a/tests/Testo/Factory/ReflectionFactoryTest.php
+++ b/tests/Testo/Factory/ReflectionFactoryTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Factory;
+
+use Testo\Assert;
+use Testo\Attribute\Test;
+use Testo\Expect;
+use Testo\Test\Factory\ReflectionFactory;
+use Tests\Fixture\Factory\AbstractTestCase;
+use Tests\Fixture\Factory\SimpleTestCase;
+use Tests\Fixture\Factory\TestCaseWithConstructor;
+use Tests\Fixture\Factory\TestCaseWithPrivateConstructor;
+
+final class ReflectionFactoryTest
+{
+    private ReflectionFactory $factory;
+
+    public function __construct()
+    {
+        $this->factory = new ReflectionFactory();
+    }
+
+    #[Test(description: 'Creates instance of simple class without constructor.')]
+    public function itCreatesInstanceWithoutConstructor(): void
+    {
+        $reflection = new \ReflectionClass(SimpleTestCase::class);
+        $instance = $this->factory->create($reflection);
+
+        Assert::object($instance)->instanceOf(SimpleTestCase::class);
+        Assert::same('created', $instance->status);
+    }
+
+    #[Test(description: 'Creates instance with constructor arguments.')]
+    public function itCreatesInstanceWithConstructorArguments(): void
+    {
+        $reflection = new \ReflectionClass(TestCaseWithConstructor::class);
+        $instance = $this->factory->create($reflection, ['test', 42]);
+
+        Assert::object($instance)->instanceOf(TestCaseWithConstructor::class);
+        Assert::same('test', $instance->name);
+        Assert::same(42, $instance->value);
+    }
+
+    #[Test(description: 'Creates instance without calling constructor when constructor is private.')]
+    public function itCreatesInstanceWithoutCallingConstructorWhenConstructorIsPrivate(): void
+    {
+        $reflection = new \ReflectionClass(TestCaseWithPrivateConstructor::class);
+        $instance = $this->factory->create($reflection);
+
+        Assert::object($instance)->instanceOf(TestCaseWithPrivateConstructor::class);
+    }
+
+    #[Test(description: 'Throws exception when trying to instantiate abstract class.')]
+    public function itThrowsExceptionWhenInstantiatingAbstractClass(): void
+    {
+        $reflection = new \ReflectionClass(AbstractTestCase::class);
+
+        Expect::exception(\Error::class);
+        $this->factory->create($reflection);
+    }
+}

--- a/tests/Testo/Interceptor/InstantiateTestCaseTest.php
+++ b/tests/Testo/Interceptor/InstantiateTestCaseTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Interceptor;
+
+use Testo\Assert;
+use Testo\Attribute\Test;
+use Testo\Expect;
+use Testo\Interceptor\Exception\TestCaseInstantiationException;
+use Testo\Interceptor\TestCaseCallInterceptor\InstantiateTestCase;
+use Testo\Test\Definition\CaseDefinition;
+use Testo\Test\Dto\CaseInfo;
+use Testo\Test\Dto\CaseResult;
+use Testo\Test\Dto\Status;
+use Testo\Test\Factory\ReflectionFactory;
+use Testo\Test\TestCaseFactory;
+use Tests\Fixture\Factory\AbstractTestCase;
+use Tests\Fixture\Factory\SimpleTestCase;
+use Tests\Fixture\Factory\TestCaseWithPrivateConstructor;
+
+final class InstantiateTestCaseTest
+{
+    #[Test(description: 'Instantiates test case when instance is null and reflection exists.')]
+    public function itInstantiatesTestCaseWhenInstanceIsNull(): void
+    {
+        $interceptor = new InstantiateTestCase(new ReflectionFactory());
+        $definition = new CaseDefinition(
+            name: 'SimpleTestCase',
+            reflection: new \ReflectionClass(SimpleTestCase::class),
+        );
+        $info = new CaseInfo($definition, instance: null);
+
+        $nextCalled = false;
+        $receivedInfo = null;
+
+        $next = function (CaseInfo $i) use (&$nextCalled, &$receivedInfo) {
+            $nextCalled = true;
+            $receivedInfo = $i;
+            return new CaseResult(
+                results: [],
+                status: Status::Passed,
+            );
+        };
+
+        $result = $interceptor->runTestCase($info, $next);
+
+        Assert::true($nextCalled);
+        Assert::instanceOf(SimpleTestCase::class, $receivedInfo->instance);
+        Assert::same(Status::Passed, $result->status);
+    }
+
+    #[Test(description: 'Skips instantiation when instance is already set.')]
+    public function itSkipsInstantiationWhenInstanceIsAlreadySet(): void
+    {
+        $interceptor = new InstantiateTestCase(new ReflectionFactory());
+        $existingInstance = new SimpleTestCase();
+        $definition = new CaseDefinition(
+            name: 'SimpleTestCase',
+            reflection: new \ReflectionClass(SimpleTestCase::class),
+        );
+        $info = new CaseInfo($definition, instance: $existingInstance);
+
+        $receivedInstance = null;
+        $next = function (CaseInfo $i) use (&$receivedInstance) {
+            $receivedInstance = $i->instance;
+            return new CaseResult(
+                results: [],
+                status: Status::Passed,
+            );
+        };
+
+        $interceptor->runTestCase($info, $next);
+
+        Assert::same($existingInstance, $receivedInstance);
+    }
+
+    #[Test(description: 'Skips instantiation when reflection is null.')]
+    public function itSkipsInstantiationWhenReflectionIsNull(): void
+    {
+        $interceptor = new InstantiateTestCase(new ReflectionFactory());
+        $definition = new CaseDefinition(
+            name: 'anonymous',
+            reflection: null,
+        );
+        $info = new CaseInfo($definition, instance: null);
+
+        $receivedInstance = null;
+        $next = function (CaseInfo $i) use (&$receivedInstance) {
+            $receivedInstance = $i->instance;
+            return new CaseResult(
+                results: [],
+                status: Status::Passed,
+            );
+        };
+
+        $interceptor->runTestCase($info, $next);
+
+        Assert::null($receivedInstance);
+    }
+
+    #[Test(description: 'Wraps factory exceptions in TestCaseInstantiationException.')]
+    public function itWrapsFactoryExceptionInTestCaseInstantiationException(): void
+    {
+        $factory = new class implements TestCaseFactory {
+            public function create(\ReflectionClass $class, array $args = []): object
+            {
+                throw new \RuntimeException('Factory error');
+            }
+        };
+
+        $interceptor = new InstantiateTestCase($factory);
+        $definition = new CaseDefinition(
+            name: 'SimpleTestCase',
+            reflection: new \ReflectionClass(SimpleTestCase::class),
+        );
+        $info = new CaseInfo($definition, instance: null);
+
+        $next = fn() => new CaseResult(
+            results: [],
+            status: Status::Passed,
+        );
+
+        Expect::exception(TestCaseInstantiationException::class);
+
+        $interceptor->runTestCase($info, $next);
+    }
+
+    #[Test(description: 'Preserves previous exception when wrapping in TestCaseInstantiationException.')]
+    public function itPreservesPreviousException(): void
+    {
+        $originalException = new \InvalidArgumentException('Invalid argument');
+
+        $factory = new class($originalException) implements TestCaseFactory {
+            public function __construct(private readonly \Throwable $exception) {}
+
+            public function create(\ReflectionClass $class, array $args = []): object
+            {
+                throw $this->exception;
+            }
+        };
+
+        $interceptor = new InstantiateTestCase($factory);
+        $definition = new CaseDefinition(
+            name: 'SimpleTestCase',
+            reflection: new \ReflectionClass(SimpleTestCase::class),
+        );
+        $info = new CaseInfo($definition, instance: null);
+
+        $next = fn() => new CaseResult(
+            results: [],
+            status: Status::Passed,
+        );
+
+        $caught = false;
+        $previous = null;
+
+        try {
+            $interceptor->runTestCase($info, $next);
+        } catch (TestCaseInstantiationException $e) {
+            $caught = true;
+            $previous = $e->getPrevious();
+        }
+
+        Assert::true($caught);
+        Assert::instanceOf(\InvalidArgumentException::class, $previous);
+        Assert::same('Invalid argument', $previous->getMessage());
+    }
+
+    #[Test(description: 'Throws exception when trying to instantiate abstract class.')]
+    public function itThrowsExceptionWhenInstantiatingAbstractClass(): void
+    {
+        $interceptor = new InstantiateTestCase(new ReflectionFactory());
+        $definition = new CaseDefinition(
+            name: 'AbstractTestCase',
+            reflection: new \ReflectionClass(AbstractTestCase::class),
+        );
+        $info = new CaseInfo($definition, instance: null);
+
+        $next = fn() => new CaseResult(
+            results: [],
+            status: Status::Passed,
+        );
+
+        Expect::exception(TestCaseInstantiationException::class);
+        $interceptor->runTestCase($info, $next);
+    }
+
+    #[Test(description: 'Instantiates class with private constructor using newInstanceWithoutConstructor.')]
+    public function itInstantiatesClassWithPrivateConstructorWithoutCallingConstructor(): void
+    {
+        $interceptor = new InstantiateTestCase(new ReflectionFactory());
+        $definition = new CaseDefinition(
+            name: 'TestCaseWithPrivateConstructor',
+            reflection: new \ReflectionClass(TestCaseWithPrivateConstructor::class),
+        );
+        $info = new CaseInfo($definition, instance: null);
+
+        $next = function (CaseInfo $i) {
+            Assert::object($i->instance)->instanceOf(TestCaseWithPrivateConstructor::class);
+            return new CaseResult(
+                results: [],
+                status: Status::Passed,
+            );
+        };
+
+        $interceptor->runTestCase($info, $next);
+    }
+
+    #[Test(description: 'Creates new CaseInfo with instance via withInstance method.')]
+    public function itCreatesNewCaseInfoWithInstance(): void
+    {
+        $interceptor = new InstantiateTestCase(new ReflectionFactory());
+        $definition = new CaseDefinition(
+            name: 'SimpleTestCase',
+            reflection: new \ReflectionClass(SimpleTestCase::class),
+        );
+        $originalInfo = new CaseInfo($definition, instance: null);
+
+        $next = function (CaseInfo $i) use ($originalInfo) {
+            Assert::notSame($originalInfo, $i, 'CaseInfo should be a new instance');
+            Assert::object($i->instance)->instanceOf(SimpleTestCase::class);
+            return new CaseResult(
+                results: [],
+                status: Status::Passed,
+            );
+        };
+
+        $interceptor->runTestCase($originalInfo, $next);
+    }
+}


### PR DESCRIPTION
This PR introduces the **TestCaseFactory**, providing developers with complete control over how test case instances are created. Previously, test classes were instantiated using basic reflection, limiting support for dependency injection and complex initialization scenarios.

### What's New

**Three Implementation Strategies:**
1. **ReflectionFactory** (default) - Simple reflection-based instantiation
2. **ContainerFactory** - PSR-11 container integration for dependency injection
3. **CallableFactory** - Custom factory logic via user-defined closures

---

## 💡 Motivation

### Problem
Test classes with constructor dependencies couldn't be instantiated:

```php
final class UserRepositoryTest 
{
    // ❌ This previously failed - no way to inject dependencies
    public function __construct(
        private DatabaseConnection $db,
        private UserRepository $repository,
    ) {}
}
```

### Solution
Now developers can configure a custom factory:

```php
// Example 1: Using PSR-11 Container
$container = new Container();
$container->set(DatabaseConnection::class, $dbConnection);

$app = Application::createFromConfig(
    config: $config,
    testCaseFactory: new ContainerFactory($container)
);

// Example 2: Custom Factory Logic
$app = Application::createFromConfig(
    config: $config,
    testCaseFactory: new CallableFactory(
        fn(\ReflectionClass $class) => $myFactory->create($class->getName())
    )
);
```