### PR TITLE
feat(Assert): Add `Expect::exception()` strictness mode

### DIFF
--- a/src/Assert/Api/ExpectedException.php
+++ b/src/Assert/Api/ExpectedException.php
@@ -32,11 +32,15 @@ interface ExpectedException
 
     /**
      * The expected exception should have the exact message.
+     *
+     * Subsequent calls replace the previous expectation.
      */
     public function withMessage(string $message): static;
 
     /**
      * The expected exception message should match the given pattern.
+     *
+     * Subsequent calls replace the previous expectation.
      *
      * @param non-empty-string $pattern Regex pattern.
      */
@@ -45,6 +49,8 @@ interface ExpectedException
     /**
      * The expected exception message should contain the given substring.
      *
+     * Can be called multiple times — the message must contain every specified substring.
+     *
      * @param non-empty-string $substring Substring to search for.
      */
     public function withMessageContaining(string $substring): static;
@@ -52,17 +58,23 @@ interface ExpectedException
     /**
      * The expected exception should have the given code or one of the given codes.
      *
-     * @param int|list<int> $code Expected code or list of expected codes.
+     * Subsequent calls replace the previous expectation.
+     *
+     * @param int|list<int> $code Expected code or list of acceptable codes.
      */
     public function withCode(int|array $code): static;
 
     /**
      * The expected exception should not have a previous exception.
+     *
+     * Subsequent calls have no additional effect.
      */
     public function withoutPrevious(): static;
 
     /**
      * The expected exception was caused by the given previous exception.
+     *
+     * Subsequent calls replace the previous expectation.
      *
      * @param class-string|\Throwable $classOrObject Expected previous exception class, interface, or an object.
      * @param (callable(self): mixed)|null $assertion Optional assertion callback for the previous exception.

--- a/src/Assert/Internal/ExpectExceptionConfigurator.php
+++ b/src/Assert/Internal/ExpectExceptionConfigurator.php
@@ -19,10 +19,10 @@ use Testo\Pipeline\Middleware\TestRunInterceptor;
  * @psalm-internal Testo\Assert
  */
 #[InterceptorOptions(order: InterceptorOptions::ORDER_ASSERTIONS + 10)]
