### PR TITLE
feat(Codecov): Add Codecov plugin

### DIFF
--- a/internal/container/src/Container.php
+++ b/internal/container/src/Container.php
@@ -60,8 +60,10 @@ interface Container extends Destroyable, ContainerInterface
      * @template T
      * @param T $service Service instance to register
      * @param class-string<T>|null $id Optional service identifier (defaults to object's class)
+     * @param bool $destroy Whether the container should manage the service's lifecycle and call its destroy
+     *        method on Container destruction (if it implements {@see Destroyable}).
      */
-    public function set(object $service, ?string $id = null): void;
+    public function set(object $service, ?string $id = null, bool $destroy = false): void;
 
     /**
      * Creates a new instance without storing it in the container.

--- a/internal/container/src/Interanl/State.php
+++ b/internal/container/src/Interanl/State.php
@@ -178,7 +178,7 @@ final class State
             }
 
             $reflection = new \ReflectionClass($service);
-            if ($reflection->isReadOnly()) {
+            if ($reflection->isReadOnly() || $reflection->isEnum()) {
                 $self->cache[$id] = $service;
                 continue;
             }

--- a/internal/container/src/Interanl/State.php
+++ b/internal/container/src/Interanl/State.php
@@ -83,9 +83,10 @@ final class State
         return \array_key_exists($id, $this->cache) || \array_key_exists($id, $this->factory);
     }
 
-    public function set(object $service, ?string $id = null): void
+    public function set(object $service, ?string $id = null, bool $destroy = false): void
     {
         $this->cache[$id ?? $service::class] = $service;
+        $service instanceof Destroyable and $this->destroy[\spl_object_id($service)] = $service;
     }
 
     /**

--- a/internal/container/src/ObjectContainer.php
+++ b/internal/container/src/ObjectContainer.php
@@ -42,10 +42,10 @@ final class ObjectContainer implements Container
     }
 
     #[\Override]
-    public function set(object $service, ?string $id = null): void
+    public function set(object $service, ?string $id = null, bool $destroy = false): void
     {
         \assert($id === null || $service instanceof $id, "Service must be instance of {$id}.");
-        $this->state->set($service, $id);
+        $this->state->set($service, $id, $destroy);
     }
 
     #[\Override]

--- a/src/Bridge/Symfony/Command/Run.php
+++ b/src/Bridge/Symfony/Command/Run.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Testo\Codecov\CoverageMode;
 use Testo\Output\Teamcity\TeamcityPlugin;
 use Testo\Output\Terminal\TerminalPlugin;
 
@@ -92,12 +93,30 @@ final class Run extends Base
             InputOption::VALUE_OPTIONAL,
             'Filter test cases by type (e.g. test, test-inline, bench)',
         );
+        $this->addOption(
+            'coverage',
+            null,
+            InputOption::VALUE_NONE,
+            'Require code coverage collection (fails if no driver available)',
+        );
+        $this->addOption(
+            'no-coverage',
+            null,
+            InputOption::VALUE_NONE,
+            'Disable code coverage collection',
+        );
     }
 
     public function __invoke(
         InputInterface  $input,
         OutputInterface $output,
     ): int {
+        if ($input->getOption('coverage')) {
+            $this->container->bind(CoverageMode::class, static fn(): CoverageMode => CoverageMode::Required);
+        } elseif ($input->getOption('no-coverage')) {
+            $this->container->bind(CoverageMode::class, static fn(): CoverageMode => CoverageMode::Disabled);
+        }
+
         $input->getOption('teamcity')
             ? $this->container->get(TeamcityPlugin::class)->configure($this->container)
             : $this->container->get(TerminalPlugin::class)->configure($this->container);

--- a/src/Codecov/CodecovPlugin.php
+++ b/src/Codecov/CodecovPlugin.php
@@ -33,11 +33,20 @@ final readonly class CodecovPlugin implements PluginConfigurator
     private array $reports;
 
     /**
-     * @param CoverageReport ...$reports Report generators to run after all tests complete.
+     * @param CoverageLevel $level Depth of coverage analysis.
+     * @param list<CoverageReport> $reports Report generators to run after all tests complete.
      */
     public function __construct(
-        CoverageReport ...$reports,
+        private CoverageLevel $level = CoverageLevel::Line,
+        array $reports = [],
     ) {
+        foreach ($reports as $report) {
+            $report instanceof CoverageReport or throw new \InvalidArgumentException(\sprintf(
+                'Codecov report must implement `%s`, got `%s`.',
+                CoverageReport::class,
+                \get_debug_type($report),
+            ));
+        }
         $this->reports = $reports;
     }
 
@@ -56,7 +65,7 @@ final readonly class CodecovPlugin implements PluginConfigurator
         }
 
         $src = $container->get(ApplicationConfig::class)->src;
-        $driver = $driver->withFilter($src);
+        $driver = $driver->withFilter($src)->withLevel($this->level);
 
         $container->get(InterceptorCollector::class)
             ->addInterceptor(new CoverageTestInterceptor($driver));

--- a/src/Codecov/CodecovPlugin.php
+++ b/src/Codecov/CodecovPlugin.php
@@ -7,7 +7,7 @@ namespace Testo\Codecov;
 use Internal\Container\Container;
 use Testo\Application\Config\ApplicationConfig;
 use Testo\Codecov\Exception\CoverageDriverNotAvailable;
-use Testo\Codecov\Internal\CoverageAggregate;
+use Testo\Codecov\Internal\CoverageCollector;
 use Testo\Codecov\Internal\Driver\PcovDriver;
 use Testo\Codecov\Internal\Driver\XdebugDriver;
 use Testo\Codecov\Internal\Middleware\CoverageTestInterceptor;
@@ -70,8 +70,8 @@ final readonly class CodecovPlugin implements PluginConfigurator
         $container->get(InterceptorCollector::class)
             ->addInterceptor(new CoverageTestInterceptor($driver));
 
-        $aggregate = new CoverageAggregate($this->reports);
-        $container->set($aggregate);
+        $aggregate = new CoverageCollector($this->reports);
+        $container->set($aggregate, destroy: true);
 
         $container->get(EventListenerCollector::class)
             ->addListener(TestSuiteFinished::class, static function (TestSuiteFinished $event) use ($aggregate): void {

--- a/src/Codecov/CodecovPlugin.php
+++ b/src/Codecov/CodecovPlugin.php
@@ -20,7 +20,10 @@ use Testo\Pipeline\InterceptorCollector;
 /**
  * Plugin that enables code coverage collection during test execution.
  *
- * Requires either the PCOV or XDebug extension to be installed.
+ * Behavior depends on {@see CoverageMode} in the container:
+ * - {@see CoverageMode::Required} — throws if no extension available
+ * - {@see CoverageMode::Available} — collects if extension present, skips silently if not (default)
+ * - {@see CoverageMode::Disabled} — skips entirely
  *
  * @api
  */
@@ -41,8 +44,19 @@ final readonly class CodecovPlugin implements PluginConfigurator
     #[\Override]
     public function configure(Container $container): void
     {
+        $mode = $container->has(CoverageMode::class)
+            ? $container->get(CoverageMode::class)
+            : CoverageMode::Available;
+        $container->set($mode);
+
+        $driver = self::detectDriver($mode);
+
+        if ($driver === null) {
+            return;
+        }
+
         $src = $container->get(ApplicationConfig::class)->src;
-        $driver = self::detectDriver()->withFilter($src);
+        $driver = $driver->withFilter($src);
 
         $container->get(InterceptorCollector::class)
             ->addInterceptor(new CoverageTestInterceptor($driver));
@@ -56,12 +70,14 @@ final readonly class CodecovPlugin implements PluginConfigurator
             });
     }
 
-    private static function detectDriver(): CoverageDriver
+    private static function detectDriver(CoverageMode $mode): ?CoverageDriver
     {
         return match (true) {
+            $mode === CoverageMode::Disabled => null,
             \extension_loaded('pcov') => new PcovDriver(),
             \extension_loaded('xdebug') => new XdebugDriver(),
-            default => throw new CoverageDriverNotAvailable(),
+            $mode === CoverageMode::Required => throw new CoverageDriverNotAvailable(),
+            default => null,
         };
     }
 }

--- a/src/Codecov/CodecovPlugin.php
+++ b/src/Codecov/CodecovPlugin.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov;
+
+use Internal\Container\Container;
+use Testo\Application\Config\ApplicationConfig;
+use Testo\Codecov\Exception\CoverageDriverNotAvailable;
+use Testo\Codecov\Internal\Driver\PcovDriver;
+use Testo\Codecov\Internal\Driver\XdebugDriver;
+use Testo\Codecov\Internal\Middleware\CoverageTestInterceptor;
+use Testo\Common\PluginConfigurator;
+use Testo\Pipeline\InterceptorCollector;
+
+/**
+ * Plugin that enables code coverage collection during test execution.
+ *
+ * Requires either the PCOV or XDebug extension to be installed.
+ *
+ * @api
+ */
+final readonly class CodecovPlugin implements PluginConfigurator
+{
+    #[\Override]
+    public function configure(Container $container): void
+    {
+        $src = $container->get(ApplicationConfig::class)->src;
+        $driver = self::detectDriver()->withFilter($src);
+
+        $container->get(InterceptorCollector::class)
+            ->addInterceptor(new CoverageTestInterceptor($driver, $src));
+    }
+
+    private static function detectDriver(): CoverageDriver
+    {
+        return match (true) {
+            \extension_loaded('pcov') => new PcovDriver(),
+            \extension_loaded('xdebug') => new XdebugDriver(),
+            default => throw new CoverageDriverNotAvailable(),
+        };
+    }
+}

--- a/src/Codecov/CodecovPlugin.php
+++ b/src/Codecov/CodecovPlugin.php
@@ -7,10 +7,14 @@ namespace Testo\Codecov;
 use Internal\Container\Container;
 use Testo\Application\Config\ApplicationConfig;
 use Testo\Codecov\Exception\CoverageDriverNotAvailable;
+use Testo\Codecov\Internal\CoverageAggregate;
 use Testo\Codecov\Internal\Driver\PcovDriver;
 use Testo\Codecov\Internal\Driver\XdebugDriver;
 use Testo\Codecov\Internal\Middleware\CoverageTestInterceptor;
+use Testo\Codecov\Report\CoverageReport;
+use Testo\Common\EventListenerCollector;
 use Testo\Common\PluginConfigurator;
