### PR TITLE
feat(Repeat): Expose `#[Repeat] attribute

### DIFF
--- a/src/Pipeline/Attribute/InterceptorOptions.php
+++ b/src/Pipeline/Attribute/InterceptorOptions.php
@@ -26,12 +26,12 @@ final class InterceptorOptions
 
     public const ORDER_DATA_PROVIDER = -200_000;
 
+    public const ORDER_DEFAULT = 0;
+
     /**
      * Register assertions and expectations
      */
-    public const ORDER_ASSERTIONS = -2_000;
-
-    public const ORDER_DEFAULT = 0;
+    public const ORDER_ASSERTIONS = 2_000;
 
     /**
      * Interceptors that are close to the test function in the interceptor chain.

--- a/src/Repeat.php
+++ b/src/Repeat.php
@@ -6,23 +6,25 @@ namespace Testo;
 
 use Testo\Pipeline\Attribute\FallbackInterceptor;
 use Testo\Pipeline\Attribute\Interceptable;
-use Testo\Repeat\Interceptor\RepeatPolicyRunInterceptor;
+use Testo\Repeat\Internal\RepeatInterceptor;
 
 /**
  * Repeat test specified number of times.
  *
  * Repetition policy that can be applied to any test.
+ * When combined with {@see Retry}, Repeat runs inside Retry: each retry attempt
+ * executes the full repeat cycle, and any single repetition failure triggers the retry logic.
  *
  * @api
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION | \Attribute::TARGET_CLASS)]
-#[FallbackInterceptor(RepeatPolicyRunInterceptor::class)]
+#[FallbackInterceptor(RepeatInterceptor::class)]
 final readonly class Repeat implements Interceptable
 {
+    /**
+     * @param int<1, max> $times Number of times to repeat the test.
+     */
     public function __construct(
-        /**
-         * Number of times to repeat the test.
-         */
         public int $times = 2,
     ) {
         $times > 0 or throw new \InvalidArgumentException('Times must be greater than 0.');

--- a/src/Repeat.php
+++ b/src/Repeat.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo;
+
+use Testo\Pipeline\Attribute\FallbackInterceptor;
+use Testo\Pipeline\Attribute\Interceptable;
+use Testo\Repeat\Interceptor\RepeatPolicyRunInterceptor;
+
+/**
+ * Repeat test specified number of times.
+ *
+ * Repetition policy that can be applied to any test.
+ *
+ * @api
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION | \Attribute::TARGET_CLASS)]
+#[FallbackInterceptor(RepeatPolicyRunInterceptor::class)]
+final readonly class Repeat implements Interceptable
+{
+    public function __construct(
+        /**
+         * Number of times to repeat the test.
+         */
+        public int $times = 2,
+    ) {
+        $times > 0 or throw new \InvalidArgumentException('Times must be greater than 0.');
+    }
+}

--- a/src/Repeat/Interceptor/RepeatPolicyRunInterceptor.php
+++ b/src/Repeat/Interceptor/RepeatPolicyRunInterceptor.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Repeat\Interceptor;
+
+use Testo\Core\Context\TestInfo;
+use Testo\Core\Context\TestResult;
+use Testo\Pipeline\Attribute\InterceptorOptions;
+use Testo\Pipeline\Middleware\TestRunInterceptor;
+use Testo\Pipeline\Policy\ConflictPolicy;
+use Testo\Repeat;
+
+/**
+ * Interceptor that repeats a test execution based on the provided repeat policy.
+ *
+ * @see Repeat
+ *
+ * @api
+ */
+#[InterceptorOptions(order: InterceptorOptions::ORDER_DEFAULT, onConflict: ConflictPolicy::Last)]
+final readonly class RepeatPolicyRunInterceptor implements TestRunInterceptor
+{
+    public function __construct(
+        private Repeat $options,
+    ) {}
+
+    #[\Override]
+    public function runTest(TestInfo $info, callable $next): TestResult
+    {
+        $times = $this->options->times;
+        for ($i = 0; $i < $times; $i++) {
+            $result = $next($info);
+
+            if ($result->status->isFailure()) {
+                return $result;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Repeat/Internal/RepeatInterceptor.php
+++ b/src/Repeat/Internal/RepeatInterceptor.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Testo\Repeat\Interceptor;
+namespace Testo\Repeat\Internal;
 
 use Testo\Core\Context\TestInfo;
 use Testo\Core\Context\TestResult;
@@ -18,8 +18,8 @@ use Testo\Repeat;
  *
  * @api
  */
-#[InterceptorOptions(order: InterceptorOptions::ORDER_DEFAULT, onConflict: ConflictPolicy::Last)]
-final readonly class RepeatPolicyRunInterceptor implements TestRunInterceptor
+#[InterceptorOptions(order: InterceptorOptions::ORDER_DEFAULT - 190, onConflict: ConflictPolicy::Last)]
+final readonly class RepeatInterceptor implements TestRunInterceptor
 {
     public function __construct(
         private Repeat $options,
@@ -29,13 +29,10 @@ final readonly class RepeatPolicyRunInterceptor implements TestRunInterceptor
     public function runTest(TestInfo $info, callable $next): TestResult
     {
         $times = $this->options->times;
-        for ($i = 0; $i < $times; $i++) {
+        \assert($times > 0);
+        do {
             $result = $next($info);
-
-            if ($result->status->isFailure()) {
-                return $result;
-            }
-        }
+        } while (--$times > 0 && !$result->status->isFailure());
 
         return $result;
     }

--- a/src/Repeat/Internal/RepeatInterceptor.php
+++ b/src/Repeat/Internal/RepeatInterceptor.php
@@ -32,7 +32,7 @@ final readonly class RepeatInterceptor implements TestRunInterceptor
         \assert($times > 0);
         do {
             $result = $next($info);
-        } while (--$times > 0 && !$result->status->isFailure());
+        } while (--$times > 0 && !($result->status->isFailure() && $result->status->isCompleted()));
 
         return $result;
     }

--- a/src/Retry.php
+++ b/src/Retry.php
@@ -12,6 +12,8 @@ use Testo\Retry\Interceptor\RetryPolicyRunInterceptor;
  * Retry test on failure.
  *
  * A universal retry policy that can be applied to any test.
+ * When combined with {@see Repeat}, Retry wraps Repeat: each retry attempt
+ * runs the full repeat cycle. If any repetition fails, Retry decides whether to try again.
  *
  * @api
  */
@@ -19,15 +21,12 @@ use Testo\Retry\Interceptor\RetryPolicyRunInterceptor;
 #[FallbackInterceptor(RetryPolicyRunInterceptor::class)]
 final readonly class Retry implements Interceptable
 {
+    /**
+     * @param int<1, max> $maxAttempts Maximum number of attempts.
+     * @param bool $markFlaky Mark the test as flaky if it passed on retry.
+     */
     public function __construct(
-        /**
-         * Maximum number of attempts.
-         */
         public int $maxAttempts = 3,
-
-        /**
-         * Mark the test as flaky if it passed on retry.
-         */
         public bool $markFlaky = true,
     ) {}
 }

--- a/src/Retry/Interceptor/RetryPolicyRunInterceptor.php
+++ b/src/Retry/Interceptor/RetryPolicyRunInterceptor.php
@@ -21,7 +21,7 @@ use Testo\Retry;
  *
  * @api
  */
-#[InterceptorOptions(order: InterceptorOptions::ORDER_DEFAULT, onConflict: ConflictPolicy::Last)]
+#[InterceptorOptions(order: InterceptorOptions::ORDER_DEFAULT - 200, onConflict: ConflictPolicy::Last)]
 final readonly class RetryPolicyRunInterceptor implements TestRunInterceptor
 {
     public function __construct(

--- a/tests/Repeat/Feature/RepeatFeatureTest.php
+++ b/tests/Repeat/Feature/RepeatFeatureTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Repeat\Feature;
+
+use Testo\Assert;
+use Testo\Core\Value\Status;
+use Testo\Test;
+use Testo\Testing\Attribute\TestingSuite;
+use Testo\Testing\Traits\TestRunner;
+use Tests\Repeat\Stub\RepeatClassLevelStub;
+use Tests\Repeat\Stub\RepeatFailingStub;
+use Tests\Repeat\Stub\RepeatPassingStub;
+
+#[TestingSuite(path: __DIR__ . '/../Stub')]
+final class RepeatFeatureTest
+{
+    #[Test]
+    public function defaultRepeatPasses(): void
+    {
+        $result = TestRunner::runTest([RepeatPassingStub::class, 'defaultRepeat']);
+
+        Assert::same($result->status, Status::Passed);
+    }
+
+    #[Test]
+    public function repeatThreeTimesPasses(): void
+    {
+        $result = TestRunner::runTest([RepeatPassingStub::class, 'repeatThreeTimes']);
+
+        Assert::same($result->status, Status::Passed);
+    }
+
+    #[Test]
+    public function repeatOncePasses(): void
+    {
+        $result = TestRunner::runTest([RepeatPassingStub::class, 'repeatOnce']);
+
+        Assert::same($result->status, Status::Passed);
+    }
+
+    #[Test]
+    public function failsOnSecondIteration(): void
+    {
+        $result = TestRunner::runTest([RepeatFailingStub::class, 'failsOnSecondIteration']);
+
+        Assert::same($result->status, Status::Failed);
+    }
+
+    #[Test]
+    public function failsImmediately(): void
+    {
+        $result = TestRunner::runTest([RepeatFailingStub::class, 'failsImmediately']);
+
+        Assert::same($result->status, Status::Failed);
+    }
+
+    #[Test]
+    public function classLevelRepeatFirstTest(): void
+    {
+        $result = TestRunner::runTest([RepeatClassLevelStub::class, 'firstTest']);
+
+        Assert::same($result->status, Status::Passed);
+    }
+
+    #[Test]
+    public function classLevelRepeatSecondTest(): void
+    {
+        $result = TestRunner::runTest([RepeatClassLevelStub::class, 'secondTest']);
+
+        Assert::same($result->status, Status::Passed);
+    }
+}

--- a/tests/Repeat/Stub/RepeatClassLevelStub.php
+++ b/tests/Repeat/Stub/RepeatClassLevelStub.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Repeat\Stub;
+
+use Testo\Assert;
+use Testo\Repeat;
+use Testo\Test;
+
+/**
+ * Stub with class-level #[Repeat] attribute.
+ */
+#[Repeat(times: 2)]
+final class RepeatClassLevelStub
+{
+    #[Test]
+    public function firstTest(): void
+    {
+        Assert::true(true);
+    }
+
+    #[Test]
+    public function secondTest(): void
+    {
+        Assert::true(true);
+    }
+}

--- a/tests/Repeat/Stub/RepeatFailingStub.php
+++ b/tests/Repeat/Stub/RepeatFailingStub.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Repeat\Stub;
+
+use Testo\Assert;
+use Testo\Repeat;
+use Testo\Test;
+
+/**
+ * Stub with tests that fail during repetition.
+ */
+final class RepeatFailingStub
+{
+    /**
+     * Passes first time, fails on second iteration.
+     */
+    #[Test]
+    #[Repeat(times: 3)]
+    public function failsOnSecondIteration(): void
+    {
+        static $counter = 0;
+        ++$counter;
+        // First call passes, second call fails
+        Assert::same($counter, 1);
+    }
+
+    /**
+     * Fails on first iteration - repeat doesn't help.
+     */
+    #[Test]
+    #[Repeat(times: 3)]
+    public function failsImmediately(): void
+    {
+        Assert::same(1, 2);
+    }
+}

--- a/tests/Repeat/Stub/RepeatPassingStub.php
+++ b/tests/Repeat/Stub/RepeatPassingStub.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Repeat\Stub;
+
+use Testo\Assert;
+use Testo\Repeat;
+use Testo\Test;
+
+/**
+ * Stub with passing repeated tests.
+ */
+final class RepeatPassingStub
+{
+    /**
+     * Default repeat (2 times), all pass.
+     */
+    #[Test]
+    #[Repeat]
+    public function defaultRepeat(): void
+    {
+        Assert::true(true);
+    }
+
+    /**
+     * Repeat 3 times, all pass.
+     */
+    #[Test]
+    #[Repeat(times: 3)]
+    public function repeatThreeTimes(): void
+    {
+        Assert::true(true);
+    }
+
+    /**
+     * Repeat once - equivalent to a normal test.
+     */
+    #[Test]
+    #[Repeat(times: 1)]
+    public function repeatOnce(): void
+    {
+        Assert::true(true);
+    }
+}

--- a/tests/Repeat/Unit/RepeatInterceptorTest.php
+++ b/tests/Repeat/Unit/RepeatInterceptorTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Repeat\Unit;
+
+use Testo\Assert;
+use Testo\Core\Context\CaseInfo;
+use Testo\Core\Context\TestInfo;
+use Testo\Core\Context\TestResult;
+use Testo\Core\Definition\CaseDefinition;
+use Testo\Core\Definition\TestDefinition;
+use Testo\Core\Value\Status;
+use Testo\Repeat;
+use Testo\Repeat\Internal\RepeatInterceptor;
+use Testo\Test;
+
+#[Test]
+final class RepeatInterceptorTest
+{
+    public function runsTestSpecifiedNumberOfTimes(): void
+    {
+        // Arrange
+        $interceptor = new RepeatInterceptor(new Repeat(times: 3));
+        $info = self::createTestInfo();
+        $callCount = 0;
+        $next = static function (TestInfo $info) use (&$callCount): TestResult {
+            $callCount++;
+            return new TestResult(info: $info, status: Status::Passed);
+        };
+
+        // Act
+        $result = $interceptor->runTest($info, $next);
+
+        // Assert
+        Assert::same($callCount, 3);
+        Assert::same($result->status, Status::Passed);
+    }
+
+    public function defaultRepeatRunsTestTwice(): void
+    {
+        // Arrange
+        $interceptor = new RepeatInterceptor(new Repeat());
+        $info = self::createTestInfo();
+        $callCount = 0;
+        $next = static function (TestInfo $info) use (&$callCount): TestResult {
+            $callCount++;
+            return new TestResult(info: $info, status: Status::Passed);
+        };
+
+        // Act
+        $interceptor->runTest($info, $next);
+
+        // Assert
+        Assert::same($callCount, 2);
+    }
+
+    public function stopsOnFailure(): void
+    {
+        // Arrange
+        $interceptor = new RepeatInterceptor(new Repeat(times: 5));
+        $info = self::createTestInfo();
+        $callCount = 0;
+        $next = static function (TestInfo $info) use (&$callCount): TestResult {
+            $callCount++;
+            if ($callCount === 2) {
+                return new TestResult(info: $info, status: Status::Failed);
+            }
+            return new TestResult(info: $info, status: Status::Passed);
+        };
+
+        // Act
+        $result = $interceptor->runTest($info, $next);
+
+        // Assert
+        Assert::same($callCount, 2);
+        Assert::same($result->status, Status::Failed);
+    }
+
+    public function stopsOnError(): void
+    {
+        // Arrange
+        $interceptor = new RepeatInterceptor(new Repeat(times: 3));
+        $info = self::createTestInfo();
+        $callCount = 0;
+        $next = static function (TestInfo $info) use (&$callCount): TestResult {
+            $callCount++;
+            return new TestResult(info: $info, status: Status::Error);
+        };
+
+        // Act
+        $result = $interceptor->runTest($info, $next);
+
+        // Assert
+        Assert::same($callCount, 1);
+        Assert::same($result->status, Status::Error);
+    }
+
+    public function returnsLastSuccessfulResult(): void
+    {
+        // Arrange
+        $interceptor = new RepeatInterceptor(new Repeat(times: 3));
+        $info = self::createTestInfo();
+        $iteration = 0;
+        $next = static function (TestInfo $info) use (&$iteration): TestResult {
+            $iteration++;
+            return new TestResult(info: $info, status: Status::Passed, result: $iteration);
+        };
+
+        // Act
+        $result = $interceptor->runTest($info, $next);
+
+        // Assert
+        Assert::same($result->result, 3);
+    }
+
+    public function singleRepeatRunsOnce(): void
+    {
+        // Arrange
+        $interceptor = new RepeatInterceptor(new Repeat(times: 1));
+        $info = self::createTestInfo();
+        $callCount = 0;
+        $next = static function (TestInfo $info) use (&$callCount): TestResult {
+            $callCount++;
+            return new TestResult(info: $info, status: Status::Passed);
+        };
+
+        // Act
+        $interceptor->runTest($info, $next);
+
+        // Assert
+        Assert::same($callCount, 1);
+    }
+
+    public function continuesOnNonFailureStatuses(): void
+    {
+        // Arrange
+        $interceptor = new RepeatInterceptor(new Repeat(times: 3));
+        $info = self::createTestInfo();
+        $callCount = 0;
+        $next = static function (TestInfo $info) use (&$callCount): TestResult {
+            $callCount++;
+            return new TestResult(info: $info, status: Status::Risky);
+        };
+
+        // Act
+        $result = $interceptor->runTest($info, $next);
+
+        // Assert
+        Assert::same($callCount, 3);
+        Assert::same($result->status, Status::Risky);
+    }
+
+    public function passesTestInfoToNext(): void
+    {
+        // Arrange
+        $interceptor = new RepeatInterceptor(new Repeat(times: 2));
+        $info = self::createTestInfo();
+        $receivedInfos = [];
+        $next = static function (TestInfo $receivedInfo) use (&$receivedInfos): TestResult {
+            $receivedInfos[] = $receivedInfo;
+            return new TestResult(info: $receivedInfo, status: Status::Passed);
+        };
+
+        // Act
+        $interceptor->runTest($info, $next);
+
+        // Assert
+        Assert::same(\count($receivedInfos), 2);
+        Assert::same($receivedInfos[0], $info);
+        Assert::same($receivedInfos[1], $info);
+    }
+
+    private static function createTestInfo(): TestInfo
+    {
+        $reflection = new \ReflectionMethod(self::class, 'createTestInfo');
+        $caseDefinition = new CaseDefinition(name: 'TestCase', type: 'test');
+        $caseInfo = new CaseInfo(definition: $caseDefinition);
+        $testDefinition = new TestDefinition(reflection: $reflection);
+
+        return new TestInfo(
+            name: 'testMethod',
+            caseInfo: $caseInfo,
+            testDefinition: $testDefinition,
+        );
+    }
+}

--- a/tests/Repeat/Unit/RepeatInterceptorTest.php
+++ b/tests/Repeat/Unit/RepeatInterceptorTest.php
@@ -11,6 +11,8 @@ use Testo\Core\Context\TestResult;
 use Testo\Core\Definition\CaseDefinition;
 use Testo\Core\Definition\TestDefinition;
 use Testo\Core\Value\Status;
+use Testo\Data\DataProvider;
+use Testo\Data\DataSet;
 use Testo\Repeat;
 use Testo\Repeat\Internal\RepeatInterceptor;
 use Testo\Test;
@@ -55,7 +57,43 @@ final class RepeatInterceptorTest
         Assert::same($callCount, 2);
     }
 
-    public function stopsOnFailure(): void
+    public function singleRepeatRunsOnce(): void
+    {
+        // Arrange
+        $interceptor = new RepeatInterceptor(new Repeat(times: 1));
+        $info = self::createTestInfo();
+        $callCount = 0;
+        $next = static function (TestInfo $info) use (&$callCount): TestResult {
+            $callCount++;
+            return new TestResult(info: $info, status: Status::Passed);
+        };
+
+        // Act
+        $interceptor->runTest($info, $next);
+
+        // Assert
+        Assert::same($callCount, 1);
+    }
+
+    public function returnsLastSuccessfulResult(): void
+    {
+        // Arrange
+        $interceptor = new RepeatInterceptor(new Repeat(times: 3));
+        $info = self::createTestInfo();
+        $iteration = 0;
+        $next = static function (TestInfo $info) use (&$iteration): TestResult {
+            $iteration++;
+            return new TestResult(info: $info, status: Status::Passed, result: $iteration);
+        };
+
+        // Act
+        $result = $interceptor->runTest($info, $next);
+
+        // Assert
+        Assert::same($result->result, 3);
+    }
+
+    public function stopsOnFailureMidway(): void
     {
         // Arrange
         $interceptor = new RepeatInterceptor(new Repeat(times: 5));
@@ -77,78 +115,34 @@ final class RepeatInterceptorTest
         Assert::same($result->status, Status::Failed);
     }
 
-    public function stopsOnError(): void
+    /**
+     * Verifies repeat behavior per status: failure statuses stop the loop, others continue.
+     */
+    #[DataSet([Status::Passed, false])]
+    #[DataSet([Status::Risky, false])]
+    #[DataSet([Status::Flaky, false])]
+    #[DataSet([Status::Skipped, false])]
+    #[DataSet([Status::Cancelled, false])]
+    #[DataSet([Status::Aborted, false])]
+    #[DataSet([Status::Failed, true])]
+    #[DataSet([Status::Error, true])]
+    public function statusBehavior(Status $status, bool $stopsLoop): void
     {
         // Arrange
         $interceptor = new RepeatInterceptor(new Repeat(times: 3));
         $info = self::createTestInfo();
         $callCount = 0;
-        $next = static function (TestInfo $info) use (&$callCount): TestResult {
+        $next = static function (TestInfo $info) use (&$callCount, $status): TestResult {
             $callCount++;
-            return new TestResult(info: $info, status: Status::Error);
+            return new TestResult(info: $info, status: $status);
         };
 
         // Act
         $result = $interceptor->runTest($info, $next);
 
         // Assert
-        Assert::same($callCount, 1);
-        Assert::same($result->status, Status::Error);
-    }
-
-    public function returnsLastSuccessfulResult(): void
-    {
-        // Arrange
-        $interceptor = new RepeatInterceptor(new Repeat(times: 3));
-        $info = self::createTestInfo();
-        $iteration = 0;
-        $next = static function (TestInfo $info) use (&$iteration): TestResult {
-            $iteration++;
-            return new TestResult(info: $info, status: Status::Passed, result: $iteration);
-        };
-
-        // Act
-        $result = $interceptor->runTest($info, $next);
-
-        // Assert
-        Assert::same($result->result, 3);
-    }
-
-    public function singleRepeatRunsOnce(): void
-    {
-        // Arrange
-        $interceptor = new RepeatInterceptor(new Repeat(times: 1));
-        $info = self::createTestInfo();
-        $callCount = 0;
-        $next = static function (TestInfo $info) use (&$callCount): TestResult {
-            $callCount++;
-            return new TestResult(info: $info, status: Status::Passed);
-        };
-
-        // Act
-        $interceptor->runTest($info, $next);
-
-        // Assert
-        Assert::same($callCount, 1);
-    }
-
-    public function continuesOnNonFailureStatuses(): void
-    {
-        // Arrange
-        $interceptor = new RepeatInterceptor(new Repeat(times: 3));
-        $info = self::createTestInfo();
-        $callCount = 0;
-        $next = static function (TestInfo $info) use (&$callCount): TestResult {
-            $callCount++;
-            return new TestResult(info: $info, status: Status::Risky);
-        };
-
-        // Act
-        $result = $interceptor->runTest($info, $next);
-
-        // Assert
-        Assert::same($callCount, 3);
-        Assert::same($result->status, Status::Risky);
+        Assert::same($callCount, $stopsLoop ? 1 : 3);
+        Assert::same($result->status, $status);
     }
 
     public function passesTestInfoToNext(): void

--- a/tests/Repeat/Unit/RepeatTest.php
+++ b/tests/Repeat/Unit/RepeatTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Repeat\Unit;
+
+use Testo\Assert;
+use Testo\Assert\ExpectException;
+use Testo\Repeat;
+use Testo\Test;
+
+#[Test]
+final class RepeatTest
+{
+    public function defaultTimesIsTwo(): void
+    {
+        // Act
+        $repeat = new Repeat();
+
+        // Assert
+        Assert::same($repeat->times, 2);
+    }
+
+    public function customTimes(): void
+    {
+        // Act
+        $repeat = new Repeat(times: 5);
+
+        // Assert
+        Assert::same($repeat->times, 5);
+    }
+
+    public function timesOneIsValid(): void
+    {
+        // Act
+        $repeat = new Repeat(times: 1);
+
+        // Assert
+        Assert::same($repeat->times, 1);
+    }
+
+    #[ExpectException(\InvalidArgumentException::class)]
+    public function zeroTimesThrowsException(): void
+    {
+        new Repeat(times: 0);
+    }
+
+    #[ExpectException(\InvalidArgumentException::class)]
+    public function negativeTimesThrowsException(): void
+    {
+        new Repeat(times: -1);
+    }
+}

--- a/tests/Repeat/suites.php
+++ b/tests/Repeat/suites.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Testo\Application\Config\FinderConfig;
+use Testo\Application\Config\SuiteConfig;
+
+/**
+ * Test suites for Repeat component.
+ */
+return [
+    new SuiteConfig(
+        name: 'Repeat: Unit',
+        location: new FinderConfig(
+            include: [__DIR__ . '/Unit'],
+        ),
+    ),
+    new SuiteConfig(
+        name: 'Repeat: Feature',
+        location: new FinderConfig(
+            include: [__DIR__ . '/Feature'],
+        ),
+    ),
+];

--- a/tests/Testo/Self/AssertTest.php
+++ b/tests/Testo/Self/AssertTest.php
@@ -10,6 +10,7 @@ use Testo\Assert\State\AssertException;
 use Testo\Data\DataProvider;
 use Testo\Data\DataSet;
 use Testo\Expect;
+use Testo\Repeat;
 use Testo\Retry;
 use Testo\Test;
 use Tests\Fixture\ClassDataProvider;
@@ -49,6 +50,24 @@ final class AssertTest
         $nested = new \RuntimeException('Inner exception');
         $e = new \InvalidArgumentException('Outer exception', 42, $nested);
         throw new \RuntimeException('Test exception with previous', 69, $e);
+    }
+
+    #[Test]
+    #[Repeat()]
+    public function repeatSuccess(): void
+    {
+        static $counter = 0;
+        ++$counter;
+        $counter > 1 ? Assert::same(2, $counter) : Assert::same(1, $counter);
+    }
+
+    #[Test]
+    #[Repeat(times: 3)]
+    public function repeatFail(): void
+    {
+        static $counter = 0;
+        ++$counter;
+        Assert::int($counter)->lessThanOrEqual(2);
     }
 
     #[Test]

--- a/tests/Testo/Self/AssertTest.php
+++ b/tests/Testo/Self/AssertTest.php
@@ -62,12 +62,18 @@ final class AssertTest
     }
 
     #[Test]
+    #[Retry(maxAttempts: 3)]
     #[Repeat(times: 3)]
     public function repeatFail(): void
     {
         static $counter = 0;
         ++$counter;
-        Assert::int($counter)->lessThanOrEqual(2);
+        try {
+            Assert::int($counter)->lessThanOrEqual(2);
+        } catch (\Throwable $t) {
+            $counter = 0;
+            throw $t;
+        }
     }
 
     #[Test]


### PR DESCRIPTION
## What was changed

Added a new `#[Repeat]` attribute and its `RepeatPolicyRunInterceptor`.

The attribute can be applied to test methods, functions, and classes. It reruns the same test a fixed number of times using the `times` argument, following the same attribute/interceptor pattern already used by `#[Retry]`.

Self-tests were also added to cover:
- successful repetition with the default `times = 2`
- stopping on the first failure during repeated execution

See commit history for details.

## Why?

Issue #111 asks for a `#[Repeat]` attribute.

The implementation follows the maintainer’s guidance to use `#[Retry]` as the template and keep the design consistent with the current attribute pipeline in Testo.

One important design decision in this PR is that `#[Repeat]` stops on the first failed or errored execution and returns that `TestResult` immediately, instead of continuing all remaining repetitions. This keeps the behavior simple and matches the current single-result execution model.

## Checklist

- Closes #111
- Tested
  - [x] Tested manually
  - [x] Unit tests added - actually just new cases for old AssertTest file
- [ ] Documentation