-final class ExpectExceptionConfigurator implements TestRunInterceptor
+final readonly class ExpectExceptionConfigurator implements TestRunInterceptor
 {
     public function __construct(
-        private readonly ExpectException $options,
+        private ExpectException $options,
     ) {}
 
     #[\Override]
@@ -30,9 +30,7 @@ final class ExpectExceptionConfigurator implements TestRunInterceptor
     {
         $context = StaticState::current() ?? throw new StateNotFound();
 
-        $context->expectations[] = new ExpectExceptionHandler(
-            classOrObject: $this->options->class,
-        );
+        $context->expectations[] = ExpectExceptionHandler::createEquals($this->options->class);
 
         return $next($info);
     }

--- a/src/Assert/Internal/Expectation/ExpectExceptionHandler.php
+++ b/src/Assert/Internal/Expectation/ExpectExceptionHandler.php
@@ -41,13 +41,19 @@ final class ExpectExceptionHandler implements ExpectedException
     private ?array $expectedPrevious = null;
 
     /**
-     * @param class-string|\Throwable $classOrObject Expected exception. A class-string triggers an
-     *        `instanceof` check; an object triggers an identity check (`===`). Equivalence
-     *        comparison is built on top by {@see self::createEquals()} via {@see self::withMessage()}
-     *        and {@see self::withCode()}.
+     * @param class-string|\Throwable $classOrObject Expected exception. The type-check mode is
+     *        determined by the input type and {@see $strictClass}:
+     *        - object → identity (`$actual === $classOrObject`),
+     *        - class-string + `$strictClass = false` → `instanceof` (default),
+     *        - class-string + `$strictClass = true` → exact class match (no subclasses).
+     *        Equivalence comparison (instanceof + message + code) is built on top by
+     *        {@see self::createEquals()} via {@see self::withMessage()} and {@see self::withCode()}.
+     * @param bool $strictClass Only meaningful for class-string input; selects exact class match
+     *        instead of `instanceof`.
      */
     private function __construct(
         public readonly string|\Throwable $classOrObject,
+        private readonly bool $strictClass = false,
     ) {}
 
     /**
@@ -75,17 +81,18 @@ final class ExpectExceptionHandler implements ExpectedException
     }
 
     /**
-     * Create a handler in identity mode.
+     * Create a handler that performs the strictest comparison the input allows.
      *
-     * The actual exception must be the very same instance (`===`) as the given one. Use for
-     * verifying that an exception propagates unchanged through middleware, decorators, or rethrow
-     * points.
+     * - class-string ⇒ exact class match (subclasses rejected),
+     * - object ⇒ identity (`===`, the very same instance must be thrown).
      *
-     * @param \Throwable $classOrObject The exact instance that must be thrown.
+     * @param class-string|\Throwable $classOrObject Expected exception class or the exact instance.
      */
-    public static function createSame(\Throwable $classOrObject): self
+    public static function createSame(string|\Throwable $classOrObject): self
     {
-        return new self($classOrObject);
+        return \is_string($classOrObject)
+            ? new self($classOrObject, strictClass: true)
+            : new self($classOrObject);
     }
 
     /**
@@ -160,24 +167,41 @@ final class ExpectExceptionHandler implements ExpectedException
     {
         $isObject = \is_object($this->classOrObject);
         $class = $isObject ? $this->classOrObject::class : $this->classOrObject;
+        $headline = match (true) {
+            $isObject => 'the same ' . $class . ' instance is thrown',
+            $this->strictClass => 'exactly ' . $class . ' is thrown',
+            default => 'exception of type ' . $class . ' is thrown',
+        };
         $composite = new ExpectationComposite(
-            expectation: $isObject
-                ? 'the same ' . $class . ' instance is thrown'
-                : 'exception of type ' . $class . ' is thrown',
+            expectation: $headline,
             context: '',
         );
 
-        # Type check: identity (object input) vs instanceof (class-string input)
+        # Type check: identity (object) | exact class (strictClass) | instanceof (default)
         if ($isObject) {
             if ($actual === $this->classOrObject) {
-                $composite->success('the same ' . $class . ' instance is thrown');
+                $composite->success($headline);
             } else {
                 $composite->fail(
-                    expectation: 'the same ' . $class . ' instance is thrown',
+                    expectation: $headline,
                     reason: $actual === null
                         ? 'none thrown'
                         : ($actual instanceof $class
                             ? 'got a different ' . $class . ' instance'
+                            : 'got ' . $actual::class),
+                );
+                return $composite;
+            }
+        } elseif ($this->strictClass) {
+            if ($actual !== null && $actual::class === $class) {
+                $composite->success($headline);
+            } else {
+                $composite->fail(
+                    expectation: $headline,
+                    reason: $actual === null
+                        ? 'none thrown'
+                        : ($actual instanceof $class
+                            ? 'got ' . $actual::class . ' (subclass of ' . $class . ')'
                             : 'got ' . $actual::class),
                 );
                 return $composite;

--- a/src/Assert/Internal/Expectation/ExpectExceptionHandler.php
+++ b/src/Assert/Internal/Expectation/ExpectExceptionHandler.php
@@ -32,8 +32,8 @@ final class ExpectExceptionHandler implements ExpectedException
     /** @var list<non-empty-string> */
     private array $expectedMessageContaining = [];
 
-    /** @var list<int|list<int>> */
-    private array $expectedCodes = [];
+    /** @var list<int>|null */
+    private ?array $expectedCodes = null;
 
     private bool $expectNoPrevious = false;
 
@@ -41,14 +41,13 @@ final class ExpectExceptionHandler implements ExpectedException
     private ?array $expectedPrevious = null;
 
     /**
-     * @param class-string|\Throwable $classOrObject Expected exception class, interface, or an object.
-     * @param bool $identity When true and an object is passed, requires the actual exception to be the
-     *        very same instance (`===`). When false (default), an object input is treated as a specimen:
-     *        class (instanceof) plus message and code must match.
+     * @param class-string|\Throwable $classOrObject Expected exception. A class-string triggers an
+     *        `instanceof` check; an object triggers an identity check (`===`). Equivalence
+     *        comparison is built on top by {@see self::createEquals()} via {@see self::withMessage()}
+     *        and {@see self::withCode()}.
      */
     private function __construct(
         public readonly string|\Throwable $classOrObject,
-        private readonly bool $identity = false,
     ) {}
 
     /**
@@ -57,11 +56,22 @@ final class ExpectExceptionHandler implements ExpectedException
      * Accepts a class-string (`instanceof` check) or an exception object treated as a specimen —
      * the actual exception must be of the same class and have the same message and code.
      *
+     * Default values from the specimen (code `0`, message `''`) are treated as "not specified" and
+     * are not enforced, so `Expect::exception(new Foo('msg'))->withCode(99)` works as expected
+     * without the specimen's implicit `code=0` conflicting with the explicit `withCode(99)`.
+     *
      * @param class-string|\Throwable $classOrObject Expected exception class, interface, or a specimen object.
      */
     public static function createEquals(string|\Throwable $classOrObject): self
     {
-        return new self($classOrObject, identity: false);
+        if (\is_string($classOrObject)) {
+            return new self($classOrObject);
+        }
+
+        $result = new self($classOrObject::class);
+        $classOrObject->getCode() === 0 or $result->withCode($classOrObject->getCode());
+        $classOrObject->getMessage() === '' or $result->withMessage($classOrObject->getMessage());
+        return $result;
     }
 
     /**
@@ -75,7 +85,7 @@ final class ExpectExceptionHandler implements ExpectedException
      */
     public static function createSame(\Throwable $classOrObject): self
     {
-        return new self($classOrObject, identity: true);
+        return new self($classOrObject);
     }
 
     /**
@@ -118,7 +128,7 @@ final class ExpectExceptionHandler implements ExpectedException
     #[\Override]
     public function withCode(int|array $code): static
     {
-        $this->expectedCodes[] = $code;
+        $this->expectedCodes = (array) $code;
         return $this;
     }
 
@@ -150,16 +160,15 @@ final class ExpectExceptionHandler implements ExpectedException
     {
         $isObject = \is_object($this->classOrObject);
         $class = $isObject ? $this->classOrObject::class : $this->classOrObject;
-        $identityMode = $isObject && $this->identity;
         $composite = new ExpectationComposite(
-            expectation: $identityMode
+            expectation: $isObject
                 ? 'the same ' . $class . ' instance is thrown'
                 : 'exception of type ' . $class . ' is thrown',
             context: '',
         );
 
-        # Type check
-        if ($identityMode) {
+        # Type check: identity (object input) vs instanceof (class-string input)
+        if ($isObject) {
             if ($actual === $this->classOrObject) {
                 $composite->success('the same ' . $class . ' instance is thrown');
             } else {
@@ -183,20 +192,6 @@ final class ExpectExceptionHandler implements ExpectedException
                 reason: $actual === null ? 'none thrown' : 'got ' . $actual::class,
             );
             return $composite;
-        }
-
-        # Auto-derive message/code expectations from a specimen object (equivalence mode).
-        # Skipped if the user already provided an explicit message- or code-related check.
-        if ($isObject && !$this->identity) {
-            if ($this->expectedMessage === null
-                && $this->expectedMessagePattern === null
-                && $this->expectedMessageContaining === []
-            ) {
-                $this->expectedMessage = $this->classOrObject->getMessage();
-            }
-            if ($this->expectedCodes === []) {
-                $this->expectedCodes[] = $this->classOrObject->getCode();
-            }
         }
 
         # fromMethod check
@@ -243,22 +238,17 @@ final class ExpectExceptionHandler implements ExpectedException
         }
 
         # Code check
-        foreach ($this->expectedCodes as $code) {
-            if (\is_array($code)) {
-                \in_array($actual->getCode(), $code, true)
-                    ? $composite->success('code is one of [' . \implode(', ', $code) . ']')
-                    : $composite->fail(
-                        expectation: 'code is one of [' . \implode(', ', $code) . ']',
-                        reason: 'got ' . $actual->getCode(),
-                    );
-            } else {
-                $actual->getCode() === $code
-                    ? $composite->success('code is ' . $code)
-                    : $composite->fail(
-                        expectation: 'code is ' . $code,
-                        reason: 'got ' . $actual->getCode(),
-                    );
-            }
+        if ($this->expectedCodes !== null) {
+            $code = $this->expectedCodes;
+            $label = \count($code) === 1
+                ? 'code is ' . $code[0]
+                : 'code is one of [' . \implode(', ', $code) . ']';
+            \in_array($actual->getCode(), $code, true)
+                ? $composite->success($label)
+                : $composite->fail(
+                    expectation: $label,
+                    reason: 'got ' . $actual->getCode(),
+                );
         }
 
         # Previous exception checks

--- a/src/Assert/Internal/Expectation/ExpectExceptionHandler.php
+++ b/src/Assert/Internal/Expectation/ExpectExceptionHandler.php
@@ -42,10 +42,41 @@ final class ExpectExceptionHandler implements ExpectedException
 
     /**
      * @param class-string|\Throwable $classOrObject Expected exception class, interface, or an object.
+     * @param bool $identity When true and an object is passed, requires the actual exception to be the
+     *        very same instance (`===`). When false (default), an object input is treated as a specimen:
+     *        class (instanceof) plus message and code must match.
      */
-    public function __construct(
+    private function __construct(
         public readonly string|\Throwable $classOrObject,
+        private readonly bool $identity = false,
     ) {}
+
+    /**
+     * Create a handler in equivalence mode.
+     *
+     * Accepts a class-string (`instanceof` check) or an exception object treated as a specimen —
+     * the actual exception must be of the same class and have the same message and code.
+     *
+     * @param class-string|\Throwable $classOrObject Expected exception class, interface, or a specimen object.
+     */
+    public static function createEquals(string|\Throwable $classOrObject): self
+    {
+        return new self($classOrObject, identity: false);
+    }
+
+    /**
+     * Create a handler in identity mode.
+     *
+     * The actual exception must be the very same instance (`===`) as the given one. Use for
+     * verifying that an exception propagates unchanged through middleware, decorators, or rethrow
+     * points.
+     *
+     * @param \Throwable $classOrObject The exact instance that must be thrown.
+     */
+    public static function createSame(\Throwable $classOrObject): self
+    {
+        return new self($classOrObject, identity: true);
+    }
 
     /**
      * The expected exception was thrown by the given method.
@@ -117,18 +148,32 @@ final class ExpectExceptionHandler implements ExpectedException
 
     private function evaluate(?\Throwable $actual): Expectation|\Throwable
     {
-        $class = \is_string($this->classOrObject) ? $this->classOrObject : $this->classOrObject::class;
+        $isObject = \is_object($this->classOrObject);
+        $class = $isObject ? $this->classOrObject::class : $this->classOrObject;
+        $identityMode = $isObject && $this->identity;
         $composite = new ExpectationComposite(
-            expectation: 'exception of type ' . $class . ' is thrown',
+            expectation: $identityMode
+                ? 'the same ' . $class . ' instance is thrown'
+                : 'exception of type ' . $class . ' is thrown',
             context: '',
         );
 
         # Type check
-        $typeMatched = \is_object($this->classOrObject)
-            ? ($actual === $this->classOrObject)
-            : ($actual instanceof $class);
-
-        if ($typeMatched) {
+        if ($identityMode) {
+            if ($actual === $this->classOrObject) {
+                $composite->success('the same ' . $class . ' instance is thrown');
+            } else {
+                $composite->fail(
+                    expectation: 'the same ' . $class . ' instance is thrown',
+                    reason: $actual === null
+                        ? 'none thrown'
+                        : ($actual instanceof $class
+                            ? 'got a different ' . $class . ' instance'
+                            : 'got ' . $actual::class),
+                );
+                return $composite;
+            }
+        } elseif ($actual instanceof $class) {
             $composite->success($class === $actual::class
                 ? $class . ' is thrown'
                 : $actual::class . ' is thrown as an instance of ' . $class);
@@ -138,6 +183,20 @@ final class ExpectExceptionHandler implements ExpectedException
                 reason: $actual === null ? 'none thrown' : 'got ' . $actual::class,
             );
             return $composite;
+        }
+
+        # Auto-derive message/code expectations from a specimen object (equivalence mode).
+        # Skipped if the user already provided an explicit message- or code-related check.
+        if ($isObject && !$this->identity) {
+            if ($this->expectedMessage === null
+                && $this->expectedMessagePattern === null
+                && $this->expectedMessageContaining === []
+            ) {
+                $this->expectedMessage = $this->classOrObject->getMessage();
+            }
+            if ($this->expectedCodes === []) {
+                $this->expectedCodes[] = $this->classOrObject->getCode();
+            }
         }
 
         # fromMethod check
@@ -225,11 +284,7 @@ final class ExpectExceptionHandler implements ExpectedException
         $previous = $actual->getPrevious();
         $prevClass = \is_string($prevClassOrObject) ? $prevClassOrObject : $prevClassOrObject::class;
 
-        $prevMatched = $previous !== null && (
-            \is_object($prevClassOrObject)
-                ? ($previous === $prevClassOrObject)
-                : ($previous instanceof $prevClass)
-        );
+        $prevMatched = $previous !== null && $previous instanceof $prevClass;
 
         if (!$prevMatched) {
             $composite->fail(
@@ -242,7 +297,7 @@ final class ExpectExceptionHandler implements ExpectedException
         $composite->success('has previous exception of type ' . $prevClass);
 
         if ($callback !== null) {
-            $subHandler = new self($prevClassOrObject);
+            $subHandler = self::createEquals($prevClassOrObject);
             $callback($subHandler);
             $subResult = $subHandler->evaluate($previous);
 

--- a/src/Assert/Internal/StaticState.php
+++ b/src/Assert/Internal/StaticState.php
@@ -102,17 +102,21 @@ final class StaticState
      * Set the expected exception for the current test.
      *
      * @param class-string|\Throwable $classOrObject The expected exception class, interface, or an exception object.
-     * @param bool $identity When true (only meaningful with an object input), requires the actual
-     *        exception to be the very same instance.
+     * @param bool $same Selects the strictest comparison the input allows:
+     *        - class-string + `false` → `instanceof` (default),
+     *        - class-string + `true` → exact class match (no subclasses),
+     *        - object + `false` → `instanceof` + message + code,
+     *        - object + `true` → identity (`===`).
      *
      * @throws \RuntimeException when there is no current {@see TestState}.
      */
     public static function expectException(
         string|\Throwable $classOrObject,
-        bool $identity = false,
+        bool $same = false,
     ): ExpectExceptionHandler {
         self::$state === null and throw new StateNotFound();
-        return self::$state->expectations[] = $identity
+
+        return self::$state->expectations[] = $same
             ? ExpectExceptionHandler::createSame($classOrObject)
             : ExpectExceptionHandler::createEquals($classOrObject);
     }

--- a/src/Assert/Internal/StaticState.php
+++ b/src/Assert/Internal/StaticState.php
@@ -102,14 +102,19 @@ final class StaticState
      * Set the expected exception for the current test.
      *
      * @param class-string|\Throwable $classOrObject The expected exception class, interface, or an exception object.
+     * @param bool $identity When true (only meaningful with an object input), requires the actual
+     *        exception to be the very same instance.
      *
      * @throws \RuntimeException when there is no current {@see TestState}.
      */
     public static function expectException(
         string|\Throwable $classOrObject,
+        bool $identity = false,
     ): ExpectExceptionHandler {
         self::$state === null and throw new StateNotFound();
-        return self::$state->expectations[] = new ExpectExceptionHandler($classOrObject);
+        return self::$state->expectations[] = $identity
+            ? ExpectExceptionHandler::createSame($classOrObject)
+            : ExpectExceptionHandler::createEquals($classOrObject);
     }
 
     public static function expectFail(Fail $exception): void

--- a/src/Expect.php
+++ b/src/Expect.php
@@ -20,8 +20,12 @@ final class Expect
     /**
      * Expect that the test will throw the given exception object or an exception of the given class/interface.
      *
-     * @param class-string|\Throwable $classOrObject The expected exception class, interface,
-     *        or an exact exception object.
+     * When an object is passed, it is treated as a specimen — the actual exception must be of the same
+     * class (instanceof) and have the same message and code. Use {@see self::sameException()} when the
+     * exact same instance must propagate.
+     *
+     * @param class-string|\Throwable $classOrObject The expected exception class, interface, or a
+     *        specimen object describing the exception to match.
      *
      * @note Requires {@see ExpectationsInterceptor} to be registered.
      */
@@ -29,6 +33,21 @@ final class Expect
         string|\Throwable $classOrObject,
     ): ExpectedException {
         return StaticState::expectException($classOrObject);
+    }
+
+    /**
+     * Expect that the test will throw the very same exception instance as the given one.
+     *
+     * Useful for verifying that an exception propagates unchanged through middleware, decorators,
+     * or rethrow points without being replaced by an equivalent copy.
+     *
+     * @param \Throwable $exception The exact instance that must be thrown.
+     *
+     * @note Requires {@see ExpectationsInterceptor} to be registered.
+     */
+    public static function sameException(\Throwable $exception): ExpectedException
+    {
+        return StaticState::expectException($exception, identity: true);
     }
 
     /**

--- a/src/Expect.php
+++ b/src/Expect.php
@@ -18,36 +18,36 @@ use Testo\Assert\Internal\StaticState;
 final class Expect
 {
     /**
-     * Expect that the test will throw the given exception object or an exception of the given class/interface.
+     * Expect that the test will throw an exception matching the given class/interface or specimen.
      *
-     * When an object is passed, it is treated as a specimen — the actual exception must be of the same
-     * class (instanceof) and have the same message and code. Use {@see self::sameException()} when the
-     * exact same instance must propagate.
+     * The comparison forms a 2×2 matrix over input type and the `$same` flag:
      *
-     * @param class-string|\Throwable $classOrObject The expected exception class, interface, or a
-     *        specimen object describing the exception to match.
+     * | input \ mode     | `$same = false` (default)         | `$same = true`                            |
+     * |------------------|-----------------------------------|-------------------------------------------|
+     * | **class-string** | `instanceof` check                | exact class match (subclasses rejected)   |
+     * | **object**       | `instanceof` + message + code     | identity (`===`, the same instance)       |
+     *
+     * `$same` means "as strict as the input allows": for a class-string, the strictest check is
+     * exact class equality; for an object, the strictest check is reference identity.
+     *
+     * For an object specimen with `$same = false`, default values (`code === 0`, empty message) are
+     * treated as "not specified" and are not enforced — `Expect::exception(new Foo('msg'))->withCode(99)`
+     * works as expected without the implicit zero conflicting with the explicit `99`.
+     *
+     * Additional constraints can be chained via the returned {@see ExpectedException}
+     * (`withMessage`, `withCode`, `fromMethod`, etc.).
+     *
+     * @param class-string|\Throwable $classOrObject The expected exception class/interface, or a
+     *        specimen object.
+     * @param bool $same When true, perform the strictest comparison the input allows.
      *
      * @note Requires {@see ExpectationsInterceptor} to be registered.
      */
     public static function exception(
         string|\Throwable $classOrObject,
+        bool $same = false,
     ): ExpectedException {
-        return StaticState::expectException($classOrObject);
-    }
-
-    /**
-     * Expect that the test will throw the very same exception instance as the given one.
-     *
-     * Useful for verifying that an exception propagates unchanged through middleware, decorators,
-     * or rethrow points without being replaced by an equivalent copy.
-     *
-     * @param \Throwable $exception The exact instance that must be thrown.
-     *
-     * @note Requires {@see ExpectationsInterceptor} to be registered.
-     */
-    public static function sameException(\Throwable $exception): ExpectedException
-    {
-        return StaticState::expectException($exception, identity: true);
+        return StaticState::expectException($classOrObject, $same);
     }
 
     /**

--- a/tests/Assert/Feature/ExpectExceptionNegativeTest.php
+++ b/tests/Assert/Feature/ExpectExceptionNegativeTest.php
@@ -131,4 +131,52 @@ final class ExpectExceptionNegativeTest
             ->contains('message is "expected previous message"')
             ->contains('code is 100');
     }
+
+    #[Test]
+    public function equivalenceWrongMessage(): void
+    {
+        $result = TestRunner::runTest([ExpectExceptionNegative::class, 'equivalenceWrongMessage']);
+
+        Assert::same($result->status, Status::Failed);
+        Assert::instanceOf($result->failure, Expectation::class);
+        Assert::string($result->failure->getFailReason())
+            ->contains('message is "expected"')
+            ->contains('got "actual"');
+    }
+
+    #[Test]
+    public function equivalenceWrongCode(): void
+    {
+        $result = TestRunner::runTest([ExpectExceptionNegative::class, 'equivalenceWrongCode']);
+
+        Assert::same($result->status, Status::Failed);
+        Assert::instanceOf($result->failure, Expectation::class);
+        Assert::string($result->failure->getFailReason())
+            ->contains('code is 42')
+            ->contains('got 99');
+    }
+
+    #[Test]
+    public function sameExceptionDifferentInstance(): void
+    {
+        $result = TestRunner::runTest([ExpectExceptionNegative::class, 'sameExceptionDifferentInstance']);
+
+        Assert::same($result->status, Status::Failed);
+        Assert::instanceOf($result->failure, Expectation::class);
+        Assert::string($result->failure->getFailReason())
+            ->contains('the same RuntimeException instance is thrown')
+            ->contains('got a different RuntimeException instance');
+    }
+
+    #[Test]
+    public function sameExceptionWrongClass(): void
+    {
+        $result = TestRunner::runTest([ExpectExceptionNegative::class, 'sameExceptionWrongClass']);
+
+        Assert::same($result->status, Status::Failed);
+        Assert::instanceOf($result->failure, Expectation::class);
+        Assert::string($result->failure->getFailReason())
+            ->contains('the same RuntimeException instance is thrown')
+            ->contains('got LogicException');
+    }
 }

--- a/tests/Assert/Feature/ExpectExceptionNegativeTest.php
+++ b/tests/Assert/Feature/ExpectExceptionNegativeTest.php
@@ -157,9 +157,9 @@ final class ExpectExceptionNegativeTest
     }
 
     #[Test]
-    public function sameExceptionDifferentInstance(): void
+    public function sameDifferentInstance(): void
     {
-        $result = TestRunner::runTest([ExpectExceptionNegative::class, 'sameExceptionDifferentInstance']);
+        $result = TestRunner::runTest([ExpectExceptionNegative::class, 'sameDifferentInstance']);
 
         Assert::same($result->status, Status::Failed);
         Assert::instanceOf($result->failure, Expectation::class);
@@ -169,14 +169,26 @@ final class ExpectExceptionNegativeTest
     }
 
     #[Test]
-    public function sameExceptionWrongClass(): void
+    public function sameWrongClass(): void
     {
-        $result = TestRunner::runTest([ExpectExceptionNegative::class, 'sameExceptionWrongClass']);
+        $result = TestRunner::runTest([ExpectExceptionNegative::class, 'sameWrongClass']);
 
         Assert::same($result->status, Status::Failed);
         Assert::instanceOf($result->failure, Expectation::class);
         Assert::string($result->failure->getFailReason())
             ->contains('the same RuntimeException instance is thrown')
             ->contains('got LogicException');
+    }
+
+    #[Test]
+    public function strictClassRejectsSubclass(): void
+    {
+        $result = TestRunner::runTest([ExpectExceptionNegative::class, 'strictClassRejectsSubclass']);
+
+        Assert::same($result->status, Status::Failed);
+        Assert::instanceOf($result->failure, Expectation::class);
+        Assert::string($result->failure->getFailReason())
+            ->contains('exactly RuntimeException is thrown')
+            ->contains('subclass of RuntimeException');
     }
 }

--- a/tests/Assert/Self/ExpectExceptionTest.php
+++ b/tests/Assert/Self/ExpectExceptionTest.php
@@ -19,7 +19,6 @@ final class ExpectExceptionTest
     {
         Expect::exception(\LogicException::class)
             ->withMessage('This is a logic exception')
-            ->withCode(123)
             ->withCode([320, 123, 456])
             ->fromMethod(self::class, __FUNCTION__)
             ->withoutPrevious();
@@ -218,6 +217,56 @@ final class ExpectExceptionTest
         Expect::sameException($expected);
 
         throw $expected;
+    }
+
+    /**
+     * A specimen with the default code (0) does not constrain the actual code —
+     * any thrown code is accepted.
+     */
+    #[Test]
+    public function specimenWithDefaultCodeDoesNotConstrainCode(): never
+    {
+        Expect::exception(new \RuntimeException('boom'));
+
+        throw new \RuntimeException('boom', 999);
+    }
+
+    /**
+     * A specimen with an empty message does not constrain the actual message —
+     * any thrown message is accepted.
+     */
+    #[Test]
+    public function specimenWithEmptyMessageDoesNotConstrainMessage(): never
+    {
+        Expect::exception(new \RuntimeException('', 42));
+
+        throw new \RuntimeException('any message here', 42);
+    }
+
+    /**
+     * Specimen with default code combined with explicit withCode — only the explicit value is enforced.
+     */
+    #[Test]
+    public function specimenDefaultCodePlusExplicitWithCode(): never
+    {
+        Expect::exception(new \RuntimeException('boom'))
+            ->withCode(99);
+
+        throw new \RuntimeException('boom', 99);
+    }
+
+    /**
+     * Multiple withCode calls — only the last one is in effect (replace semantics).
+     */
+    #[Test]
+    public function withCodeReplacesPrevious(): never
+    {
+        Expect::exception(\RuntimeException::class)
+            ->withCode(1)
+            ->withCode(2)
+            ->withCode([7, 99]);
+
+        throw new \RuntimeException('', 99);
     }
 
     private function throwHelper(): never

--- a/tests/Assert/Self/ExpectExceptionTest.php
+++ b/tests/Assert/Self/ExpectExceptionTest.php
@@ -161,6 +161,65 @@ final class ExpectExceptionTest
         throw new \LogicException('This is a logic exception', 123, $previous);
     }
 