+use Testo\Event\TestSuite\TestSuiteFinished;
 use Testo\Pipeline\InterceptorCollector;
 
 /**
@@ -22,6 +26,18 @@ use Testo\Pipeline\InterceptorCollector;
  */
 final readonly class CodecovPlugin implements PluginConfigurator
 {
+    /** @var list<CoverageReport> */
+    private array $reports;
+
+    /**
+     * @param CoverageReport ...$reports Report generators to run after all tests complete.
+     */
+    public function __construct(
+        CoverageReport ...$reports,
+    ) {
+        $this->reports = $reports;
+    }
+
     #[\Override]
     public function configure(Container $container): void
     {
@@ -29,7 +45,15 @@ final readonly class CodecovPlugin implements PluginConfigurator
         $driver = self::detectDriver()->withFilter($src);
 
         $container->get(InterceptorCollector::class)
-            ->addInterceptor(new CoverageTestInterceptor($driver, $src));
+            ->addInterceptor(new CoverageTestInterceptor($driver));
+
+        $aggregate = new CoverageAggregate($this->reports);
+        $container->set($aggregate);
+
+        $container->get(EventListenerCollector::class)
+            ->addListener(TestSuiteFinished::class, static function (TestSuiteFinished $event) use ($aggregate): void {
+                $aggregate->mergeSuiteResult($event->suiteResult);
+            });
     }
 
     private static function detectDriver(): CoverageDriver

--- a/src/Codecov/CoverageDriver.php
+++ b/src/Codecov/CoverageDriver.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov;
+
+use Testo\Application\Config\FinderConfig;
+
+/**
+ * Interface for code coverage collection engines.
+ *
+ * @api
+ */
+interface CoverageDriver
+{
+    /**
+     * Returns a new driver instance with the given path filter.
+     *
+     * When set, only files matching the filter's include/exclude paths are tracked.
+     */
+    public function withFilter(FinderConfig $filter): static;
+
+    /**
+     * Starts code coverage collection.
+     */
+    public function start(): void;
+
+    /**
+     * Stops collection and returns the raw coverage data.
+     *
+     * @return array<string, array<int, int>> File path => [line number => status].
+     *         Status values: 1 = executed, -1 = not executed, -2 = not executable.
+     */
+    public function collect(): array;
+
+    /**
+     * Clears any accumulated coverage data.
+     */
+    public function clear(): void;
+}

--- a/src/Codecov/CoverageDriver.php
+++ b/src/Codecov/CoverageDriver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Testo\Codecov;
 
 use Testo\Application\Config\FinderConfig;
+use Testo\Codecov\Dto\CoverageResult;
 
 /**
  * Interface for code coverage collection engines.
@@ -23,20 +24,25 @@ interface CoverageDriver
     public function withFilter(FinderConfig $filter): static;
 
     /**
+     * Returns a new driver instance with the given coverage level.
+     *
+     * If the driver does not support the requested level, it should fall back
+     * to the highest supported level (e.g. PCOV supports only {@see CoverageLevel::Line}).
+     */
+    public function withLevel(CoverageLevel $level): static;
+
+    /**
      * Starts code coverage collection.
      */
     public function start(): void;
 
     /**
-     * Stops collection and returns the raw coverage data.
+     * Stops collection and returns coverage data as DTOs.
      *
-     * The returned data must already be filtered by the configured {@see FinderConfig}
-     * (set via {@see withFilter()}). Callers should not need to apply file-level filtering.
-     *
-     * @return array<string, array<int, int>> File path => [line number => status].
-     *         Status values: 1 = executed, -1 = not executed, -2 = not executable.
+     * The returned data is already filtered by the configured {@see FinderConfig}
+     * and parsed according to the configured {@see CoverageLevel}.
      */
-    public function collect(): array;
+    public function collect(): CoverageResult;
 
     /**
      * Clears any accumulated coverage data.

--- a/src/Codecov/CoverageDriver.php
+++ b/src/Codecov/CoverageDriver.php
@@ -16,7 +16,9 @@ interface CoverageDriver
     /**
      * Returns a new driver instance with the given path filter.
      *
-     * When set, only files matching the filter's include/exclude paths are tracked.
+     * The driver is responsible for file-level filtering: only files matching
+     * the filter's include paths and not matching exclude paths are returned
+     * by {@see collect()}.
      */
     public function withFilter(FinderConfig $filter): static;
 
@@ -27,6 +29,9 @@ interface CoverageDriver
 
     /**
      * Stops collection and returns the raw coverage data.
+     *
+     * The returned data must already be filtered by the configured {@see FinderConfig}
+     * (set via {@see withFilter()}). Callers should not need to apply file-level filtering.
      *
      * @return array<string, array<int, int>> File path => [line number => status].
      *         Status values: 1 = executed, -1 = not executed, -2 = not executable.

--- a/src/Codecov/CoverageLevel.php
+++ b/src/Codecov/CoverageLevel.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov;
+
+/**
+ * Defines the depth of code coverage analysis.
+ *
+ * Each level includes all data from the previous one:
+ * - **Line** — which lines of code were executed during tests.
+ * - **Branch** — Line + which branches (if/else, switch cases, ternary, ??) were taken.
+ * - **Path** — Branch + which complete execution paths through each function were followed.
+ *
+ * Higher levels provide deeper insight but increase overhead.
+ *
+ * ## Example
+ *
+ * Given the code:
+ *
+ * ```
+ *  function greet(bool $loud, bool $formal): string
+ *  {
+ *      $greeting = $formal ? 'Good day' : 'Hi';    // 2 branches: true/false
+ *      return $loud ? strtoupper($greeting) : $greeting; // 2 branches: true/false
+ *  }
+ * ```
+ *
+ * - **Line** reports whether each line was executed (e.g. lines 3 and 4).
+ * - **Branch** reports which branches were taken:
+ *   line 3 has 2 branches (`$formal` true or false),
+ *   line 4 has 2 branches (`$loud` true or false) — 4 branches total.
+ *   A test calling `greet(true, true)` covers 2 of 4 branches (50%).
+ * - **Path** reports which *combinations* of branches were followed:
+ *   there are 4 possible paths (true+true, true+false, false+true, false+false).
+ *   A test calling `greet(true, true)` covers 1 of 4 paths (25%).
+ *
+ * ## Driver support
+ *
+ * - **PCOV** — only supports {@see Line}. Higher levels silently fall back to Line.
+ * - **XDebug** — supports all three levels. Branch and Path require XDebug's
+ *   `XDEBUG_CC_BRANCH_CHECK` flag, which adds analysis overhead.
+ *
+ * @api
+ */
+enum CoverageLevel
+{
+    /**
+     * Track which lines were executed. Supported by both PCOV and XDebug.
+     */
+    case Line;
+
+    /**
+     * Track which branches were taken. XDebug only.
+     *
+     * A branch is a possible direction at a decision point: each side of an `if/else`,
+     * each `case` in a `switch`, each arm of a `match`, the true/false side of `?:`, etc.
+     *
+     * Includes all line coverage data.
+     */
+    case Branch;
+
+    /**
+     * Track which execution paths were followed. XDebug only.
+     *
+     * A path is a unique combination of branches through a function from entry to exit.
+     * A function with two independent `if` statements has 4 possible paths (2 × 2).
+     * Path coverage reveals untested combinations that branch coverage alone may miss.
+     *
+     * Includes all line and branch coverage data.
+     */
+    case Path;
+}

--- a/src/Codecov/CoverageMode.php
+++ b/src/Codecov/CoverageMode.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov;
+
+/**
+ * Controls code coverage collection behavior.
+ *
+ * Set in the container (e.g. from CLI flags) before plugin configuration.
+ * If not set, {@see CoverageMode::Available} is used as default.
+ *
+ * @api
+ */
+enum CoverageMode
+{
+    /**
+     * Coverage required. Throw if no extension is available.
+     */
+    case Required;
+
+    /**
+     * Use coverage if extension is available, skip silently if not.
+     */
+    case Available;
+
+    /**
+     * Skip coverage entirely, zero overhead.
+     */
+    case Disabled;
+}

--- a/src/Codecov/Dto/BranchCoverage.php
+++ b/src/Codecov/Dto/BranchCoverage.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov\Dto;
+
+/**
+ * A single branch within a function's control flow graph.
+ */
+final readonly class BranchCoverage
+{
+    public function __construct(
+        /** @var int<0, max> Opcode index where this branch starts. */
+        public int $opStart,
+
+        /** @var int<0, max> Opcode index where this branch ends. */
+        public int $opEnd,
+
+        /** @var int<1, max> Source line where this branch starts. */
+        public int $lineStart,
+
+        /** @var int<1, max> Source line where this branch ends. */
+        public int $lineEnd,
+
+        /** Whether this branch was executed. */
+        public bool $hit,
+
+        /** @var list<int<0, max>> Outgoing branch opcode indices. */
+        public array $out,
+
+        /** @var list<bool> Whether each outgoing branch was taken. */
+        public array $outHit,
+    ) {}
+
+    public function merge(self $other): self
+    {
+        return new self(
+            $this->opStart,
+            $this->opEnd,
+            $this->lineStart,
+            $this->lineEnd,
+            $this->hit || $other->hit,
+            $this->out,
+            \array_map(
+                static fn(bool $a, bool $b): bool => $a || $b,
+                $this->outHit,
+                $other->outHit,
+            ),
+        );
+    }
+}

--- a/src/Codecov/Dto/CoverageResult.php
+++ b/src/Codecov/Dto/CoverageResult.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov\Dto;
+
+use Testo\Application\Config\FinderConfig;
+
+/**
+ * Aggregated code coverage data across multiple files.
+ */
+final readonly class CoverageResult
+{
+    public function __construct(
+        /** @var array<non-empty-string, FileCoverage> File path => coverage data. */
+        public array $files = [],
+    ) {}
+
+    /**
+     * Creates a CoverageResult from raw driver data, filtered by the given config.
+     *
+     * @param array<string, array<int, int>> $rawData Raw coverage data from the driver.
+     */
+    public static function fromRawData(array $rawData, FinderConfig $filter): self
+    {
+        $files = [];
+
+        foreach ($rawData as $filePath => $lines) {
+            if (!self::matchesFilter($filePath, $filter)) {
+                continue;
+            }
+
+            $lineStatuses = [];
+            foreach ($lines as $lineNumber => $status) {
+                $lineStatus = LineStatus::tryFrom($status);
+                $lineStatus !== null and $lineStatuses[$lineNumber] = $lineStatus;
+            }
+
+            $lineStatuses !== [] and $files[$filePath] = new FileCoverage($filePath, $lineStatuses);
+        }
+
+        return new self($files);
+    }
+
+    /**
+     * Merges another result into this one.
+     */
+    public function merge(self $other): self
+    {
+        $merged = $this->files;
+
+        foreach ($other->files as $path => $fileCoverage) {
+            $merged[$path] = isset($merged[$path])
+                ? $merged[$path]->merge($fileCoverage)
+                : $fileCoverage;
+        }
+
+        return new self($merged);
+    }
+
+    private static function matchesFilter(string $filePath, FinderConfig $filter): bool
+    {
+        if ($filter->includes !== []) {
+            $included = false;
+            foreach ($filter->includes as $path) {
+                if (\str_starts_with($filePath, (string) $path)) {
+                    $included = true;
+                    break;
+                }
+            }
+
+            if (!$included) {
+                return false;
+            }
+        }
+
+        foreach ($filter->excludes as $path) {
+            if (\str_starts_with($filePath, (string) $path)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Codecov/Dto/CoverageResult.php
+++ b/src/Codecov/Dto/CoverageResult.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Testo\Codecov\Dto;
 
-use Testo\Application\Config\FinderConfig;
-
 /**
  * Aggregated code coverage data across multiple files.
  */
@@ -17,19 +15,17 @@ final readonly class CoverageResult
     ) {}
 
     /**
-     * Creates a CoverageResult from raw driver data, filtered by the given config.
+     * Creates a CoverageResult from raw driver data.
+     *
+     * File-level filtering is the driver's responsibility.
      *
      * @param array<string, array<int, int>> $rawData Raw coverage data from the driver.
      */
-    public static function fromRawData(array $rawData, FinderConfig $filter): self
+    public static function fromRawData(array $rawData): self
     {
         $files = [];
 
         foreach ($rawData as $filePath => $lines) {
-            if (!self::matchesFilter($filePath, $filter)) {
-                continue;
-            }
-
             $lineStatuses = [];
             foreach ($lines as $lineNumber => $status) {
                 $lineStatus = LineStatus::tryFrom($status);
@@ -56,30 +52,5 @@ final readonly class CoverageResult
         }
 
         return new self($merged);
-    }
-
-    private static function matchesFilter(string $filePath, FinderConfig $filter): bool
-    {
-        if ($filter->includes !== []) {
-            $included = false;
-            foreach ($filter->includes as $path) {
-                if (\str_starts_with($filePath, (string) $path)) {
-                    $included = true;
-                    break;
-                }
-            }
-
-            if (!$included) {
-                return false;
-            }
-        }
-
-        foreach ($filter->excludes as $path) {
-            if (\str_starts_with($filePath, (string) $path)) {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/src/Codecov/Dto/CoverageResult.php
+++ b/src/Codecov/Dto/CoverageResult.php
@@ -17,22 +17,35 @@ final readonly class CoverageResult
     /**
      * Creates a CoverageResult from raw driver data.
      *
-     * File-level filtering is the driver's responsibility.
+     * Automatically detects the format:
+     * - Line-only: `array<string, array<int, int>>`
+     * - Branch/Path: `array<string, array{lines: array<int, int>, functions: array}>`
      *
-     * @param array<string, array<int, int>> $rawData Raw coverage data from the driver.
+     * File-level filtering is the driver's responsibility.
      */
     public static function fromRawData(array $rawData): self
     {
         $files = [];
 
-        foreach ($rawData as $filePath => $lines) {
+        foreach ($rawData as $filePath => $fileData) {
+            // Detect format: branch/path data has a 'lines' key
+            $hasFunction = \is_array($fileData) && \array_key_exists('lines', $fileData);
+
+            $rawLines = $hasFunction ? $fileData['lines'] : $fileData;
+
             $lineStatuses = [];
-            foreach ($lines as $lineNumber => $status) {
+            foreach ($rawLines as $lineNumber => $status) {
                 $lineStatus = LineStatus::tryFrom($status);
                 $lineStatus !== null and $lineStatuses[$lineNumber] = $lineStatus;
             }
 
-            $lineStatuses !== [] and $files[$filePath] = new FileCoverage($filePath, $lineStatuses);
+            $functions = [];
+            if ($hasFunction && isset($fileData['functions'])) {
+                $functions = self::parseFunctions($fileData['functions']);
+            }
+
+            ($lineStatuses !== [] || $functions !== [])
+                and $files[$filePath] = new FileCoverage($filePath, $lineStatuses, $functions);
         }
 
         return new self($files);
@@ -52,5 +65,40 @@ final readonly class CoverageResult
         }
 
         return new self($merged);
+    }
+
+    /**
+     * @return array<non-empty-string, FunctionCoverage>
+     */
+    private static function parseFunctions(array $rawFunctions): array
+    {
+        $functions = [];
+
+        foreach ($rawFunctions as $name => $data) {
+            $branches = [];
+            foreach ($data['branches'] ?? [] as $opStart => $branchData) {
+                $branches[$opStart] = new BranchCoverage(
+                    opStart: $branchData['op_start'],
+                    opEnd: $branchData['op_end'],
+                    lineStart: $branchData['line_start'],
+                    lineEnd: $branchData['line_end'],
+                    hit: $branchData['hit'] > 0,
+                    out: $branchData['out'],
+                    outHit: \array_map(static fn(int $h): bool => $h > 0, $branchData['out_hit']),
+                );
+            }
+
+            $paths = [];
+            foreach ($data['paths'] ?? [] as $pathData) {
+                $paths[] = new PathCoverage(
+                    path: $pathData['path'],
+                    hit: $pathData['hit'] > 0,
+                );
+            }
+
+            $functions[$name] = new FunctionCoverage($name, $branches, $paths);
+        }
+
+        return $functions;
     }
 }

--- a/src/Codecov/Dto/FileCoverage.php
+++ b/src/Codecov/Dto/FileCoverage.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov\Dto;
+
+/**
+ * Code coverage data for a single source file.
+ */
+final readonly class FileCoverage
+{
+    public function __construct(
+        /** @var non-empty-string Absolute path to the source file. */
+        public string $path,
+
+        /** @var array<int<0, max>, LineStatus> Line number => coverage status. */
+        public array $lines,
+    ) {}
+
+    /**
+     * Merges another coverage into this one.
+     * A line is considered Executed if it was executed in either coverage run.
+     */
+    public function merge(self $other): self
+    {
+        $merged = $this->lines;
+
+        foreach ($other->lines as $line => $status) {
+            $merged[$line] = match (true) {
+                !isset($merged[$line]) => $status,
+                $merged[$line] === LineStatus::Executed,
+                $status === LineStatus::Executed => LineStatus::Executed,
+                default => $merged[$line],
+            };
+        }
+
+        return new self($this->path, $merged);
+    }
+}

--- a/src/Codecov/Dto/FileCoverage.php
+++ b/src/Codecov/Dto/FileCoverage.php
@@ -6,6 +6,10 @@ namespace Testo\Codecov\Dto;
 
 /**
  * Code coverage data for a single source file.
+ *
+ * Line coverage is always present. Branch and path coverage (via {@see $functions})
+ * is optional and only populated when collected with {@see CoverageLevel::Branch}
+ * or {@see CoverageLevel::Path}.
  */
 final readonly class FileCoverage
 {
@@ -15,6 +19,9 @@ final readonly class FileCoverage
 
         /** @var array<int<0, max>, LineStatus> Line number => coverage status. */
         public array $lines,
+
+        /** @var array<non-empty-string, FunctionCoverage> Function name => branch/path data. */
+        public array $functions = [],
     ) {}
 
     /**
@@ -23,17 +30,23 @@ final readonly class FileCoverage
      */
     public function merge(self $other): self
     {
-        $merged = $this->lines;
-
+        $mergedLines = $this->lines;
         foreach ($other->lines as $line => $status) {
-            $merged[$line] = match (true) {
-                !isset($merged[$line]) => $status,
-                $merged[$line] === LineStatus::Executed,
+            $mergedLines[$line] = match (true) {
+                !isset($mergedLines[$line]) => $status,
+                $mergedLines[$line] === LineStatus::Executed,
                 $status === LineStatus::Executed => LineStatus::Executed,
-                default => $merged[$line],
+                default => $mergedLines[$line],
             };
         }
 
-        return new self($this->path, $merged);
+        $mergedFunctions = $this->functions;
+        foreach ($other->functions as $name => $function) {
+            $mergedFunctions[$name] = isset($mergedFunctions[$name])
+                ? $mergedFunctions[$name]->merge($function)
+                : $function;
+        }
+
+        return new self($this->path, $mergedLines, $mergedFunctions);
     }
 }

--- a/src/Codecov/Dto/FunctionCoverage.php
+++ b/src/Codecov/Dto/FunctionCoverage.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov\Dto;
+
+/**
+ * Branch and path coverage data for a single function or method.
+ */
+final readonly class FunctionCoverage
+{
+    public function __construct(
+        /** @var non-empty-string Function name (e.g. 'MyClass->myMethod' or '{main}'). */
+        public string $name,
+
+        /** @var array<int<0, max>, BranchCoverage> Branches indexed by opcode start. */
+        public array $branches,
+
+        /** @var list<PathCoverage> All possible execution paths. */
+        public array $paths,
+    ) {}
+
+    public function merge(self $other): self
+    {
+        $branches = $this->branches;
+        foreach ($other->branches as $opStart => $branch) {
+            $branches[$opStart] = isset($branches[$opStart])
+                ? $branches[$opStart]->merge($branch)
+                : $branch;
+        }
+
+        $paths = [];
+        foreach ($this->paths as $i => $path) {
+            $paths[] = isset($other->paths[$i])
+                ? $path->merge($other->paths[$i])
+                : $path;
+        }
+
+        return new self($this->name, $branches, $paths);
+    }
+}

--- a/src/Codecov/Dto/LineStatus.php
+++ b/src/Codecov/Dto/LineStatus.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov\Dto;
+
+/**
+ * Represents the coverage status of a single source code line.
+ */
+enum LineStatus: int
+{
+    /** Line was executed during tests. */
+    case Executed = 1;
+
+    /** Line is executable but was not executed. */
+    case NotExecuted = -1;
+
+    /** Line is not executable (dead code, comments, declarations). */
+    case Dead = -2;
+
+    public function isExecutable(): bool
+    {
+        return $this !== self::Dead;
+    }
+}

--- a/src/Codecov/Dto/PathCoverage.php
+++ b/src/Codecov/Dto/PathCoverage.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov\Dto;
+
+/**
+ * A single execution path through a function.
+ *
+ * A path is an ordered sequence of branches (identified by their opcode start indices)
+ * that were followed during execution.
+ */
+final readonly class PathCoverage
+{
+    public function __construct(
+        /** @var list<int<0, max>> Sequence of branch opcode start indices forming this path. */
+        public array $path,
+
+        /** Whether this path was followed during execution. */
+        public bool $hit,
+    ) {}
+
+    public function merge(self $other): self
+    {
+        return new self($this->path, $this->hit || $other->hit);
+    }
+}

--- a/src/Codecov/Exception/CoverageDriverNotAvailable.php
+++ b/src/Codecov/Exception/CoverageDriverNotAvailable.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov\Exception;
+
+/**
+ * Thrown when no supported coverage driver extension is available.
+ */
+final class CoverageDriverNotAvailable extends \RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'No code coverage driver available. Install the PCOV or XDebug extension.',
+        );
+    }
+}

--- a/src/Codecov/Internal/Cache.php
+++ b/src/Codecov/Internal/Cache.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov\Internal;
+
+use Testo\Codecov\Dto\CoverageResult;
+
+/**
+ * @internal
+ */
+final class Cache
+{
+    public function __construct(
+        public CoverageResult $value,
+    ) {}
+}

--- a/src/Codecov/Internal/CoverageAggregate.php
+++ b/src/Codecov/Internal/CoverageAggregate.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov\Internal;
+
+use Internal\Destroy\Destroyable;
+use Testo\Codecov\Dto\CoverageResult;
+use Testo\Codecov\Report\CoverageReport;
+use Testo\Core\Context\SuiteResult;
+
+/**
+ * Mutable aggregate that collects coverage data across test suites.
+ *
+ * Merges per-test coverage from suite results as they finish.
+ * On destruction, generates all configured reports.
+ *
+ * @internal
+ */
+final class CoverageAggregate implements Destroyable
+{
+    private CoverageResult $result;
+
+    /**
+     * @param list<CoverageReport> $reports
+     */
+    public function __construct(
+        private readonly array $reports,
+    ) {
+        $this->result = new CoverageResult();
+    }
+
+    public function mergeSuiteResult(SuiteResult $suiteResult): void
+    {
+        foreach ($suiteResult as $caseResult) {
+            foreach ($caseResult as $testResult) {
+                $coverage = $testResult->getAttribute(CoverageResult::class);
+                $coverage instanceof CoverageResult and $this->result = $this->result->merge($coverage);
+            }
+        }
+    }
+
+    public function destroy(): void
+    {
+        foreach ($this->reports as $report) {
+            $report->generate($this->result);
+        }
+    }
+}

--- a/src/Codecov/Internal/CoverageCollector.php
+++ b/src/Codecov/Internal/CoverageCollector.php
@@ -17,33 +17,36 @@ use Testo\Core\Context\SuiteResult;
  *
  * @internal
  */
-final class CoverageAggregate implements Destroyable
+final readonly class CoverageCollector implements Destroyable
 {
-    private CoverageResult $result;
+    private Cache $cache;
 
     /**
      * @param list<CoverageReport> $reports
      */
     public function __construct(
-        private readonly array $reports,
+        private array $reports,
     ) {
-        $this->result = new CoverageResult();
+        $this->cache = new Cache(new CoverageResult());
     }
 
     public function mergeSuiteResult(SuiteResult $suiteResult): void
     {
+        $r = $this->cache->value;
         foreach ($suiteResult as $caseResult) {
             foreach ($caseResult as $testResult) {
                 $coverage = $testResult->getAttribute(CoverageResult::class);
-                $coverage instanceof CoverageResult and $this->result = $this->result->merge($coverage);
+                $coverage instanceof CoverageResult and $r = $r->merge($coverage);
             }
         }
+
+        $this->cache->value = $r;
     }
 
     public function destroy(): void
     {
         foreach ($this->reports as $report) {
-            $report->generate($this->result);
+            $report->generate($this->cache->value);
         }
     }
 }

--- a/src/Codecov/Internal/Driver/NormalizePath.php
+++ b/src/Codecov/Internal/Driver/NormalizePath.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov\Internal\Driver;
+
+use Internal\Path;
+
+/**
+ * Normalizes {@see Path} to system-native directory prefix for path matching.
+ *
+ * @internal
+ */
+trait NormalizePath
+{
+    /**
+     * Converts a {@see Path} to a system-native string with trailing separator.
+     *
+     * @return non-empty-string
+     */
+    private static function normalizePath(Path $path): string
+    {
+        $p = \str_replace('/', \DIRECTORY_SEPARATOR, (string) $path->absolute());
+
+        return $path->isDir() ? $p . \DIRECTORY_SEPARATOR : $p;
+    }
+}

--- a/src/Codecov/Internal/Driver/PcovDriver.php
+++ b/src/Codecov/Internal/Driver/PcovDriver.php
@@ -66,9 +66,12 @@ final readonly class PcovDriver implements CoverageDriver
 
     private function matchesFilter(string $file): bool
     {
+        // Normalize separators: Path uses '/', but PCOV on Windows may return '\'
+        $normalized = \str_replace('\\', '/', $file);
+
         $included = false;
         foreach ($this->includes as $path) {
-            if (\str_starts_with($file, $path)) {
+            if (\str_starts_with($normalized, $path)) {
                 $included = true;
                 break;
             }
@@ -79,7 +82,7 @@ final readonly class PcovDriver implements CoverageDriver
         }
 
         foreach ($this->excludes as $path) {
-            if (\str_starts_with($file, $path)) {
+            if (\str_starts_with($normalized, $path)) {
                 return false;
             }
         }

--- a/src/Codecov/Internal/Driver/PcovDriver.php
+++ b/src/Codecov/Internal/Driver/PcovDriver.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov\Internal\Driver;
+
+use Testo\Application\Config\FinderConfig;
+use Testo\Codecov\CoverageDriver;
+
+/**
+ * PCOV-based coverage driver.
+ *
+ * @internal
+ */
+final readonly class PcovDriver implements CoverageDriver
+{
+    /**
+     * @param list<non-empty-string> $includes
+     * @param list<non-empty-string> $excludes
+     */
+    public function __construct(
+        private array $includes = [],
+        private array $excludes = [],
+    ) {}
+
+    #[\Override]
+    public function withFilter(FinderConfig $filter): static
+    {
+        return new self(
+            \array_map(\strval(...), $filter->includes),
+            \array_map(\strval(...), $filter->excludes),
+        );
+    }
+
+    #[\Override]
+    public function start(): void
+    {
+        \pcov\start();
+    }
+
+    #[\Override]
+    public function collect(): array
+    {
+        \pcov\stop();
+
+        if ($this->includes === []) {
+            $data = \pcov\collect();
+        } else {
+            $waiting = \pcov\waiting();
+            $filtered = \array_filter($waiting, $this->matchesFilter(...));
+            $data = $filtered !== []
+                ? \pcov\collect(\pcov\inclusive, \array_values($filtered))
+                : [];
+        }
+
+        \pcov\clear();
+
+        return $data;
+    }
+
+    #[\Override]
+    public function clear(): void
+    {
+        \pcov\clear();
+    }
+
+    private function matchesFilter(string $file): bool
+    {
+        $included = false;
+        foreach ($this->includes as $path) {
+            if (\str_starts_with($file, $path)) {
+                $included = true;
+                break;
+            }
+        }
+
+        if (!$included) {
+            return false;
+        }
+
+        foreach ($this->excludes as $path) {
+            if (\str_starts_with($file, $path)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Codecov/Internal/Driver/PcovDriver.php
+++ b/src/Codecov/Internal/Driver/PcovDriver.php
@@ -6,6 +6,8 @@ namespace Testo\Codecov\Internal\Driver;
 
 use Testo\Application\Config\FinderConfig;
 use Testo\Codecov\CoverageDriver;
+use Testo\Codecov\CoverageLevel;
+use Testo\Codecov\Dto\CoverageResult;
 
 /**
  * PCOV-based coverage driver.
@@ -14,6 +16,7 @@ use Testo\Codecov\CoverageDriver;
  */
 final readonly class PcovDriver implements CoverageDriver
 {
+    use NormalizePath;
     /**
      * @param list<non-empty-string> $includes
      * @param list<non-empty-string> $excludes
@@ -27,9 +30,18 @@ final readonly class PcovDriver implements CoverageDriver
     public function withFilter(FinderConfig $filter): static
     {
         return new self(
-            \array_map(\strval(...), $filter->includes),
-            \array_map(\strval(...), $filter->excludes),
+            \array_map(self::normalizePath(...), $filter->includes),
+            \array_map(self::normalizePath(...), $filter->excludes),
         );
+    }
+
+    /**
+     * PCOV only supports line coverage. Higher levels silently fall back to Line.
+     */
+    #[\Override]
+    public function withLevel(CoverageLevel $level): static
+    {
+        return $this;
     }
 
     #[\Override]
@@ -39,7 +51,7 @@ final readonly class PcovDriver implements CoverageDriver
     }
 
     #[\Override]
-    public function collect(): array
+    public function collect(): CoverageResult
     {
         \pcov\stop();
 
@@ -55,7 +67,7 @@ final readonly class PcovDriver implements CoverageDriver
 
         \pcov\clear();
 
-        return $data;
+        return CoverageResult::fromRawData($data);
     }
 
     #[\Override]
@@ -66,12 +78,9 @@ final readonly class PcovDriver implements CoverageDriver
 
     private function matchesFilter(string $file): bool
     {
-        // Normalize separators: Path uses '/', but PCOV on Windows may return '\'
-        $normalized = \str_replace('\\', '/', $file);
-
         $included = false;
         foreach ($this->includes as $path) {
-            if (\str_starts_with($normalized, $path)) {
+            if (\str_starts_with($file, $path)) {
                 $included = true;
                 break;
             }
@@ -82,7 +91,7 @@ final readonly class PcovDriver implements CoverageDriver
         }
 
         foreach ($this->excludes as $path) {
-            if (\str_starts_with($normalized, $path)) {
+            if (\str_starts_with($file, $path)) {
                 return false;
             }
         }

--- a/src/Codecov/Internal/Driver/XdebugDriver.php
+++ b/src/Codecov/Internal/Driver/XdebugDriver.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov\Internal\Driver;
+
+use Testo\Application\Config\FinderConfig;
+use Testo\Codecov\CoverageDriver;
+
+/**
+ * XDebug-based coverage driver.
+ *
+ * Requires XDebug >= 3.0 with `coverage` mode enabled.
+ *
+ * @internal
+ */
+final readonly class XdebugDriver implements CoverageDriver
+{
+    /**
+     * @param list<non-empty-string> $includes
+     * @param list<non-empty-string> $excludes
+     */
+    public function __construct(
+        private array $includes = [],
+        private array $excludes = [],
+    ) {}
+
+    #[\Override]
+    public function withFilter(FinderConfig $filter): static
+    {
+        return new self(
+            \array_map(\strval(...), $filter->includes),
+            \array_map(\strval(...), $filter->excludes),
+        );
+    }
+
+    #[\Override]
+    public function start(): void
+    {
+        $this->includes !== [] and \xdebug_set_filter(
+            \XDEBUG_FILTER_CODE_COVERAGE,
+            \XDEBUG_PATH_INCLUDE,
+            $this->includes,
+        );
+
+        \xdebug_start_code_coverage(\XDEBUG_CC_UNUSED | \XDEBUG_CC_DEAD_CODE);
+    }
+
+    #[\Override]
+    public function collect(): array
+    {
+        $data = \xdebug_get_code_coverage();
+        \xdebug_stop_code_coverage();
+
+        foreach ($this->excludes as $exclude) {
+            foreach ($data as $filePath => $_) {
+                \str_starts_with($filePath, $exclude) and $data[$filePath] = null;
+            }
+        }
+
+        return \array_filter($data);
+    }
+
+    #[\Override]
+    public function clear(): void
+    {
+        // XDebug clears data on xdebug_stop_code_coverage() by default.
+    }
+}

--- a/src/Codecov/Internal/Driver/XdebugDriver.php
+++ b/src/Codecov/Internal/Driver/XdebugDriver.php
@@ -6,6 +6,8 @@ namespace Testo\Codecov\Internal\Driver;
 
 use Testo\Application\Config\FinderConfig;
 use Testo\Codecov\CoverageDriver;
+use Testo\Codecov\CoverageLevel;
+use Testo\Codecov\Dto\CoverageResult;
 
 /**
  * XDebug-based coverage driver.
@@ -16,6 +18,7 @@ use Testo\Codecov\CoverageDriver;
  */
 final readonly class XdebugDriver implements CoverageDriver
 {
+    use NormalizePath;
     /**
      * @param list<non-empty-string> $includes
      * @param list<non-empty-string> $excludes
@@ -23,6 +26,7 @@ final readonly class XdebugDriver implements CoverageDriver
     public function __construct(
         private array $includes = [],
         private array $excludes = [],
+        private CoverageLevel $level = CoverageLevel::Line,
     ) {
         // Tag files not yet loaded by the autoloader for engine-level filtering.
         // Files already compiled are filtered in collect() as a fallback.
@@ -37,49 +41,54 @@ final readonly class XdebugDriver implements CoverageDriver
     public function withFilter(FinderConfig $filter): static
     {
         return new self(
-            \array_map(\strval(...), $filter->includes),
-            \array_map(\strval(...), $filter->excludes),
+            \array_map(self::normalizePath(...), $filter->includes),
+            \array_map(self::normalizePath(...), $filter->excludes),
+            $this->level,
         );
+    }
+
+    #[\Override]
+    public function withLevel(CoverageLevel $level): static
+    {
+        return new self($this->includes, $this->excludes, $level);
     }
 
     #[\Override]
     public function start(): void
     {
-        \xdebug_start_code_coverage(\XDEBUG_CC_UNUSED | \XDEBUG_CC_DEAD_CODE);
+        $flags = \XDEBUG_CC_UNUSED | \XDEBUG_CC_DEAD_CODE;
+
+        $this->level !== CoverageLevel::Line and $flags |= \XDEBUG_CC_BRANCH_CHECK;
+
+        \xdebug_start_code_coverage($flags);
     }
 
     #[\Override]
-    public function collect(): array
+    public function collect(): CoverageResult
     {
         $data = \xdebug_get_code_coverage();
         \xdebug_stop_code_coverage();
 
-        if ($this->includes === [] && $this->excludes === []) {
-            return $data;
+        if ($this->includes !== [] || $this->excludes !== []) {
+            foreach ($data as $filePath => $_) {
+                if ($this->includes !== [] && !$this->matchesAny($filePath, $this->includes)) {
+                    unset($data[$filePath]);
+                    continue;
+                }
+
+                if ($this->matchesAny($filePath, $this->excludes)) {
+                    unset($data[$filePath]);
+                }
+            }
         }
 
-        $filtered = [];
-        foreach ($data as $filePath => $lines) {
-            $normalized = \str_replace('\\', '/', $filePath);
-
-            if ($this->includes !== [] && !$this->matchesAny($normalized, $this->includes)) {
-                continue;
-            }
-
-            if ($this->matchesAny($normalized, $this->excludes)) {
-                continue;
-            }
-
-            $filtered[$filePath] = $lines;
-        }
-
-        return $filtered;
+        return CoverageResult::fromRawData($data);
     }
 
     #[\Override]
     public function clear(): void
     {
-        // XDebug clears data on \xdebug_stop_code_coverage() by default.
+        // XDebug clears data on \\xdebug_stop_code_coverage() by default.
     }
 
     /**

--- a/src/Codecov/Internal/Driver/XdebugDriver.php
+++ b/src/Codecov/Internal/Driver/XdebugDriver.php
@@ -28,8 +28,8 @@ final readonly class XdebugDriver implements CoverageDriver
         private array $excludes = [],
         private CoverageLevel $level = CoverageLevel::Line,
     ) {
-        // Tag files not yet loaded by the autoloader for engine-level filtering.
-        // Files already compiled are filtered in collect() as a fallback.
+        # Tag files not yet loaded by the autoloader for engine-level filtering.
+        # Files already compiled are filtered in collect() as a fallback.
         $this->includes !== [] and \xdebug_set_filter(
             \XDEBUG_FILTER_CODE_COVERAGE,
             \XDEBUG_PATH_INCLUDE,
@@ -88,7 +88,7 @@ final readonly class XdebugDriver implements CoverageDriver
     #[\Override]
     public function clear(): void
     {
-        // XDebug clears data on \\xdebug_stop_code_coverage() by default.
+        # XDebug clears data on \\xdebug_stop_code_coverage() by default.
     }
 
     /**

--- a/src/Codecov/Internal/Driver/XdebugDriver.php
+++ b/src/Codecov/Internal/Driver/XdebugDriver.php
@@ -23,7 +23,15 @@ final readonly class XdebugDriver implements CoverageDriver
     public function __construct(
         private array $includes = [],
         private array $excludes = [],
-    ) {}
+    ) {
+        // Tag files not yet loaded by the autoloader for engine-level filtering.
+        // Files already compiled are filtered in collect() as a fallback.
+        $this->includes !== [] and \xdebug_set_filter(
+            \XDEBUG_FILTER_CODE_COVERAGE,
+            \XDEBUG_PATH_INCLUDE,
+            $this->includes,
+        );
+    }
 
     #[\Override]
     public function withFilter(FinderConfig $filter): static
@@ -37,12 +45,6 @@ final readonly class XdebugDriver implements CoverageDriver
     #[\Override]
     public function start(): void
     {
-        $this->includes !== [] and \xdebug_set_filter(
-            \XDEBUG_FILTER_CODE_COVERAGE,
-            \XDEBUG_PATH_INCLUDE,
-            $this->includes,
-        );
-
         \xdebug_start_code_coverage(\XDEBUG_CC_UNUSED | \XDEBUG_CC_DEAD_CODE);
     }
 
@@ -52,18 +54,45 @@ final readonly class XdebugDriver implements CoverageDriver
         $data = \xdebug_get_code_coverage();
         \xdebug_stop_code_coverage();
 
-        foreach ($this->excludes as $exclude) {
-            foreach ($data as $filePath => $_) {
-                \str_starts_with($filePath, $exclude) and $data[$filePath] = null;
-            }
+        if ($this->includes === [] && $this->excludes === []) {
+            return $data;
         }
 
-        return \array_filter($data);
+        $filtered = [];
+        foreach ($data as $filePath => $lines) {
+            $normalized = \str_replace('\\', '/', $filePath);
+
+            if ($this->includes !== [] && !$this->matchesAny($normalized, $this->includes)) {
+                continue;
+            }
+
+            if ($this->matchesAny($normalized, $this->excludes)) {
+                continue;
+            }
+
+            $filtered[$filePath] = $lines;
+        }
+
+        return $filtered;
     }
 
     #[\Override]
     public function clear(): void
     {
-        // XDebug clears data on xdebug_stop_code_coverage() by default.
+        // XDebug clears data on \xdebug_stop_code_coverage() by default.
+    }
+
+    /**
+     * @param list<non-empty-string> $prefixes
+     */
+    private function matchesAny(string $path, array $prefixes): bool
+    {
+        foreach ($prefixes as $prefix) {
+            if (\str_starts_with($path, $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Codecov/Internal/Middleware/CoverageTestInterceptor.php
+++ b/src/Codecov/Internal/Middleware/CoverageTestInterceptor.php
@@ -34,10 +34,8 @@ final readonly class CoverageTestInterceptor implements TestRunInterceptor
         try {
             $result = $next($info);
         } finally {
-            $rawData = $this->driver->collect();
+            $coverage = $this->driver->collect();
         }
-
-        $coverage = CoverageResult::fromRawData($rawData);
 
         return $result->withAttribute(CoverageResult::class, $coverage);
     }

--- a/src/Codecov/Internal/Middleware/CoverageTestInterceptor.php
+++ b/src/Codecov/Internal/Middleware/CoverageTestInterceptor.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Testo\Codecov\Internal\Middleware;
 
-use Testo\Application\Config\FinderConfig;
 use Testo\Codecov\CoverageDriver;
 use Testo\Codecov\Dto\CoverageResult;
 use Testo\Core\Context\TestInfo;
@@ -16,16 +15,15 @@ use Testo\Pipeline\Middleware\TestRunInterceptor;
  * Collects per-test code coverage data.
  *
  * Wraps each test execution with driver start/collect calls and attaches
- * the filtered coverage result to the {@see TestResult} attributes.
+ * the coverage result to the {@see TestResult} attributes.
  *
  * @internal
  */
-#[InterceptorOptions(order: InterceptorOptions::ORDER_RIGHT_BEFORE_TEST)]
+#[InterceptorOptions(order: \PHP_INT_MAX)]
 final readonly class CoverageTestInterceptor implements TestRunInterceptor
 {
     public function __construct(
         private CoverageDriver $driver,
-        private FinderConfig $filter,
     ) {}
 
     #[\Override]
@@ -39,7 +37,7 @@ final readonly class CoverageTestInterceptor implements TestRunInterceptor
             $rawData = $this->driver->collect();
         }
 
-        $coverage = CoverageResult::fromRawData($rawData, $this->filter);
+        $coverage = CoverageResult::fromRawData($rawData);
 
         return $result->withAttribute(CoverageResult::class, $coverage);
     }

--- a/src/Codecov/Internal/Middleware/CoverageTestInterceptor.php
+++ b/src/Codecov/Internal/Middleware/CoverageTestInterceptor.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov\Internal\Middleware;
+
+use Testo\Application\Config\FinderConfig;
+use Testo\Codecov\CoverageDriver;
+use Testo\Codecov\Dto\CoverageResult;
+use Testo\Core\Context\TestInfo;
+use Testo\Core\Context\TestResult;
+use Testo\Pipeline\Attribute\InterceptorOptions;
+use Testo\Pipeline\Middleware\TestRunInterceptor;
+
+/**
+ * Collects per-test code coverage data.
+ *
+ * Wraps each test execution with driver start/collect calls and attaches
+ * the filtered coverage result to the {@see TestResult} attributes.
+ *
+ * @internal
+ */
+#[InterceptorOptions(order: InterceptorOptions::ORDER_RIGHT_BEFORE_TEST)]
+final readonly class CoverageTestInterceptor implements TestRunInterceptor
+{
+    public function __construct(
+        private CoverageDriver $driver,
+        private FinderConfig $filter,
+    ) {}
+
+    #[\Override]
+    public function runTest(TestInfo $info, callable $next): TestResult
+    {
+        $this->driver->start();
+
+        try {
+            $result = $next($info);
+        } finally {
+            $rawData = $this->driver->collect();
+        }
+
+        $coverage = CoverageResult::fromRawData($rawData, $this->filter);
+
+        return $result->withAttribute(CoverageResult::class, $coverage);
+    }
+}

--- a/src/Codecov/Report/CloverReport.php
+++ b/src/Codecov/Report/CloverReport.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov\Report;
+
+use Testo\Codecov\Dto\CoverageResult;
+use Testo\Codecov\Dto\FileCoverage;
+use Testo\Codecov\Dto\LineStatus;
+
+/**
+ * Generates a Clover XML coverage report.
+ *
+ * Compatible with CI tools such as SonarQube, Codecov.io, and Atlassian Clover.
+ *
+ * @api
+ */
+final readonly class CloverReport implements CoverageReport
+{
+    public function __construct(
+        /** @var non-empty-string Output file path. */
+        private string $outputPath,
+        private string $projectName = '',
+    ) {}
+
+    #[\Override]
+    public function generate(CoverageResult $result): void
+    {
+        $timestamp = \time();
+
+        $xml = new \XMLWriter();
+        $xml->openMemory();
+        $xml->setIndent(true);
+        $xml->setIndentString('  ');
+
+        $xml->startDocument('1.0', 'UTF-8');
+
+        $xml->startElement('coverage');
+        $xml->writeAttribute('generated', (string) $timestamp);
+
+        $xml->startElement('project');
+        $xml->writeAttribute('timestamp', (string) $timestamp);
+        $this->projectName !== '' and $xml->writeAttribute('name', $this->projectName);
+
+        $totalStatements = 0;
+        $totalCovered = 0;
+        $fileCount = 0;
+
+        foreach ($result->files as $fileCoverage) {
+            [$statements, $covered] = $this->writeFile($xml, $fileCoverage);
+            $totalStatements += $statements;
+            $totalCovered += $covered;
+            $fileCount++;
+        }
+
+        // Project-level metrics
+        $this->writeMetrics($xml, [
+            'files' => $fileCount,
+            'statements' => $totalStatements,
+            'coveredstatements' => $totalCovered,
+            'elements' => $totalStatements,
+            'coveredelements' => $totalCovered,
+            'conditionals' => 0,
+            'coveredconditionals' => 0,
+        ]);
+
+        $xml->endElement(); // project
+        $xml->endElement(); // coverage
+        $xml->endDocument();
+
+        $dir = \dirname($this->outputPath);
+        \is_dir($dir) or \mkdir($dir, 0o755, true);
+        \file_put_contents($this->outputPath, $xml->outputMemory());
+    }
+
+    /**
+     * @return array{int<0, max>, int<0, max>} [statements, covered]
+     */
+    private function writeFile(\XMLWriter $xml, FileCoverage $fileCoverage): array
+    {
+        $xml->startElement('file');
+        $xml->writeAttribute('name', $fileCoverage->path);
+
+        $statements = 0;
+        $covered = 0;
+
+        // Sort lines by number
+        $lines = $fileCoverage->lines;
+        \ksort($lines);
+
+        foreach ($lines as $lineNumber => $status) {
+            if (!$status->isExecutable()) {
+                continue;
+            }
+
+            $count = $status === LineStatus::Executed ? 1 : 0;
+            $statements++;
+            $covered += $count;
+
+            $xml->startElement('line');
+            $xml->writeAttribute('num', (string) $lineNumber);
+            $xml->writeAttribute('type', 'stmt');
+            $xml->writeAttribute('count', (string) $count);
+            $xml->endElement();
+        }
+
+        $this->writeMetrics($xml, [
+            'statements' => $statements,
+            'coveredstatements' => $covered,
+            'elements' => $statements,
+            'coveredelements' => $covered,
+            'conditionals' => 0,
+            'coveredconditionals' => 0,
+        ]);
+
+        $xml->endElement(); // file
+
+        return [$statements, $covered];
+    }
+
+    /**
+     * @param array<string, int> $values
+     */
+    private function writeMetrics(\XMLWriter $xml, array $values): void
+    {
+        $xml->startElement('metrics');
+        foreach ($values as $name => $value) {
+            $xml->writeAttribute($name, (string) $value);
+        }
+        $xml->endElement();
+    }
+}

--- a/src/Codecov/Report/CoberturaReport.php
+++ b/src/Codecov/Report/CoberturaReport.php
@@ -11,6 +11,7 @@ use Testo\Codecov\Dto\LineStatus;
 /**
  * Generates a Cobertura XML coverage report.
  *
+ * When branch/path data is available, fills in branch-rate and per-line condition coverage.
  * Compatible with CI tools such as GitHub Actions, GitLab CI, and Jenkins.
  *
  * @api
@@ -42,21 +43,26 @@ final readonly class CoberturaReport implements CoverageReport
         $packages = $this->groupByPackage($result, $sourceRoot);
 
         // Calculate totals
-        $totalStatements = 0;
-        $totalCovered = 0;
+        $totalLines = 0;
+        $totalLinesCovered = 0;
+        $totalBranches = 0;
+        $totalBranchesCovered = 0;
         foreach ($result->files as $fileCoverage) {
             [$s, $c] = self::countLines($fileCoverage);
-            $totalStatements += $s;
-            $totalCovered += $c;
+            $totalLines += $s;
+            $totalLinesCovered += $c;
+            [$b, $bc] = self::countBranches($fileCoverage);
+            $totalBranches += $b;
+            $totalBranchesCovered += $bc;
         }
 
         $xml->startElement('coverage');
-        $xml->writeAttribute('line-rate', self::rate($totalCovered, $totalStatements));
-        $xml->writeAttribute('branch-rate', '0');
-        $xml->writeAttribute('lines-covered', (string) $totalCovered);
-        $xml->writeAttribute('lines-valid', (string) $totalStatements);
-        $xml->writeAttribute('branches-covered', '0');
-        $xml->writeAttribute('branches-valid', '0');
+        $xml->writeAttribute('line-rate', self::rate($totalLinesCovered, $totalLines));
+        $xml->writeAttribute('branch-rate', self::rate($totalBranchesCovered, $totalBranches));
+        $xml->writeAttribute('lines-covered', (string) $totalLinesCovered);
+        $xml->writeAttribute('lines-valid', (string) $totalLines);
+        $xml->writeAttribute('branches-covered', (string) $totalBranchesCovered);
+        $xml->writeAttribute('branches-valid', (string) $totalBranches);
         $xml->writeAttribute('complexity', '0');
         $xml->writeAttribute('version', '0.4');
         $xml->writeAttribute('timestamp', (string) \time());
@@ -112,18 +118,23 @@ final readonly class CoberturaReport implements CoverageReport
      */
     private function writePackage(\XMLWriter $xml, string $packageName, array $files): void
     {
-        $pkgStatements = 0;
-        $pkgCovered = 0;
+        $pkgLines = 0;
+        $pkgLinesCovered = 0;
+        $pkgBranches = 0;
+        $pkgBranchesCovered = 0;
         foreach ($files as $file) {
             [$s, $c] = self::countLines($file['coverage']);
-            $pkgStatements += $s;
-            $pkgCovered += $c;
+            $pkgLines += $s;
+            $pkgLinesCovered += $c;
+            [$b, $bc] = self::countBranches($file['coverage']);
+            $pkgBranches += $b;
+            $pkgBranchesCovered += $bc;
         }
 
         $xml->startElement('package');
         $xml->writeAttribute('name', $packageName);
-        $xml->writeAttribute('line-rate', self::rate($pkgCovered, $pkgStatements));
-        $xml->writeAttribute('branch-rate', '0');
+        $xml->writeAttribute('line-rate', self::rate($pkgLinesCovered, $pkgLines));
+        $xml->writeAttribute('branch-rate', self::rate($pkgBranchesCovered, $pkgBranches));
         $xml->writeAttribute('complexity', '0');
 
         $xml->startElement('classes');
@@ -138,16 +149,19 @@ final readonly class CoberturaReport implements CoverageReport
     private function writeClass(\XMLWriter $xml, string $relativePath, FileCoverage $fileCoverage): void
     {
         [$statements, $covered] = self::countLines($fileCoverage);
+        [$branches, $branchesCovered] = self::countBranches($fileCoverage);
 
-        // Use filename without extension as class name
         $className = \basename($relativePath, '.php');
 
         $xml->startElement('class');
         $xml->writeAttribute('name', $className);
         $xml->writeAttribute('filename', $relativePath);
         $xml->writeAttribute('line-rate', self::rate($covered, $statements));
-        $xml->writeAttribute('branch-rate', '0');
+        $xml->writeAttribute('branch-rate', self::rate($branchesCovered, $branches));
         $xml->writeAttribute('complexity', '0');
+
+        // Build per-line branch map
+        $lineBranches = self::buildLineBranchMap($fileCoverage);
 
         $xml->startElement('lines');
 
@@ -162,6 +176,14 @@ final readonly class CoberturaReport implements CoverageReport
             $xml->startElement('line');
             $xml->writeAttribute('number', (string) $lineNumber);
             $xml->writeAttribute('hits', $status === LineStatus::Executed ? '1' : '0');
+
+            if (isset($lineBranches[$lineNumber])) {
+                [$brTotal, $brCovered] = $lineBranches[$lineNumber];
+                $xml->writeAttribute('branch', 'true');
+                $pct = $brTotal > 0 ? (int) (100 * $brCovered / $brTotal) : 0;
+                $xml->writeAttribute('condition-coverage', \sprintf('%d%% (%d/%d)', $pct, $brCovered, $brTotal));
+            }
+
             $xml->endElement();
         }
 
@@ -187,6 +209,57 @@ final readonly class CoberturaReport implements CoverageReport
         }
 
         return [$statements, $covered];
+    }
+
+    /**
+     * @return array{int<0, max>, int<0, max>} [total branches, covered branches]
+     */
+    private static function countBranches(FileCoverage $fileCoverage): array
+    {
+        $total = 0;
+        $covered = 0;
+
+        foreach ($fileCoverage->functions as $function) {
+            foreach ($function->branches as $branch) {
+                $total += \count($branch->outHit);
+                $covered += \count(\array_filter($branch->outHit));
+            }
+        }
+
+        return [$total, $covered];
+    }
+
+    /**
+     * Builds a map of line number => [total_branches, covered_branches]
+     * for lines that are branch decision points.
+     *
+     * @return array<int, array{int<0, max>, int<0, max>}>
+     */
+    private static function buildLineBranchMap(FileCoverage $fileCoverage): array
+    {
+        $map = [];
+
+        foreach ($fileCoverage->functions as $function) {
+            foreach ($function->branches as $branch) {
+                // Only mark lines with multiple outgoing edges as branch points
+                if (\count($branch->out) < 2) {
+                    continue;
+                }
+
+                $line = $branch->lineStart;
+                $total = \count($branch->outHit);
+                $covered = \count(\array_filter($branch->outHit));
+
+                if (!isset($map[$line])) {
+                    $map[$line] = [0, 0];
+                }
+
+                $map[$line][0] += $total;
+                $map[$line][1] += $covered;
+            }
+        }
+
+        return $map;
     }
 
     private static function rate(int $covered, int $total): string

--- a/src/Codecov/Report/CoberturaReport.php
+++ b/src/Codecov/Report/CoberturaReport.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov\Report;
+
+use Testo\Codecov\Dto\CoverageResult;
+use Testo\Codecov\Dto\FileCoverage;
+use Testo\Codecov\Dto\LineStatus;
+
+/**
+ * Generates a Cobertura XML coverage report.
+ *
+ * Compatible with CI tools such as GitHub Actions, GitLab CI, and Jenkins.
+ *
+ * @api
+ */
+final readonly class CoberturaReport implements CoverageReport
+{
+    public function __construct(
+        /** @var non-empty-string Output file path. */
+        private string $outputPath,
+        /** @var non-empty-string Source root for relative paths. */
+        private string $sourceRoot = '',
+    ) {}
+
+    #[\Override]
+    public function generate(CoverageResult $result): void
+    {
+        $sourceRoot = $this->sourceRoot !== '' ? $this->sourceRoot : (string) \getcwd();
+        $sourceRoot = \rtrim(\str_replace('\\', '/', $sourceRoot), '/');
+
+        $xml = new \XMLWriter();
+        $xml->openMemory();
+        $xml->setIndent(true);
+        $xml->setIndentString('  ');
+
+        $xml->startDocument('1.0', 'UTF-8');
+        $xml->writeDtd('coverage', null, 'http://cobertura.sourceforge.net/xml/coverage-04.dtd');
+
+        // Group files by directory into packages
+        $packages = $this->groupByPackage($result, $sourceRoot);
+
+        // Calculate totals
+        $totalStatements = 0;
+        $totalCovered = 0;
+        foreach ($result->files as $fileCoverage) {
+            [$s, $c] = self::countLines($fileCoverage);
+            $totalStatements += $s;
+            $totalCovered += $c;
+        }
+
+        $xml->startElement('coverage');
+        $xml->writeAttribute('line-rate', self::rate($totalCovered, $totalStatements));
+        $xml->writeAttribute('branch-rate', '0');
+        $xml->writeAttribute('lines-covered', (string) $totalCovered);
+        $xml->writeAttribute('lines-valid', (string) $totalStatements);
+        $xml->writeAttribute('branches-covered', '0');
+        $xml->writeAttribute('branches-valid', '0');
+        $xml->writeAttribute('complexity', '0');
+        $xml->writeAttribute('version', '0.4');
+        $xml->writeAttribute('timestamp', (string) \time());
+
+        // Sources
+        $xml->startElement('sources');
+        $xml->writeElement('source', $sourceRoot);
+        $xml->endElement();
+
+        // Packages
+        $xml->startElement('packages');
+        foreach ($packages as $packageName => $files) {
+            $this->writePackage($xml, $packageName, $files);
+        }
+        $xml->endElement(); // packages
+
+        $xml->endElement(); // coverage
+        $xml->endDocument();
+
+        $dir = \dirname($this->outputPath);
+        \is_dir($dir) or \mkdir($dir, 0o755, true);
+        \file_put_contents($this->outputPath, $xml->outputMemory());
+    }
+
+    /**
+     * Groups files by their relative directory path.
+     *
+     * @return array<string, list<array{relative: string, coverage: FileCoverage}>>
+     */
+    private function groupByPackage(CoverageResult $result, string $sourceRoot): array
+    {
+        $packages = [];
+
+        foreach ($result->files as $fileCoverage) {
+            $normalized = \str_replace('\\', '/', $fileCoverage->path);
+            $relative = \str_starts_with($normalized, $sourceRoot . '/')
+                ? \substr($normalized, \strlen($sourceRoot) + 1)
+                : $normalized;
+
+            $packageName = \dirname($relative);
+            $packageName === '.' and $packageName = '';
+
+            $packages[$packageName][] = ['relative' => $relative, 'coverage' => $fileCoverage];
+        }
+
+        \ksort($packages);
+
+        return $packages;
+    }
+
+    /**
+     * @param list<array{relative: string, coverage: FileCoverage}> $files
+     */
+    private function writePackage(\XMLWriter $xml, string $packageName, array $files): void
+    {
+        $pkgStatements = 0;
+        $pkgCovered = 0;
+        foreach ($files as $file) {
+            [$s, $c] = self::countLines($file['coverage']);
+            $pkgStatements += $s;
+            $pkgCovered += $c;
+        }
+
+        $xml->startElement('package');
+        $xml->writeAttribute('name', $packageName);
+        $xml->writeAttribute('line-rate', self::rate($pkgCovered, $pkgStatements));
+        $xml->writeAttribute('branch-rate', '0');
+        $xml->writeAttribute('complexity', '0');
+
+        $xml->startElement('classes');
+        foreach ($files as $file) {
+            $this->writeClass($xml, $file['relative'], $file['coverage']);
+        }
+        $xml->endElement(); // classes
+
+        $xml->endElement(); // package
+    }
+
+    private function writeClass(\XMLWriter $xml, string $relativePath, FileCoverage $fileCoverage): void
+    {
+        [$statements, $covered] = self::countLines($fileCoverage);
+
+        // Use filename without extension as class name
+        $className = \basename($relativePath, '.php');
+
+        $xml->startElement('class');
+        $xml->writeAttribute('name', $className);
+        $xml->writeAttribute('filename', $relativePath);
+        $xml->writeAttribute('line-rate', self::rate($covered, $statements));
+        $xml->writeAttribute('branch-rate', '0');
+        $xml->writeAttribute('complexity', '0');
+
+        $xml->startElement('lines');
+
+        $lines = $fileCoverage->lines;
+        \ksort($lines);
+
+        foreach ($lines as $lineNumber => $status) {
+            if (!$status->isExecutable()) {
+                continue;
+            }
+
+            $xml->startElement('line');
+            $xml->writeAttribute('number', (string) $lineNumber);
+            $xml->writeAttribute('hits', $status === LineStatus::Executed ? '1' : '0');
+            $xml->endElement();
+        }
+
+        $xml->endElement(); // lines
+        $xml->endElement(); // class
+    }
+
+    /**
+     * @return array{int<0, max>, int<0, max>} [statements, covered]
+     */
+    private static function countLines(FileCoverage $fileCoverage): array
+    {
+        $statements = 0;
+        $covered = 0;
+
+        foreach ($fileCoverage->lines as $status) {
+            if (!$status->isExecutable()) {
+                continue;
+            }
+
+            $statements++;
+            $status === LineStatus::Executed and $covered++;
+        }
+
+        return [$statements, $covered];
+    }
+
+    private static function rate(int $covered, int $total): string
+    {
+        return $total === 0 ? '0' : \sprintf('%.4f', $covered / $total);
+    }
+}

--- a/src/Codecov/Report/CoverageReport.php
+++ b/src/Codecov/Report/CoverageReport.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Codecov\Report;
+
+use Testo\Codecov\Dto\CoverageResult;
+
+/**
+ * Generates a coverage report in a specific format.
+ *
+ * @api
+ */
+interface CoverageReport
+{
+    public function generate(CoverageResult $result): void;
+}

--- a/testo.php
+++ b/testo.php
@@ -10,6 +10,7 @@ use Testo\Bench\BenchmarkPlugin;
 use Testo\Inline\InlineTestPlugin;
 
 return new ApplicationConfig(
+    src: ['src'],
     suites: \array_merge(
         [
             new SuiteConfig(
@@ -24,7 +25,7 @@ return new ApplicationConfig(
             ),
         ],
         # If running in CI, skip the sandbox
-        \filter_var(dump(\getenv('TESTO_CI')), FILTER_VALIDATE_BOOLEAN) ? [] : [
+        \filter_var(\getenv('TESTO_CI'), FILTER_VALIDATE_BOOLEAN) ? [] : [
             new SuiteConfig(
                 name: 'sandbox',
                 location: new FinderConfig(
@@ -41,4 +42,10 @@ return new ApplicationConfig(
         require 'tests/Output/suites.php',
         require 'tests/Test/suites.php',
     ),
+    plugins: [
+        new \Testo\Codecov\CodecovPlugin(
+            new \Testo\Codecov\Report\CloverReport(__DIR__ . '/clover.xml', 'Testo'),
+            new \Testo\Codecov\Report\CoberturaReport(__DIR__ . '/cobertura.xml'),
+        ),
+    ],
 );

--- a/testo.php
+++ b/testo.php
@@ -41,11 +41,15 @@ return new ApplicationConfig(
         require 'tests/Application/suites.php',
         require 'tests/Output/suites.php',
         require 'tests/Test/suites.php',
+        require 'tests/Codecov/suites.php',
     ),
     plugins: [
         new \Testo\Codecov\CodecovPlugin(
-            new \Testo\Codecov\Report\CloverReport(__DIR__ . '/clover.xml', 'Testo'),
-            new \Testo\Codecov\Report\CoberturaReport(__DIR__ . '/cobertura.xml'),
+            level: \Testo\Codecov\CoverageLevel::Path,
+            reports: [
+                new \Testo\Codecov\Report\CloverReport(__DIR__ . '/clover.xml', 'Testo'),
+                new \Testo\Codecov\Report\CoberturaReport(__DIR__ . '/cobertura.xml'),
+            ],
         ),
     ],
 );

--- a/tests/Codecov/Unit/Dto/BranchCoverageTest.php
+++ b/tests/Codecov/Unit/Dto/BranchCoverageTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Codecov\Unit\Dto;
+
+use Testo\Assert;
+use Testo\Codecov\Dto\BranchCoverage;
+use Testo\Test;
+
+#[Test]
+final class BranchCoverageTest
+{
+    public function mergeHitWins(): void
+    {
+        $a = new BranchCoverage(0, 3, 5, 6, hit: false, out: [4, 7], outHit: [false, false]);
+        $b = new BranchCoverage(0, 3, 5, 6, hit: true, out: [4, 7], outHit: [true, false]);
+
+        $merged = $a->merge($b);
+
+        Assert::true($merged->hit);
+        Assert::same($merged->outHit, [true, false]);
+    }
+
+    public function mergeOutHitCombines(): void
+    {
+        $a = new BranchCoverage(0, 3, 5, 6, hit: true, out: [4, 7], outHit: [true, false]);
+        $b = new BranchCoverage(0, 3, 5, 6, hit: false, out: [4, 7], outHit: [false, true]);
+
+        $merged = $a->merge($b);
+
+        Assert::same($merged->outHit, [true, true]);
+    }
+
+    public function mergePreservesStructuralFields(): void
+    {
+        $a = new BranchCoverage(0, 5, 10, 12, hit: false, out: [6, 9], outHit: [false, false]);
+        $b = new BranchCoverage(0, 5, 10, 12, hit: false, out: [6, 9], outHit: [false, false]);
+
+        $merged = $a->merge($b);
+
+        Assert::same($merged->opStart, 0);
+        Assert::same($merged->opEnd, 5);
+        Assert::same($merged->lineStart, 10);
+        Assert::same($merged->lineEnd, 12);
+        Assert::same($merged->out, [6, 9]);
+    }
+}

--- a/tests/Codecov/Unit/Dto/CoverageResultTest.php
+++ b/tests/Codecov/Unit/Dto/CoverageResultTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Codecov\Unit\Dto;
+
+use Testo\Assert;
+use Testo\Codecov\Dto\CoverageResult;
+use Testo\Codecov\Dto\LineStatus;
+use Testo\Test;
+
+#[Test]
+final class CoverageResultTest
+{
+    public function emptyByDefault(): void
+    {
+        $result = new CoverageResult();
+
+        Assert::same($result->files, []);
+    }
+
+    public function fromRawDataLineOnly(): void
+    {
+        $raw = [
+            '/src/Foo.php' => [5 => 1, 6 => -1, 7 => -2],
+            '/src/Bar.php' => [10 => 1],
+        ];
+
+        // Act
+        $result = CoverageResult::fromRawData($raw);
+
+        // Assert
+        Assert::count($result->files, 2);
+        Assert::same($result->files['/src/Foo.php']->lines[5], LineStatus::Executed);
+        Assert::same($result->files['/src/Foo.php']->lines[6], LineStatus::NotExecuted);
+        Assert::same($result->files['/src/Foo.php']->lines[7], LineStatus::Dead);
+        Assert::same($result->files['/src/Bar.php']->lines[10], LineStatus::Executed);
+    }
+
+    public function fromRawDataSkipsInvalidStatuses(): void
+    {
+        $raw = [
+            '/src/Foo.php' => [5 => 1, 6 => 99],
+        ];
+
+        $result = CoverageResult::fromRawData($raw);
+
+        Assert::count($result->files['/src/Foo.php']->lines, 1);
+    }
+
+    public function fromRawDataSkipsEmptyFiles(): void
+    {
+        $raw = [
+            '/src/Empty.php' => [5 => 99, 6 => 42],
+        ];
+
+        $result = CoverageResult::fromRawData($raw);
+
+        Assert::same($result->files, []);
+    }
+
+    public function fromRawDataBranchFormat(): void
+    {
+        $raw = [
+            '/src/Foo.php' => [
+                'lines' => [5 => 1, 6 => -1],
+                'functions' => [
+                    'Foo->bar' => [
+                        'branches' => [
+                            0 => [
+                                'op_start' => 0,
+                                'op_end' => 3,
+                                'line_start' => 5,
+                                'line_end' => 6,
+                                'hit' => 1,
+                                'out' => [4, 7],
+                                'out_hit' => [1, 0],
+                            ],
+                        ],
+                        'paths' => [
+                            ['path' => [0, 4], 'hit' => 1],
+                            ['path' => [0, 7], 'hit' => 0],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        // Act
+        $result = CoverageResult::fromRawData($raw);
+
+        // Assert lines
+        Assert::same($result->files['/src/Foo.php']->lines[5], LineStatus::Executed);
+        Assert::same($result->files['/src/Foo.php']->lines[6], LineStatus::NotExecuted);
+
+        // Assert functions
+        $functions = $result->files['/src/Foo.php']->functions;
+        Assert::count($functions, 1);
+
+        $fn = $functions['Foo->bar'];
+        Assert::same($fn->name, 'Foo->bar');
+        Assert::count($fn->branches, 1);
+        Assert::true($fn->branches[0]->hit);
+        Assert::same($fn->branches[0]->out, [4, 7]);
+        Assert::count($fn->paths, 2);
+        Assert::true($fn->paths[0]->hit);
+        Assert::false($fn->paths[1]->hit);
+    }
+
+    public function mergeCombinesFiles(): void
+    {
+        $a = CoverageResult::fromRawData([
+            '/src/Foo.php' => [5 => 1],
+        ]);
+        $b = CoverageResult::fromRawData([
+            '/src/Bar.php' => [10 => 1],
+        ]);
+
+        $merged = $a->merge($b);
+
+        Assert::count($merged->files, 2);
+    }
+
+    public function mergeSameFileCombinesLines(): void
+    {
+        $a = CoverageResult::fromRawData([
+            '/src/Foo.php' => [5 => -1, 6 => 1],
+        ]);
+        $b = CoverageResult::fromRawData([
+            '/src/Foo.php' => [5 => 1, 7 => -1],
+        ]);
+
+        $merged = $a->merge($b);
+
+        Assert::count($merged->files, 1);
+        Assert::same($merged->files['/src/Foo.php']->lines[5], LineStatus::Executed);
+        Assert::same($merged->files['/src/Foo.php']->lines[6], LineStatus::Executed);
+        Assert::same($merged->files['/src/Foo.php']->lines[7], LineStatus::NotExecuted);
+    }
+}

--- a/tests/Codecov/Unit/Dto/FileCoverageTest.php
+++ b/tests/Codecov/Unit/Dto/FileCoverageTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Codecov\Unit\Dto;
+
+use Testo\Assert;
+use Testo\Codecov\Dto\FileCoverage;
+use Testo\Codecov\Dto\LineStatus;
+use Testo\Test;
+
+#[Test]
+final class FileCoverageTest
+{
+    public function constructWithLines(): void
+    {
+        $file = new FileCoverage('/src/Foo.php', [
+            5 => LineStatus::Executed,
+            6 => LineStatus::NotExecuted,
+        ]);
+
+        Assert::same($file->path, '/src/Foo.php');
+        Assert::count($file->lines, 2);
+        Assert::same($file->functions, []);
+    }
+
+    public function mergeExecutedWins(): void
+    {
+        $a = new FileCoverage('/src/Foo.php', [
+            5 => LineStatus::Executed,
+            6 => LineStatus::NotExecuted,
+            7 => LineStatus::NotExecuted,
+        ]);
+
+        $b = new FileCoverage('/src/Foo.php', [
+            5 => LineStatus::NotExecuted,
+            6 => LineStatus::Executed,
+            8 => LineStatus::Dead,
+        ]);
+
+        // Act
+        $merged = $a->merge($b);
+
+        // Assert
+        Assert::same($merged->lines[5], LineStatus::Executed);
+        Assert::same($merged->lines[6], LineStatus::Executed);
+        Assert::same($merged->lines[7], LineStatus::NotExecuted);
+        Assert::same($merged->lines[8], LineStatus::Dead);
+    }
+
+    public function mergeReturnsNewInstance(): void
+    {
+        $a = new FileCoverage('/src/Foo.php', [5 => LineStatus::Executed]);
+        $b = new FileCoverage('/src/Foo.php', [6 => LineStatus::Executed]);
+
+        $merged = $a->merge($b);
+
+        Assert::notSame($merged, $a);
+        Assert::notSame($merged, $b);
+    }
+
+    public function mergeDeadDoesNotOverrideNotExecuted(): void
+    {
+        $a = new FileCoverage('/src/Foo.php', [5 => LineStatus::NotExecuted]);
+        $b = new FileCoverage('/src/Foo.php', [5 => LineStatus::Dead]);
+
+        $merged = $a->merge($b);
+
+        Assert::same($merged->lines[5], LineStatus::NotExecuted);
+    }
+}

--- a/tests/Codecov/Unit/Dto/FunctionCoverageTest.php
+++ b/tests/Codecov/Unit/Dto/FunctionCoverageTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Codecov\Unit\Dto;
+
+use Testo\Assert;
+use Testo\Codecov\Dto\BranchCoverage;
+use Testo\Codecov\Dto\FunctionCoverage;
+use Testo\Codecov\Dto\PathCoverage;
+use Testo\Test;
+
+#[Test]
+final class FunctionCoverageTest
+{
+    public function mergeBranchesAndPaths(): void
+    {
+        $a = new FunctionCoverage('Foo->bar', [
+            0 => new BranchCoverage(0, 3, 5, 6, hit: true, out: [4, 7], outHit: [true, false]),
+        ], [
+            new PathCoverage([0, 4], hit: true),
+            new PathCoverage([0, 7], hit: false),
+        ]);
+
+        $b = new FunctionCoverage('Foo->bar', [
+            0 => new BranchCoverage(0, 3, 5, 6, hit: false, out: [4, 7], outHit: [false, true]),
+        ], [
+            new PathCoverage([0, 4], hit: false),
+            new PathCoverage([0, 7], hit: true),
+        ]);
+
+        // Act
+        $merged = $a->merge($b);
+
+        // Assert branches
+        Assert::true($merged->branches[0]->hit);
+        Assert::same($merged->branches[0]->outHit, [true, true]);
+
+        // Assert paths
+        Assert::true($merged->paths[0]->hit);
+        Assert::true($merged->paths[1]->hit);
+    }
+
+    public function mergeAddsNewBranches(): void
+    {
+        $a = new FunctionCoverage('Foo->bar', [
+            0 => new BranchCoverage(0, 3, 5, 6, hit: true, out: [4], outHit: [true]),
+        ], []);
+
+        $b = new FunctionCoverage('Foo->bar', [
+            0 => new BranchCoverage(0, 3, 5, 6, hit: false, out: [4], outHit: [false]),
+            5 => new BranchCoverage(5, 8, 8, 10, hit: true, out: [9], outHit: [true]),
+        ], []);
+
+        $merged = $a->merge($b);
+
+        Assert::count($merged->branches, 2);
+        Assert::true($merged->branches[0]->hit);
+        Assert::true($merged->branches[5]->hit);
+    }
+}

--- a/tests/Codecov/Unit/Dto/LineStatusTest.php
+++ b/tests/Codecov/Unit/Dto/LineStatusTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Codecov\Unit\Dto;
+
+use Testo\Assert;
+use Testo\Codecov\Dto\LineStatus;
+use Testo\Test;
+
+#[Test]
+final class LineStatusTest
+{
+    public function backedValues(): void
+    {
+        Assert::same(LineStatus::Executed->value, 1);
+        Assert::same(LineStatus::NotExecuted->value, -1);
+        Assert::same(LineStatus::Dead->value, -2);
+    }
+
+    public function executedIsExecutable(): void
+    {
+        Assert::true(LineStatus::Executed->isExecutable());
+    }
+
+    public function notExecutedIsExecutable(): void
+    {
+        Assert::true(LineStatus::NotExecuted->isExecutable());
+    }
+
+    public function deadIsNotExecutable(): void
+    {
+        Assert::false(LineStatus::Dead->isExecutable());
+    }
+
+    public function tryFromValidValues(): void
+    {
+        Assert::same(LineStatus::tryFrom(1), LineStatus::Executed);
+        Assert::same(LineStatus::tryFrom(-1), LineStatus::NotExecuted);
+        Assert::same(LineStatus::tryFrom(-2), LineStatus::Dead);
+    }
+
+    public function tryFromInvalidReturnsNull(): void
+    {
+        Assert::null(LineStatus::tryFrom(0));
+        Assert::null(LineStatus::tryFrom(99));
+    }
+}

--- a/tests/Codecov/Unit/Dto/PathCoverageTest.php
+++ b/tests/Codecov/Unit/Dto/PathCoverageTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Codecov\Unit\Dto;
+
+use Testo\Assert;
+use Testo\Codecov\Dto\PathCoverage;
+use Testo\Test;
+
+#[Test]
+final class PathCoverageTest
+{
+    public function mergeHitWins(): void
+    {
+        $a = new PathCoverage([0, 4], hit: false);
+        $b = new PathCoverage([0, 4], hit: true);
+
+        $merged = $a->merge($b);
+
+        Assert::true($merged->hit);
+        Assert::same($merged->path, [0, 4]);
+    }
+
+    public function mergeBothNotHit(): void
+    {
+        $a = new PathCoverage([0, 7], hit: false);
+        $b = new PathCoverage([0, 7], hit: false);
+
+        Assert::false($a->merge($b)->hit);
+    }
+
+    public function mergeBothHit(): void
+    {
+        $a = new PathCoverage([0, 4, 10], hit: true);
+        $b = new PathCoverage([0, 4, 10], hit: true);
+
+        Assert::true($a->merge($b)->hit);
+    }
+}

--- a/tests/Codecov/Unit/Report/CloverReportTest.php
+++ b/tests/Codecov/Unit/Report/CloverReportTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Codecov\Unit\Report;
+
+use Testo\Assert;
+use Testo\Codecov\Dto\CoverageResult;
+use Testo\Codecov\Dto\FileCoverage;
+use Testo\Codecov\Dto\LineStatus;
+use Testo\Codecov\Report\CloverReport;
+use Testo\Test;
+
+#[Test]
+final class CloverReportTest
+{
+    public function generatesValidXml(): void
+    {
+        // Arrange
+        $result = new CoverageResult([
+            '/src/Foo.php' => new FileCoverage('/src/Foo.php', [
+                5 => LineStatus::Executed,
+                6 => LineStatus::NotExecuted,
+                7 => LineStatus::Dead,
+            ]),
+        ]);
+        $path = \sys_get_temp_dir() . '/testo_clover_' . \uniqid() . '.xml';
+
+        // Act
+        (new CloverReport($path, 'TestProject'))->generate($result);
+
+        // Assert
+        $xml = \simplexml_load_file($path);
+        Assert::notSame($xml, false);
+        Assert::same((string) $xml['generated'] !== '', true);
+        Assert::same((string) $xml->project['name'], 'TestProject');
+
+        \unlink($path);
+    }
+
+    public function countsStatementsCorrectly(): void
+    {
+        // Arrange
+        $result = new CoverageResult([
+            '/src/Foo.php' => new FileCoverage('/src/Foo.php', [
+                5 => LineStatus::Executed,
+                6 => LineStatus::Executed,
+                7 => LineStatus::NotExecuted,
+                8 => LineStatus::Dead,
+            ]),
+        ]);
+        $path = \sys_get_temp_dir() . '/testo_clover_' . \uniqid() . '.xml';
+
+        // Act
+        (new CloverReport($path))->generate($result);
+
+        // Assert
+        $xml = \simplexml_load_file($path);
+        $metrics = $xml->project->metrics;
+        Assert::same((string) $metrics['files'], '1');
+        Assert::same((string) $metrics['statements'], '3');
+        Assert::same((string) $metrics['coveredstatements'], '2');
+
+        \unlink($path);
+    }
+
+    public function emptyResultProducesEmptyReport(): void
+    {
+        // Arrange
+        $path = \sys_get_temp_dir() . '/testo_clover_' . \uniqid() . '.xml';
+
+        // Act
+        (new CloverReport($path))->generate(new CoverageResult());
+
+        // Assert
+        $xml = \simplexml_load_file($path);
+        Assert::same((string) $xml->project->metrics['files'], '0');
+        Assert::same((string) $xml->project->metrics['statements'], '0');
+
+        \unlink($path);
+    }
+
+    public function writesLineElements(): void
+    {
+        // Arrange
+        $result = new CoverageResult([
+            '/src/Foo.php' => new FileCoverage('/src/Foo.php', [
+                10 => LineStatus::Executed,
+                20 => LineStatus::NotExecuted,
+            ]),
+        ]);
+        $path = \sys_get_temp_dir() . '/testo_clover_' . \uniqid() . '.xml';
+
+        // Act
+        (new CloverReport($path))->generate($result);
+
+        // Assert
+        $xml = \simplexml_load_file($path);
+        $lines = $xml->project->file->line;
+        Assert::count($lines, 2);
+        Assert::same((string) $lines[0]['num'], '10');
+        Assert::same((string) $lines[0]['count'], '1');
+        Assert::same((string) $lines[1]['num'], '20');
+        Assert::same((string) $lines[1]['count'], '0');
+
+        \unlink($path);
+    }
+}

--- a/tests/Codecov/Unit/Report/CoberturaReportTest.php
+++ b/tests/Codecov/Unit/Report/CoberturaReportTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Codecov\Unit\Report;
+
+use Testo\Assert;
+use Testo\Codecov\Dto\BranchCoverage;
+use Testo\Codecov\Dto\CoverageResult;
+use Testo\Codecov\Dto\FileCoverage;
+use Testo\Codecov\Dto\FunctionCoverage;
+use Testo\Codecov\Dto\LineStatus;
+use Testo\Codecov\Dto\PathCoverage;
+use Testo\Codecov\Report\CoberturaReport;
+use Testo\Test;
+
+#[Test]
+final class CoberturaReportTest
+{
+    public function generatesValidXml(): void
+    {
+        // Arrange
+        $result = new CoverageResult([
+            '/project/src/Foo.php' => new FileCoverage('/project/src/Foo.php', [
+                5 => LineStatus::Executed,
+                6 => LineStatus::NotExecuted,
+            ]),
+        ]);
+        $path = \sys_get_temp_dir() . '/testo_cobertura_' . \uniqid() . '.xml';
+
+        // Act
+        (new CoberturaReport($path, '/project'))->generate($result);
+
+        // Assert
+        $xml = \simplexml_load_file($path);
+        Assert::notSame($xml, false);
+        Assert::same((string) $xml['version'], '0.4');
+        Assert::same((string) $xml['lines-covered'], '1');
+        Assert::same((string) $xml['lines-valid'], '2');
+
+        \unlink($path);
+    }
+
+    public function groupsFilesByPackage(): void
+    {
+        // Arrange
+        $result = new CoverageResult([
+            '/project/src/Core/Foo.php' => new FileCoverage('/project/src/Core/Foo.php', [
+                5 => LineStatus::Executed,
+            ]),
+            '/project/src/Core/Bar.php' => new FileCoverage('/project/src/Core/Bar.php', [
+                10 => LineStatus::Executed,
+            ]),
+            '/project/src/Http/Handler.php' => new FileCoverage('/project/src/Http/Handler.php', [
+                3 => LineStatus::NotExecuted,
+            ]),
+        ]);
+        $path = \sys_get_temp_dir() . '/testo_cobertura_' . \uniqid() . '.xml';
+
+        // Act
+        (new CoberturaReport($path, '/project'))->generate($result);
+
+        // Assert
+        $xml = \simplexml_load_file($path);
+        $packages = $xml->packages->package;
+        Assert::count($packages, 2);
+
+        \unlink($path);
+    }
+
+    public function relativeFilenames(): void
+    {
+        // Arrange
+        $result = new CoverageResult([
+            '/project/src/Foo.php' => new FileCoverage('/project/src/Foo.php', [
+                5 => LineStatus::Executed,
+            ]),
+        ]);
+        $path = \sys_get_temp_dir() . '/testo_cobertura_' . \uniqid() . '.xml';
+
+        // Act
+        (new CoberturaReport($path, '/project'))->generate($result);
+
+        // Assert
+        $xml = \simplexml_load_file($path);
+        $class = $xml->packages->package->classes->class;
+        Assert::same((string) $class['filename'], 'src/Foo.php');
+        Assert::same((string) $class['name'], 'Foo');
+
+        \unlink($path);
+    }
+
+    public function branchDataFillsRates(): void
+    {
+        // Arrange — file with branch data
+        $result = new CoverageResult([
+            '/src/Foo.php' => new FileCoverage('/src/Foo.php', [
+                5 => LineStatus::Executed,
+                6 => LineStatus::NotExecuted,
+            ], [
+                'Foo->bar' => new FunctionCoverage('Foo->bar', [
+                    0 => new BranchCoverage(0, 3, 5, 6, hit: true, out: [4, 7], outHit: [true, false]),
+                ], [
+                    new PathCoverage([0, 4], hit: true),
+                    new PathCoverage([0, 7], hit: false),
+                ]),
+            ]),
+        ]);
+        $path = \sys_get_temp_dir() . '/testo_cobertura_' . \uniqid() . '.xml';
+
+        // Act
+        (new CoberturaReport($path, '/'))->generate($result);
+
+        // Assert
+        $xml = \simplexml_load_file($path);
+
+        // Branch rate should be 0.5 (1 of 2 out_hit)
+        Assert::same((string) $xml['branches-covered'], '1');
+        Assert::same((string) $xml['branches-valid'], '2');
+
+        // Line 5 should have branch="true" with condition-coverage
+        $lines = $xml->packages->package->classes->class->lines->line;
+        $branchLine = null;
+        foreach ($lines as $line) {
+            if ((string) $line['number'] === '5') {
+                $branchLine = $line;
+                break;
+            }
+        }
+
+        Assert::notSame($branchLine, null);
+        Assert::same((string) $branchLine['branch'], 'true');
+        Assert::same((string) $branchLine['condition-coverage'], '50% (1/2)');
+
+        \unlink($path);
+    }
+
+    public function noBranchDataProducesZeroBranchRate(): void
+    {
+        // Arrange
+        $result = new CoverageResult([
+            '/src/Foo.php' => new FileCoverage('/src/Foo.php', [
+                5 => LineStatus::Executed,
+            ]),
+        ]);
+        $path = \sys_get_temp_dir() . '/testo_cobertura_' . \uniqid() . '.xml';
+
+        // Act
+        (new CoberturaReport($path, '/'))->generate($result);
+
+        // Assert
+        $xml = \simplexml_load_file($path);
+        Assert::same((string) $xml['branch-rate'], '0');
+        Assert::same((string) $xml['branches-covered'], '0');
+        Assert::same((string) $xml['branches-valid'], '0');
+
+        \unlink($path);
+    }
+}

--- a/tests/Codecov/suites.php
+++ b/tests/Codecov/suites.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Testo\Application\Config\FinderConfig;
+use Testo\Application\Config\SuiteConfig;
+
+return [
+    new SuiteConfig(
+        name: 'Codecov/Unit',
+        location: new FinderConfig(
+            include: [__DIR__ . '/Unit'],
+        ),
+    ),
+];

--- a/tests/Testo/Self/AssertTest.php
+++ b/tests/Testo/Self/AssertTest.php
@@ -17,7 +17,7 @@ use Tests\Fixture\ClassDataProvider;
 /**
  * Assertion examples.
  */
-final class AsserTest
+final class AssertTest
 {
     #[Test]
     public function simpleAssertions(): void


### PR DESCRIPTION
## What was changed

Added **Codecov plugin** for code coverage collection and XML report generation.

- `CodecovPlugin` with configurable `CoverageLevel` (Line/Branch/Path) and report generators
- `CoverageMode` (Required/Available/Disabled) for safe activation via CLI flags
- `CoverageDriver` interface with immutable `withFilter`/`withLevel`; built-in `XdebugDriver` and `PcovDriver`
- `CloverReport` and `CoberturaReport` (with branch coverage support) implementing `CoverageReport` interface
- Typed DTOs: `CoverageResult`, `FileCoverage`, `FunctionCoverage`, `BranchCoverage`, `PathCoverage`, `LineStatus`
- `CoverageAggregate` merges per-test data on suite finish events, generates reports on destroy
- 34 unit tests for DTOs and reporters
## Why?

<!-- Tell your future self why have you made these changes -->

## Checklist

- Closes #84 
- Tested
  - [x] Tested manually
  - [x] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->
