### PR TITLE
Add `DataZip` and `DataCross`

### DIFF
--- a/src/Common/Reflection.php
+++ b/src/Common/Reflection.php
@@ -201,7 +201,7 @@ final class Reflection
                 $reflection = match (true) {
                     isset($frame['class'], $frame['function']) => new \ReflectionMethod(
                         $frame['class'],
-                        $frame['function']
+                        $frame['function'],
                     ),
                     isset($frame['function']) => new \ReflectionFunction($frame['function']),
                     default => null,

--- a/src/Data/DataCross.php
+++ b/src/Data/DataCross.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Data;
+
+use Testo\Data\Internal\DataProviderAttribute;
+use Testo\Data\Internal\DataProviderInterceptor;
+use Testo\Pipeline\Attribute\FallbackInterceptor;
+use Testo\Pipeline\Attribute\Interceptable;
+
+/**
+ * Crosses multiple data providers together.
+ *
+ * Each data set will contain one value from each provider, combined into an array.
+ * All possible combinations of values from the providers will be generated.
+ *
+ * @api
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION | \Attribute::IS_REPEATABLE)]
+#[FallbackInterceptor(DataProviderInterceptor::class)]
+final class DataCross implements Interceptable, DataProviderAttribute
+{
+    /**
+     * @param array<DataProviderAttribute> $providers Data providers to cross together.
+     */
+    public readonly array $providers;
+
+    public function __construct(DataProviderAttribute ...$providers)
+    {
+        $this->providers = $providers;
+    }
+}

--- a/src/Data/DataZip.php
+++ b/src/Data/DataZip.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Data;
+
+use Testo\Data\Internal\DataProviderAttribute;
+use Testo\Data\Internal\DataProviderInterceptor;
+use Testo\Pipeline\Attribute\FallbackInterceptor;
+use Testo\Pipeline\Attribute\Interceptable;
+
+/**
+ * Zips multiple data providers together.
+ *
+ * Each data set will contain one value from each provider, combined into an array.
+ * If the providers have different lengths, `null` will be used for missing values.
+ *
+ * @api
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION | \Attribute::IS_REPEATABLE)]
+#[FallbackInterceptor(DataProviderInterceptor::class)]
+final class DataZip implements Interceptable, DataProviderAttribute
+{
+    /**
+     * @param array<DataProvider> $providers Data providers to zip together.
+     */
+    public readonly array $providers;
+
+    public function __construct(DataProvider ...$providers)
+    {
+        $this->providers = $providers;
+    }
+}

--- a/src/Data/Internal/DataProviderInterceptor.php
+++ b/src/Data/Internal/DataProviderInterceptor.php
@@ -9,6 +9,7 @@ use Testo\Core\Context\TestInfo;
 use Testo\Core\Context\TestResult;
 use Testo\Core\Filter\DataPointer;
 use Testo\Core\Value\Status;
+use Testo\Data\DataCross;
 use Testo\Data\DataProvider;
 use Testo\Data\DataSet;
 use Testo\Data\DataZip;
@@ -27,10 +28,15 @@ use Testo\Pipeline\Policy\ConflictPolicy;
 #[InterceptorOptions(order: InterceptorOptions::ORDER_DATA_PROVIDER, onConflict: ConflictPolicy::First)]
 final class DataProviderInterceptor implements TestRunInterceptor
 {
+    /** Key separator for DataZip (parallel combination). */
+    private const KEY_SEPARATOR_ZIP = '|';
+
+    /** Key separator for DataCross (cartesian product). */
+    private const KEY_SEPARATOR_CROSS = '×';
+
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
-    ) {
-    }
+    ) {}
 
     #[\Override]
     public function runTest(TestInfo $info, callable $next): TestResult
@@ -57,12 +63,7 @@ final class DataProviderInterceptor implements TestRunInterceptor
 
                 $attr = $attribute->newInstance();
 
-                $datasets = match (true) {
-                    $attr instanceof DataProvider => self::fromDataProvider($info, $attr),
-                    $attr instanceof DataSet => [($attr->name ?? 0) => $attr->arguments],
-                    $attr instanceof DataZip => self::fromDataZip($info, $attr),
-                    default => throw new \RuntimeException('Unknown Data Provider Attribute type.'),
-                };
+                $datasets = self::extractDataSets($info, $attr);
 
                 # Handle each data set
                 $results = [];