+    /**
+     * Object input is treated as a specimen — class, message and code must match,
+     * but the actual exception is a different instance.
+     */
+    #[Test]
+    public function equivalenceFromSpecimen(): never
+    {
+        Expect::exception(new \RuntimeException('boom', 42));
+
+        throw new \RuntimeException('boom', 42);
+    }
+
+    /**
+     * A subclass of the specimen's class is accepted (instanceof, not strict class match).
+     */
+    #[Test]
+    public function equivalenceAcceptsSubclass(): never
+    {
+        Expect::exception(new \RuntimeException('boom', 42));
+
+        throw new class('boom', 42) extends \RuntimeException {};
+    }
+
+    /**
+     * Explicit withMessage overrides the auto-derived one from the specimen.
+     */
+    #[Test]
+    public function equivalenceMessageOverride(): never
+    {
+        Expect::exception(new \RuntimeException('default', 7))
+            ->withMessage('override');
+
+        throw new \RuntimeException('override', 7);
+    }
+
+    /**
+     * Explicit withCode overrides the auto-derived one from the specimen.
+     */
+    #[Test]
+    public function equivalenceCodeOverride(): never
+    {
+        Expect::exception(new \RuntimeException('boom', 7))
+            ->withCode(99);
+
+        throw new \RuntimeException('boom', 99);
+    }
+
+    /**
+     * sameException requires the very same instance to be thrown.
+     */
+    #[Test]
+    public function sameExceptionInstance(): never
+    {
+        $expected = new \RuntimeException('boom', 42);
+        Expect::sameException($expected);
+
+        throw $expected;
+    }
+
     private function throwHelper(): never
     {
         throw new \RuntimeException('from helper');

--- a/tests/Assert/Self/ExpectExceptionTest.php
+++ b/tests/Assert/Self/ExpectExceptionTest.php
@@ -208,15 +208,26 @@ final class ExpectExceptionTest
     }
 
     /**
-     * sameException requires the very same instance to be thrown.
+     * `same: true` with an object input requires the very same instance to be thrown.
      */
     #[Test]