@@ -163,6 +164,17 @@ final class DataProviderInterceptor implements TestRunInterceptor
         return $result;
     }
 
+    private static function extractDataSets(TestInfo $info, object $attr): iterable
+    {
+        return match (true) {
+            $attr instanceof DataProvider => self::fromDataProvider($info, $attr),
+            $attr instanceof DataSet => [($attr->name ?? 0) => $attr->arguments],
+            $attr instanceof DataCross => self::fromDataCross($info, $attr),
+            $attr instanceof DataZip => self::fromDataZip($info, $attr),
+            default => throw new \RuntimeException('Unknown Data Provider Attribute type.'),
+        };
+    }
+
     /**
      * Extract data sets from a DataProvider attribute.
      */
@@ -232,7 +244,61 @@ final class DataProviderInterceptor implements TestRunInterceptor
             return;
         }
 
-        yield \implode(':', $key) => \array_merge(...$dataSet);
+        yield \implode(self::KEY_SEPARATOR_ZIP, $key) => \array_merge(...$dataSet);
         goto dataset;
+    }
+
+    /**
+     * Extract data sets from a DataCross attribute (cartesian product).
+     */
+    private static function fromDataCross(TestInfo $info, DataCross $attr): iterable
+    {
+        // Collect all datasets from each provider into arrays
+        $allDatasets = [];
+        foreach ($attr->providers as $providerAttr) {
+            $datasets = [];
+            foreach (self::extractDataSets($info, $providerAttr) as $key => $dataset) {
+                $datasets[$key] = $dataset;
+            }
+            if ($datasets === []) {
+                return; // If any provider is empty, no combinations possible
+            }
+            $allDatasets[] = $datasets;
+        }
+
+        if ($allDatasets === []) {
+            return;
+        }
+
+        yield from self::cartesianProduct($allDatasets);
+    }
+
+    /**
+     * Generate the cartesian product of multiple arrays of datasets.
+     *
+     * @param list<array<array-key, array>> $arrays Arrays of datasets from each provider.
+     * @param int<0, max> $index Current provider index.
+     * @param list<array> $currentData Accumulated dataset arguments.
+     * @param list<string> $currentKeys Accumulated dataset keys.
+     */
+    private static function cartesianProduct(
+        array $arrays,
+        int $index = 0,
+        array $currentData = [],
+        array $currentKeys = [],
+    ): iterable {
+        if ($index === \count($arrays)) {
+            yield \implode(self::KEY_SEPARATOR_CROSS, $currentKeys) => \array_merge(...$currentData);
+            return;
+        }
+
+        foreach ($arrays[$index] as $key => $dataset) {
+            yield from self::cartesianProduct(
+                $arrays,
+                $index + 1,
+                [...$currentData, $dataset],
+                [...$currentKeys, (string) $key],
+            );
+        }
     }
 }

--- a/src/Data/Internal/DataProviderInterceptor.php
+++ b/src/Data/Internal/DataProviderInterceptor.php
@@ -11,6 +11,7 @@ use Testo\Core\Filter\DataPointer;
 use Testo\Core\Value\Status;
 use Testo\Data\DataProvider;
 use Testo\Data\DataSet;
+use Testo\Data\DataZip;
 use Testo\Data\MultipleResult;
 use Testo\Event\Test\TestBatchFinished;
 use Testo\Event\Test\TestBatchStarting;
@@ -28,7 +29,8 @@ final class DataProviderInterceptor implements TestRunInterceptor
 {
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
-    ) {}
+    ) {
+    }
 
     #[\Override]
     public function runTest(TestInfo $info, callable $next): TestResult
@@ -58,6 +60,7 @@ final class DataProviderInterceptor implements TestRunInterceptor
                 $datasets = match (true) {
                     $attr instanceof DataProvider => self::fromDataProvider($info, $attr),
                     $attr instanceof DataSet => [($attr->name ?? 0) => $attr->arguments],
+                    $attr instanceof DataZip => self::fromDataZip($info, $attr),
                     default => throw new \RuntimeException('Unknown Data Provider Attribute type.'),
                 };
 
@@ -177,7 +180,7 @@ final class DataProviderInterceptor implements TestRunInterceptor
                 $m = $class->getMethod($provider);
                 $provider = match (true) {
                     $m->isStatic() => $m->getClosure(null),
-                    default => static fn() => $m->getClosure($info->caseInfo->instance->getInstance()),
+                    default => static fn () => $m->getClosure($info->caseInfo->instance->getInstance()),
                 };
             }
 
@@ -193,5 +196,43 @@ final class DataProviderInterceptor implements TestRunInterceptor
         );
 
         return $datasets;
+    }
+
+    /**
+     * Extract data sets from a DataZip attribute.
+     */
+    private static function fromDataZip(TestInfo $info, DataZip $attr): iterable
+    {
+        $generators = \array_map(
+            static fn ($providerAttr): DeferredGenerator => DeferredGenerator::fromHandler(
+                static function () use ($info, $providerAttr) {
+                    yield from self::fromDataProvider($info, $providerAttr);
+                },
+            ),
+            $attr->providers,
+        );
+
+        dataset:
+        $allFinished = true;
+        $dataSet = [];
+        $key = [];
+        foreach ($generators as $gen) {
+            if ($gen->valid()) {
+                $allFinished = false;
+                $dataSet[] = $gen->current();
+                $key[] = $gen->key();
+                $gen->next();
+            } else {
+                $key[] = '';
+                $dataSet[] = null;
+            }
+        }
+
+        if ($allFinished) {
+            return;
+        }
+
+        yield \implode(':', $key) => \array_merge(...$dataSet);
+        goto dataset;
     }
 }

--- a/src/Data/Internal/DeferredGenerator.php
+++ b/src/Data/Internal/DeferredGenerator.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Data\Internal;
+
+/**
+ * A wrapper around a generator that doesn't start the wrapped generator ASAP.
+ *
+ * @implements \Iterator<mixed, mixed>
+ */
+final class DeferredGenerator implements \Iterator
+{
+    private bool $started = false;
+    private bool $finished = false;
+    private \Generator $generator;
+    private \Closure $handler;
+
+    private function __construct() {}
+
+    /**
+     * @param \Closure(): mixed $handler
+     */
+    public static function fromHandler(\Closure $handler): self
+    {
+        $self = new self();
+        $self->handler = $handler;
+        return $self;
+    }
+
+    /**
+     * Throw an exception into the generator.
+     *
+     * @note doesn't throw generator's exceptions; use {@see catch()} to handle them.
+     */
+    public function throw(\Throwable $exception): void
+    {
+        $this->started or throw new \LogicException('Cannot throw exception into a generator that was not started.');
+        $this->finished and throw new \LogicException(
+            'Cannot throw exception into a generator that was already finished.',
+        );
+        $this->generator->throw($exception);
+    }
+
+    /**
+     * Send a value to the generator.
+     *
+     * @note doesn't throw generator's exceptions; use {@see catch()} to handle them.
+     */
+    public function send(mixed $value): mixed
+    {
+        $this->start();
+        $this->finished and throw new \LogicException('Cannot send value to a generator that was already finished.');
+        return $this->generator->send($value);
+    }
+
+    /**
+     * Get the return value of the generator if it was finished.
+     */
+    public function getReturn(): mixed
+    {
+        $this->finished or throw new \LogicException('Cannot get return value of a generator that was not finished.');
+        return $this->generator->getReturn();
+    }
+
+    /**
+     * Get the current value of the generator.
+     */
+    public function current(): mixed
+    {
+        $this->start();
+        return $this->generator->current();
+    }
+
+    /**
+     * Get the current key of the generator.
+     */
+    public function key(): mixed
+    {
+        $this->start();
+        return $this->generator->key();
+    }
+
+    /**
+     * Start or resume the generator.
+     */
+    public function next(): void
+    {
+        if (!$this->started || $this->finished) {
+            $this->finished or $this->start();
+            return;
+        }
+
+        $this->generator->next();
+    }
+
+    /**
+     * Check if the generator is not finished.
+     *
+     * @note It starts the Generator.
+     */
+    public function valid(): bool
+    {
+        $this->start();
+        $result = $this->generator->valid() or $this->finished = true;
+        return $result;
+    }
+
+    public function rewind(): void
+    {
+        $this->generator->rewind();
+    }
+
+    private static function getDummyGenerator(): \Generator
+    {
+        static $generator;
+
+        if ($generator === null) {
+            $generator = (static function (): \Generator {
+                yield;
+            })();
+            $generator->current();
+        }
+
+        return $generator;
+    }
+
+    private function start(): void
+    {
+        if ($this->started) {
+            return;
+        }
+
+        $this->started = true;
+        try {
+            $result = ($this->handler)();
+
+            if ($result instanceof \Generator) {
+                $this->generator = $result;
+                return;
+            }
+
+            /** @psalm-suppress all */
+            $this->generator = (static function (mixed $result): \Generator {
+                return $result;
+                yield;
+            })($result);
+            $this->finished = true;
+        } catch (\Throwable $e) {
+            $this->generator = self::getDummyGenerator();
+            throw $e;
+        } finally {
+            unset($this->handler, $this->values);
+        }
+    }
+}