-    public function sameExceptionInstance(): never
+    public function sameInstance(): never
     {
         $expected = new \RuntimeException('boom', 42);
-        Expect::sameException($expected);
+        Expect::exception($expected, same: true);
 
         throw $expected;
+    }
+
+    /**
+     * `same: true` with a class-string requires exact class match — subclasses are rejected.
+     */
+    #[Test]
+    public function strictClassMatch(): never
+    {
+        Expect::exception(\RuntimeException::class, same: true);
+
+        throw new \RuntimeException('boom');
     }
 
     /**

--- a/tests/Assert/Stub/ExpectExceptionNegative.php
+++ b/tests/Assert/Stub/ExpectExceptionNegative.php
@@ -157,24 +157,35 @@ final class ExpectExceptionNegative
     }
 
     /**
-     * sameException: an equivalent but different instance must fail.
+     * `same: true` with object: an equivalent but different instance must fail.
      */
     #[Test]
-    public function sameExceptionDifferentInstance(): never
+    public function sameDifferentInstance(): never
     {
-        Expect::sameException(new \RuntimeException('boom', 42));
+        Expect::exception(new \RuntimeException('boom', 42), same: true);
 
         throw new \RuntimeException('boom', 42);
     }
 
     /**
-     * sameException: a wrong class must fail.
+     * `same: true` with object: a wrong class must fail.
      */
     #[Test]
-    public function sameExceptionWrongClass(): never
+    public function sameWrongClass(): never
     {
-        Expect::sameException(new \RuntimeException('boom'));
+        Expect::exception(new \RuntimeException('boom'), same: true);
 
         throw new \LogicException('boom');
+    }
+
+    /**
+     * `same: true` with class-string: a subclass must be rejected.
+     */
+    #[Test]
+    public function strictClassRejectsSubclass(): never
+    {
+        Expect::exception(\RuntimeException::class, same: true);
+
+        throw new class('subclass') extends \RuntimeException {};
     }
 }

--- a/tests/Assert/Stub/ExpectExceptionNegative.php
+++ b/tests/Assert/Stub/ExpectExceptionNegative.php
@@ -133,4 +133,48 @@ final class ExpectExceptionNegative
 
         throw new \RuntimeException('', 0, new \LogicException('actual previous message', 999));
     }
+
+    /**
+     * Specimen object: class matches, but the message differs.
+     */
+    #[Test]
+    public function equivalenceWrongMessage(): never
+    {
+        Expect::exception(new \RuntimeException('expected', 7));
+
+        throw new \RuntimeException('actual', 7);
+    }
+
+    /**
+     * Specimen object: class and message match, but the code differs.
+     */
+    #[Test]
+    public function equivalenceWrongCode(): never
+    {
+        Expect::exception(new \RuntimeException('boom', 42));
+
+        throw new \RuntimeException('boom', 99);
+    }
+
+    /**
+     * sameException: an equivalent but different instance must fail.
+     */
+    #[Test]
+    public function sameExceptionDifferentInstance(): never
+    {
+        Expect::sameException(new \RuntimeException('boom', 42));
+
+        throw new \RuntimeException('boom', 42);
+    }
+
+    /**
+     * sameException: a wrong class must fail.
+     */
+    #[Test]
+    public function sameExceptionWrongClass(): never
+    {
+        Expect::sameException(new \RuntimeException('boom'));
+
+        throw new \LogicException('boom');
+    }
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! -->

## What was changed

Add `bool $same = false` parameter into `Expect::exception()`. The flag selects the strictest check the input allows:

- class-string + true  → exact class match (new — rejects subclasses)
- object      + true  → identity (`===`)
- false (default)     → instanceof, plus message+code for object specimens

## Checklist

- Closes #117 
- Tested
  - [ ] Tested manually
  - [x] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->