--- a/src/Pipeline/InterceptorProvider.php
+++ b/src/Pipeline/InterceptorProvider.php
@@ -19,7 +19,6 @@ use Testo\Pipeline\Attribute\Interceptable;
 use Testo\Pipeline\Internal\InterceptorMarker;
 use Yiisoft\Injector\Injector;
 
-
 final class InterceptorProvider
 {
     /**

--- a/testo.php
+++ b/testo.php
@@ -19,6 +19,6 @@ return new ApplicationConfig(
         require 'tests/Assert/suites.php',
         require 'tests/Common/suites.php',
         require 'tests/Lifecycle/suites.php',
-        require 'tests/Sample/suites.php',
+        require 'tests/Data/suites.php',
     ),
 );

--- a/tests/Data/Self/DataCross.php
+++ b/tests/Data/Self/DataCross.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Data\Self;
+
+use Testo\Application\Attribute\Test;
+use Testo\Assert;
+use Testo\Data\DataProvider;
+use Testo\Data\DataSet;
+
+final class DataCross
+{
+    public static function numbersProvider(): array
+    {
+        return [
+            [1, 2],
+            [3, 4],
+        ];
+    }
+
+    public static function lettersProvider(): iterable
+    {
+        yield 'ab' => ['a', 'b'];
+        yield 'cd' => ['c', 'd'];
+        yield 'ef' => ['e', 'f'];
+    }
+
+    #[Test]
+    #[\Testo\Data\DataCross(
+        new DataProvider('numbersProvider'),
+        new DataProvider('lettersProvider'),
+    )]
+    public function crossProduct(int $a, int $b, string $c, string $d): void
+    {
+        // 2 number sets × 3 letter sets = 6 combinations
+        Assert::true(\in_array([$a, $b, $c, $d], [
+            [1, 2, 'a', 'b'],
+            [1, 2, 'c', 'd'],
+            [1, 2, 'e', 'f'],
+            [3, 4, 'a', 'b'],
+            [3, 4, 'c', 'd'],
+            [3, 4, 'e', 'f'],
+        ], true));
+    }
+
+    #[Test]
+    #[\Testo\Data\DataCross(
+        new DataSet([true], 'yes'),
+        new DataProvider('lettersProvider'),
+        new DataSet([42], 'answer'),
+    )]
+    public function mixedProviders(bool $flag, string $c, string $d, int $number): void
+    {
+        // 1 DataSet × 3 letters × 1 DataSet = 3 combinations
+        Assert::true($flag);
+        Assert::same(42, $number);
+        Assert::true(\in_array([$c, $d], [
+            ['a', 'b'],
+            ['c', 'd'],
+            ['e', 'f'],
+        ], true));
+    }
+}

--- a/tests/Data/Self/DataProviders.php
+++ b/tests/Data/Self/DataProviders.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sample\Self;
+namespace Tests\Data\Self;
 
 use Testo\Application\Attribute\Test;
 use Testo\Data\DataProvider;

--- a/tests/Data/Self/DataProviders.php
+++ b/tests/Data/Self/DataProviders.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Data\Self;
 
 use Testo\Application\Attribute\Test;
+use Testo\Assert;
 use Testo\Data\DataProvider;
 use Testo\Data\DataSet;
 
@@ -24,9 +25,17 @@ final class DataProviders
     #[DataProvider('bigNumbersProvider')]
     #[DataSet([7, 8], 'seven-eight')]
     #[DataSet(['b' => 7, 'a' => 8])]
-    public function sum(int $a, int $b): int
+    public function sum(int $a, int $b): void
     {
-        return $a + $b;
+        Assert::true(\in_array([$a, $b], [
+            [1, 2],
+            [3, 4],
+            [5, 6],
+            [100, 200],
+            [300, 400],
+            [500, 600],
+            [7, 8],
+        ], true) || ($a === 8 && $b === 7), 'Invalid data set provided.');
     }
 
     private static function bigNumbersProvider(): array

--- a/tests/Data/Self/DataZip.php
+++ b/tests/Data/Self/DataZip.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Data\Self;
+
+use Testo\Application\Attribute\Test;
+use Testo\Assert;
+use Testo\Data\DataProvider;
+
+final class DataZip
+{
+    public static function numbersProvider(): array
+    {
+        return [
+            [1, 2],
+            [3, 4],
+            [5, 6],
+        ];
+    }
+
+    public static function lettersProvider(): iterable
+    {
+        yield 'ab' => ['a', 'b'];
+        yield 'cd' => ['c', 'd'];
+        yield 'ef' => ['e', 'f'];
+    }
+
+    #[Test]
+    #[\Testo\Data\DataZip(
+        new DataProvider('numbersProvider'),
+        new DataProvider('lettersProvider'),
+    )]
+    public function sum(int $a, int $b, string $c, string $d): void
+    {
+        Assert::true(\in_array([$a, $b, $c, $d], [
+            [1, 2, 'a', 'b'],
+            [3, 4, 'c', 'd'],
+            [5, 6, 'e', 'f'],
+        ], true));
+    }
+}

--- a/tests/Data/Self/TestInlineAttribute.php
+++ b/tests/Data/Self/TestInlineAttribute.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sample\Self;
+namespace Tests\Data\Self;
 
 use Testo\Inline\TestInline;
 use Webmozart\Assert\Assert;

--- a/tests/Data/suites.php
+++ b/tests/Data/suites.php
@@ -6,11 +6,11 @@ use Testo\Application\Config\FinderConfig;
 use Testo\Application\Config\SuiteConfig;
 
 /**
- * Test suites for Sample component.
+ * Test suites for Data component.
  */
 return [
     new SuiteConfig(
-        name: 'Sample: Self Testing',
+        name: 'Data: Self Testing',
         location: new FinderConfig(
             include: [__DIR__ . '/Self'],
         ),


### PR DESCRIPTION
<!-- Thanks for opening a PR! -->

## What was changed

- Add `#[DataZip]` attribute for parallel combination of multiple data providers
- Add `#[DataCross]` attribute for cartesian product of multiple data providers
- Both attributes support nesting with `DataProvider`, `DataSet`, and each other

### New Attributes

#### DataZip

Combines data providers in parallel (like Python's `zip`). Each iteration takes one element from each provider:

```php
#[DataZip(
    new DataProvider('users'),    // [['Alice'], ['Bob']]
    new DataProvider('roles'),    // [['admin'], ['guest']]
)]
public function testUserRole(string $user, string $role): void
{
    // Runs 2 times: ('Alice', 'admin'), ('Bob', 'guest')
}
```

Key separator: `|` (e.g., `alice|admin`)

#### DataCross

Generates cartesian product of all data providers (all possible combinations):

```php
#[DataCross(
    new DataProvider('users'),    // [['Alice'], ['Bob']]
    new DataProvider('roles'),    // [['admin'], ['guest']]
)]
public function testUserRole(string $user, string $role): void
{
    // Runs 4 times: ('Alice', 'admin'), ('Alice', 'guest'),
    //               ('Bob', 'admin'), ('Bob', 'guest')
}
```

Key separator: `×` (e.g., `alice×admin`)

#### Mixed Usage

Both attributes support mixing different provider types:

```php
#[DataCross(
    new DataSet([true], 'enabled'),
    new DataProvider('environments'),
    new DataSet(['v2'], 'api'),
)]
public function testFeature(bool $flag, string $env, string $version): void
```


## Checklist

- Closes #69
- Tested
  - [x] Tested manually
  - [x] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->
