### PR TITLE
JUnit XML output + Infection bridge integration

### DIFF
--- a/bridge/infection/src/TestoAdapter.php
+++ b/bridge/infection/src/TestoAdapter.php
@@ -22,6 +22,14 @@ final class TestoAdapter implements TestFrameworkAdapter
         private readonly string $projectDir,
         /** @var non-empty-string Infection's tmp directory; safe to drop per-mutant bootstrap files in. */
         private readonly string $tmpDir,
+        /**
+         * @var non-empty-string Path where Infection expects the JUnit XML
+         *      report. We pass it back to Testo via `--log-junit=<path>` and
+         *      probe its existence in {@see hasJUnitReport()} to decide
+         *      whether to use JUnit-driven test mapping or fall back to
+         *      reflection-based resolution.
+         */
+        private readonly string $jUnitFilePath,
     ) {
         // On Windows, Infection's TestFrameworkFinder may hand us `bin/testo.bat`.
         // We can't `php testo.bat` — strip the `.bat` and run the sibling PHP script directly.
@@ -45,10 +53,19 @@ final class TestoAdapter implements TestFrameworkAdapter
         return 'unknown';
     }
 
+    /**
+     * Reports whether a JUnit XML file is on disk at the path Infection
+     * expects. Probed dynamically rather than declared statically: if Testo
+     * succeeded in writing the report (it does so when `--log-junit=<path>` is
+     * passed and `JUnitPlugin` is configured), Infection switches to
+     * JUnit-driven test→file mapping. If the file is missing for any reason
+     * (Testo crashed before flush, plugin replaced, etc.), the bridge stays
+     * on the reflection-based fallback in {@see getMutantCommandLine()}.
+     */
     #[\Override]
     public function hasJUnitReport(): bool
     {
-        return false;
+        return \is_file($this->jUnitFilePath);
     }
 
     /**
@@ -81,6 +98,11 @@ final class TestoAdapter implements TestFrameworkAdapter
 
         $skipCoverage or $cmd[] = '--coverage';
 
+        // Always request JUnit output at Infection's expected path. The
+        // default JUnitPlugin in `ApplicationPlugins::defaults()` is inert
+        // until activated by this flag; user-added instances ignore it.
+        $cmd[] = '--log-junit=' . $this->jUnitFilePath;
+
         $extraOptions === '' or $cmd[] = $extraOptions;
 
         return $cmd;
@@ -108,13 +130,24 @@ final class TestoAdapter implements TestFrameworkAdapter
 
         // Narrow Testo's discovery to the test files Infection knows cover this mutant.
         // This avoids tokenizing every test file in every suite just to filter most of them out.
-        // `TestLocation::filePath` is populated only when Infection reads a JUnit report;
-        // since `hasJUnitReport()` returns false, we resolve the path from the class name.
+        //
+        // `TestLocation::filePath` is populated when Infection consumed a JUnit
+        // report (see {@see hasJUnitReport()}). When it's not — either because
+        // the report was missing or because that particular test wasn't found
+        // in the XML (e.g. free-function tests) — we resolve the path from
+        // the class/function name via reflection.
         $paths = [];
         $methods = [];
         foreach ($coverageTests as $test) {
             $method = self::stripDataSetSuffix($test->getMethod());
             $methods[$method] = true;
+
+            $filePath = $test->getFilePath();
+            if ($filePath !== null && $filePath !== '') {
+                $paths[$filePath] = true;
+                continue;
+            }
+
             $path = self::resolveTestFilePath($method);
             $path === null or $paths[$path] = true;
         }
@@ -130,39 +163,6 @@ final class TestoAdapter implements TestFrameworkAdapter
         $extraOptions === '' or $cmd[] = $extraOptions;
 
         return $cmd;
-    }
-
-    /**
-     * Writes a per-mutant auto_prepend_file with the original/mutant paths baked in.
-     *
-     * Avoids relying on env-variable inheritance, which Symfony Process does not reliably
-     * propagate to child processes started without an explicit `env` argument.
-     *
-     * @return non-empty-string Absolute path to the generated bootstrap file.
-     */
-    private function writeMutantBootstrap(string $hash, string $original, string $mutant): string
-    {
-        \is_dir($this->tmpDir) or \mkdir($this->tmpDir, 0o755, true);
-
-        $autoload = $this->projectDir . '/vendor/autoload.php';
-
-        $contents = \sprintf(
-            <<<'PHP'
-                <?php
-                declare(strict_types=1);
-                require %s;
-                \Infection\StreamWrapper\IncludeInterceptor::intercept(%s, %s);
-                \Infection\StreamWrapper\IncludeInterceptor::enable();
-                PHP,
-            \var_export($autoload, true),
-            \var_export($original, true),
-            \var_export($mutant, true),
-        );
-
-        $path = $this->tmpDir . '/testo-bootstrap-' . $hash . '.php';
-        \file_put_contents($path, $contents);
-
-        return $path;
     }
 
     /**
@@ -199,5 +199,38 @@ final class TestoAdapter implements TestFrameworkAdapter
 
         $file = $reflection->getFileName();
         return $file === false ? null : $file;
+    }
+
+    /**
+     * Writes a per-mutant auto_prepend_file with the original/mutant paths baked in.
+     *
+     * Avoids relying on env-variable inheritance, which Symfony Process does not reliably
+     * propagate to child processes started without an explicit `env` argument.
+     *
+     * @return non-empty-string Absolute path to the generated bootstrap file.
+     */
+    private function writeMutantBootstrap(string $hash, string $original, string $mutant): string
+    {
+        \is_dir($this->tmpDir) or \mkdir($this->tmpDir, 0o755, true);
+
+        $autoload = $this->projectDir . '/vendor/autoload.php';
+
+        $contents = \sprintf(
+            <<<'PHP'
+                <?php
+                declare(strict_types=1);
+                require %s;
+                \Infection\StreamWrapper\IncludeInterceptor::intercept(%s, %s);
+                \Infection\StreamWrapper\IncludeInterceptor::enable();
+                PHP,
+            \var_export($autoload, true),
+            \var_export($original, true),
+            \var_export($mutant, true),
+        );
+
+        $path = $this->tmpDir . '/testo-bootstrap-' . $hash . '.php';
+        \file_put_contents($path, $contents);
+
+        return $path;
     }
 }

--- a/bridge/infection/src/TestoAdapterFactory.php
+++ b/bridge/infection/src/TestoAdapterFactory.php
@@ -29,6 +29,7 @@ final class TestoAdapterFactory implements TestFrameworkAdapterFactory
             testFrameworkExecutable: $testFrameworkExecutable,
             projectDir: $projectDir,
             tmpDir: $tmpDir,
+            jUnitFilePath: $jUnitFilePath,
         );
     }
 

--- a/bridge/symfony-console/src/Command/Run.php
+++ b/bridge/symfony-console/src/Command/Run.php
@@ -104,6 +104,13 @@ final class Run extends Base
             InputOption::VALUE_NONE,
             'Disable code coverage collection',
         );
+        $this->addOption(
+            'log-junit',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Write JUnit XML report to the given path (overrides JUnitPlugin config). '
+            . 'Flag name mirrors PHPUnit / Pest / ParaTest.',
+        );
     }
 
     public function __invoke(

--- a/core/Application/Config/Plugin/ApplicationPlugins.php
+++ b/core/Application/Config/Plugin/ApplicationPlugins.php
@@ -6,11 +6,13 @@ namespace Testo\Application\Config\Plugin;
 
 use Testo\Common\PluginConfigurator;
 use Testo\Filter\FilterPlugin;
+use Testo\Output\JUnit\JUnitPlugin;
 
 $_ = [];
 // \class_exists(TeamcityPlugin::class) and $_[] = new TeamcityPlugin();
 // \class_exists(TerminalPlugin::class) and $_[] = new TerminalPlugin();
 \class_exists(FilterPlugin::class) and $_[] = new FilterPlugin();
+\class_exists(JUnitPlugin::class) and $_[] = new JUnitPlugin();
 
 \define([__NAMESPACE__ . '\DEFAULT_APPLICATION_PLUGINS'][0], $_);
 unset($_);

--- a/core/Output/JUnit/Internal/JUnitCaseNode.php
+++ b/core/Output/JUnit/Internal/JUnitCaseNode.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\JUnit\Internal;
+
+use Testo\Core\Value\Status;
+
+/**
+ * Captured `<testcase>` payload produced from a single `TestResult`.
+ *
+ * @internal
+ */
+final readonly class JUnitCaseNode
+{
+    public function __construct(
+        /** @var non-empty-string */
+        public string $name,
+        public string $classname,
+        public ?string $file,
+        public ?int $line,
+        public float $time,
+        public Status $status,
+        public ?JUnitCaseOutcome $outcome,
+    ) {}
+}

--- a/core/Output/JUnit/Internal/JUnitCaseOutcome.php
+++ b/core/Output/JUnit/Internal/JUnitCaseOutcome.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\JUnit\Internal;
+
+/**
+ * Encapsulates the optional child element of a `<testcase>` (one of
+ * `<failure>`, `<error>`, `<skipped>`).
+ *
+ * @internal
+ */
+final readonly class JUnitCaseOutcome
+{
+    public function __construct(
+        /**
+         * @var non-empty-string XML element name: 'failure', 'error', or 'skipped'.
+         */
+        public string $element,
+        public string $type,
+        public string $message,
+        public string $details,
+    ) {}
+}

--- a/core/Output/JUnit/Internal/JUnitInput.php
+++ b/core/Output/JUnit/Internal/JUnitInput.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\JUnit\Internal;
+
+use Testo\Application\Config\Internal\Attribute\InflectableConfig;
+use Testo\Application\Config\Internal\Attribute\InputOption;
+
+/**
+ * CLI input for the JUnit reporter.
+ *
+ * The `--log-junit=<path>` flag overrides the `outputPath` constructor
+ * argument of {@see \Testo\Output\JUnit\JUnitPlugin}. The flag name mirrors
+ * PHPUnit / Pest / ParaTest so external tools (e.g. Infection's bridge) can
+ * pass the path through using the convention they already speak.
+ *
+ * @internal
+ * @psalm-internal Testo\Output\JUnit
+ */
+#[InflectableConfig]
+final class JUnitInput
+{
+    #[InputOption('log-junit')]
+    public ?string $outputPath = null;
+}

--- a/core/Output/JUnit/Internal/JUnitSuiteNode.php
+++ b/core/Output/JUnit/Internal/JUnitSuiteNode.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\JUnit\Internal;
+
+/**
+ * Mutable accumulator for a single `<testsuite>` element while events stream
+ * in. Counters are `local` (own children) and `total` (rolled up across
+ * descendants); the rollup runs once on document generation.
+ *
+ * @internal
+ */
+final class JUnitSuiteNode
+{
+    /** @var list<JUnitSuiteNode> */
+    public array $children = [];
+
+    /** @var list<JUnitCaseNode> */
+    public array $cases = [];
+
+    public int $tests = 0;
+    public int $failures = 0;
+    public int $errors = 0;
+    public int $skipped = 0;
+    public float $time = 0.0;
+    public int $totalTests = 0;
+    public int $totalFailures = 0;
+    public int $totalErrors = 0;
+    public int $totalSkipped = 0;
+    public float $totalTime = 0.0;
+
+    /**
+     * @param non-empty-string $name
+     * @param non-empty-string|null $file Optional source-file attribute for the
+     *        suite. Set on the class-layer suite so Infection can resolve a
+     *        `<testsuite>` to a test file via JUnit instead of reflection.
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly ?string $file = null,
+    ) {}
+}

--- a/core/Output/JUnit/Internal/JUnitWriter.php
+++ b/core/Output/JUnit/Internal/JUnitWriter.php
@@ -1,0 +1,437 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\JUnit\Internal;
+
+use Internal\Path;
+use Testo\Core\Context\TestInfo;
+use Testo\Core\Context\TestResult;
+use Testo\Core\Value\Status;
+use Testo\Output\Rendering\StackTrace;
+
+/**
+ * Builds and writes a JUnit XML (PHPUnit dialect) document.
+ *
+ * Maintains a stack of nested `<testsuite>` accumulators and a list of
+ * `<testcase>` records inside the currently-open suite. Counters and time
+ * are folded up to the parent on each suite close. The XML is emitted on
+ * {@see write()} call.
+ *
+ * Status mapping rationale (see issue #122):
+ * - `Risky` is reported as `<error type="Risky">`. PHPUnit and Codeception
+ *   disagree on the encoding (`<error>` vs `<warning>`); `<error>` is in the
+ *   JUnit XSD and is consumed correctly by GitHub Actions, GitLab, Jenkins.
+ *   `<warning>` is non-standard and silently dropped by most consumers.
+ * - `Flaky` is reported as a passing test (no child element); the test
+ *   succeeded after retries, which most CI tools treat as a green test.
+ *
+ * @internal
+ */
+final class JUnitWriter
+{
+    /**
+     * Top-level suites — children of the root `<testsuites>` node.
+     *
+     * @var list<JUnitSuiteNode>
+     */
+    private array $rootSuites = [];
+
+    /**
+     * Open suite nesting stack; the last element is where new test cases
+     * and nested suites are attached.
+     *
+     * @var list<JUnitSuiteNode>
+     */
+    private array $stack = [];
+
+    public function reset(): void
+    {
+        $this->rootSuites = [];
+        $this->stack = [];
+    }
+
+    /**
+     * Opens a new `<testsuite>` and pushes it onto the stack.
+     *
+     * @param non-empty-string $name
+     * @param non-empty-string|null $file Optional source-file attribute,
+     *        meaningful for the class-layer suite (Infection consumes it).
+     */
+    public function startSuite(string $name, ?string $file = null): void
+    {
+        $this->stack[] = new JUnitSuiteNode($name, $file);
+    }
+
+    /**
+     * Closes the most recently opened `<testsuite>`. The closed suite is
+     * folded into its parent (or the root list if no parent is open).
+     */
+    public function finishSuite(): void
+    {
+        if ($this->stack === []) {
+            return;
+        }
+
+        /** @var JUnitSuiteNode $node */
+        $node = \array_pop($this->stack);
+
+        if ($this->stack === []) {
+            $this->rootSuites[] = $node;
+            return;
+        }
+
+        $parent = $this->stack[\array_key_last($this->stack)];
+        $parent->children[] = $node;
+    }
+
+    /**
+     * Records a `<testcase>` for a finished test result under the currently
+     * open suite. If no suite is open, an implicit "default" root suite is
+     * created to host the test case.
+     *
+     * @param non-empty-string|null $overrideName Replaces the test name (used for data-provider rows).
+     */
+    public function addTestResult(TestResult $result, ?string $overrideName = null): void
+    {
+        $info = $result->info;
+        $name = $overrideName ?? $info->name;
+        $duration = (int) $result->getAttribute('duration');
+        $time = $duration / 1000.0;
+
+        $reflection = $info->testDefinition->reflection;
+        $file = $reflection->getFileName();
+        $file = $file === false ? null : $file;
+        $line = $reflection->getStartLine();
+        $line = $line === false ? null : $line;
+
+        $case = new JUnitCaseNode(
+            name: $name,
+            classname: self::classnameFor($info),
+            file: $file,
+            line: $line,
+            time: $time,
+            status: $result->status,
+            outcome: self::outcomeFor($result),
+        );
+
+        $suite = $this->currentSuite();
+        $suite->cases[] = $case;
+        $suite->tests++;
+        $suite->time += $time;
+
+        match ($result->status) {
+            Status::Failed => $suite->failures++,
+            Status::Error, Status::Aborted, Status::Risky => $suite->errors++,
+            Status::Skipped, Status::Cancelled => $suite->skipped++,
+            Status::Passed, Status::Flaky => null,
+        };
+    }
+
+    /**
+     * Generates the XML document and writes it to disk. Parent directories
+     * are created on demand.
+     *
+     * @param non-empty-string $rootName
+     */
+    public function write(Path $path, string $rootName): void
+    {
+        $dir = (string) $path->parent();
+        \is_dir($dir) or \mkdir($dir, 0o755, true) or throw new \RuntimeException("Failed to create directory: {$dir}");
+
+        \file_put_contents((string) $path, $this->generate($rootName));
+    }
+
+    /**
+     * @param non-empty-string $rootName
+     */
+    public function generate(string $rootName): string
+    {
+        // Auto-close any suites left open (defensive; SessionFinished may fire
+        // mid-execution if a suite/case did not close cleanly).
+        while ($this->stack !== []) {
+            $this->finishSuite();
+        }
+
+        $totals = $this->rollup();
+
+        $xml = new \XMLWriter();
+        $xml->openMemory();
+        $xml->setIndent(true);
+        $xml->setIndentString('  ');
+
+        $xml->startDocument('1.0', 'UTF-8');
+
+        $xml->startElement('testsuites');
+        $xml->writeAttribute('name', $rootName);
+        $xml->writeAttribute('tests', (string) $totals['tests']);
+        $xml->writeAttribute('failures', (string) $totals['failures']);
+        $xml->writeAttribute('errors', (string) $totals['errors']);
+        $xml->writeAttribute('skipped', (string) $totals['skipped']);
+        $xml->writeAttribute('time', self::formatTime($totals['time']));
+
+        foreach ($this->rootSuites as $suite) {
+            $this->writeSuite($xml, $suite);
+        }
+
+        $xml->endElement(); // testsuites
+        $xml->endDocument();
+
+        return $xml->outputMemory();
+    }
+
+    /**
+     * Aggregates counters of a suite together with its descendants, mutating
+     * the node so the rolled-up values are written into XML.
+     *
+     * @return array{tests: int, failures: int, errors: int, skipped: int, time: float}
+     */
+    private static function rollupSuite(JUnitSuiteNode $suite): array
+    {
+        $tests = $suite->tests;
+        $failures = $suite->failures;
+        $errors = $suite->errors;
+        $skipped = $suite->skipped;
+        $time = $suite->time;
+
+        foreach ($suite->children as $child) {
+            $childTotals = self::rollupSuite($child);
+            $tests += $childTotals['tests'];
+            $failures += $childTotals['failures'];
+            $errors += $childTotals['errors'];
+            $skipped += $childTotals['skipped'];
+            $time += $childTotals['time'];
+        }
+
+        $suite->totalTests = $tests;
+        $suite->totalFailures = $failures;
+        $suite->totalErrors = $errors;
+        $suite->totalSkipped = $skipped;
+        $suite->totalTime = $time;
+
+        return [
+            'tests' => $tests,
+            'failures' => $failures,
+            'errors' => $errors,
+            'skipped' => $skipped,
+            'time' => $time,
+        ];
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function classnameFor(TestInfo $info): string
+    {
+        $reflection = $info->testDefinition->reflection;
+
+        if ($reflection instanceof \ReflectionMethod) {
+            return $reflection->getDeclaringClass()->getName();
+        }
+
+        $caseReflection = $info->caseInfo->definition->reflection;
+        if ($caseReflection !== null) {
+            return $caseReflection->getName();
+        }
+
+        $namespace = $reflection->getNamespaceName();
+        return $namespace === '' ? '<global>' : $namespace;
+    }
+
+    private static function outcomeFor(TestResult $result): ?JUnitCaseOutcome
+    {
+        return match ($result->status) {
+            Status::Passed, Status::Flaky => null,
+
+            Status::Failed => new JUnitCaseOutcome(
+                element: 'failure',
+                type: $result->failure !== null ? $result->failure::class : 'Failure',
+                message: $result->failure?->getMessage() ?? 'Test failed',
+                details: self::formatTrace($result),
+            ),
+
+            Status::Error => new JUnitCaseOutcome(
+                element: 'error',
+                type: $result->failure !== null ? $result->failure::class : 'Error',
+                message: $result->failure?->getMessage() ?? 'Test errored',
+                details: self::formatTrace($result),
+            ),
+
+            Status::Aborted => new JUnitCaseOutcome(
+                element: 'error',
+                type: 'Aborted',
+                message: $result->failure?->getMessage() ?? 'Test aborted',
+                details: self::formatTrace($result),
+            ),
+
+            Status::Risky => new JUnitCaseOutcome(
+                element: 'error',
+                type: 'Risky',
+                message: $result->failure?->getMessage() ?? 'Test marked as risky',
+                details: self::formatTrace($result),
+            ),
+
+            Status::Skipped => new JUnitCaseOutcome(
+                element: 'skipped',
+                type: 'Skipped',
+                message: $result->failure?->getMessage() ?? '',
+                details: '',
+            ),
+
+            Status::Cancelled => new JUnitCaseOutcome(
+                element: 'skipped',
+                type: 'Cancelled',
+                message: $result->failure?->getMessage() ?? 'Test cancelled',
+                details: '',
+            ),
+        };
+    }
+
+    private static function formatTrace(TestResult $result): string
+    {
+        $failure = $result->failure;
+        if ($failure === null) {
+            return '';
+        }
+
+        $boundary = $result->info->testDefinition->reflection;
+        $parts = [];
+        $current = $failure;
+
+        do {
+            $class = $current::class;
+            $file = $current->getFile();
+            $line = $current->getLine();
+            $trace = self::formatTraceFrames(StackTrace::cutStackTrace($current->getTrace(), $boundary, false));
+
+            $parts[] = "{$class}\nFile: {$file}:{$line}\n\nStack trace:\n{$trace}";
+        } while ($current = $current->getPrevious());
+
+        return \implode("\n\nCaused by:\n", $parts);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $trace
+     */
+    private static function formatTraceFrames(array $trace): string
+    {
+        $lines = [];
+
+        foreach ($trace as $i => $frame) {
+            $location = isset($frame['file'])
+                ? "{$frame['file']}({$frame['line']})"
+                : '[internal function]';
+            $call = isset($frame['class'])
+                ? "{$frame['class']}{$frame['type']}{$frame['function']}()"
+                : "{$frame['function']}()";
+            $lines[] = "#{$i} {$location}: {$call}";
+        }
+
+        return \implode("\n", $lines);
+    }
+
+    private static function formatTime(float $seconds): string
+    {
+        return \sprintf('%.6F', $seconds);
+    }
+
+    /**
+     * Wraps text in CDATA, escaping any literal `]]>` occurrences so the
+     * payload survives intact.
+     */
+    private static function escapeCdata(string $text): string
+    {
+        $safe = \str_replace(']]>', ']]]]><![CDATA[>', $text);
+        return '<![CDATA[' . $safe . ']]>';
+    }
+
+    /**
+     * @return array{tests: int, failures: int, errors: int, skipped: int, time: float}
+     */
+    private function rollup(): array
+    {
+        $tests = 0;
+        $failures = 0;
+        $errors = 0;
+        $skipped = 0;
+        $time = 0.0;
+
+        foreach ($this->rootSuites as $suite) {
+            $totals = self::rollupSuite($suite);
+            $tests += $totals['tests'];
+            $failures += $totals['failures'];
+            $errors += $totals['errors'];
+            $skipped += $totals['skipped'];
+            $time += $totals['time'];
+        }
+
+        return [
+            'tests' => $tests,
+            'failures' => $failures,
+            'errors' => $errors,
+            'skipped' => $skipped,
+            'time' => $time,
+        ];
+    }
+
+    private function writeSuite(\XMLWriter $xml, JUnitSuiteNode $suite): void
+    {
+        $xml->startElement('testsuite');
+        $xml->writeAttribute('name', $suite->name);
+        $suite->file === null or $xml->writeAttribute('file', $suite->file);
+        $xml->writeAttribute('tests', (string) $suite->totalTests);
+        $xml->writeAttribute('failures', (string) $suite->totalFailures);
+        $xml->writeAttribute('errors', (string) $suite->totalErrors);
+        $xml->writeAttribute('skipped', (string) $suite->totalSkipped);
+        $xml->writeAttribute('time', self::formatTime($suite->totalTime));
+
+        foreach ($suite->children as $child) {
+            $this->writeSuite($xml, $child);
+        }
+
+        foreach ($suite->cases as $case) {
+            $this->writeCase($xml, $case);
+        }
+
+        $xml->endElement(); // testsuite
+    }
+
+    private function writeCase(\XMLWriter $xml, JUnitCaseNode $case): void
+    {
+        $xml->startElement('testcase');
+        $xml->writeAttribute('name', $case->name);
+        $case->classname === '' or $xml->writeAttribute('classname', $case->classname);
+        $case->file !== null and $xml->writeAttribute('file', $case->file);
+        $case->line !== null and $xml->writeAttribute('line', (string) $case->line);
+        $xml->writeAttribute('time', self::formatTime($case->time));
+
+        $outcome = $case->outcome;
+        if ($outcome !== null) {
+            if ($outcome->element === 'skipped') {
+                $xml->startElement('skipped');
+                $outcome->message === '' or $xml->writeAttribute('message', $outcome->message);
+                $xml->endElement();
+            } else {
+                $xml->startElement($outcome->element);
+                $xml->writeAttribute('type', $outcome->type);
+                $outcome->message === '' or $xml->writeAttribute('message', $outcome->message);
+                $outcome->details === '' or $xml->writeRaw(self::escapeCdata($outcome->details));
+                $xml->endElement();
+            }
+        }
+
+        $xml->endElement(); // testcase
+    }
+
+    private function currentSuite(): JUnitSuiteNode
+    {
+        if ($this->stack === []) {
+            // No suite open — host orphan tests in an implicit root suite so
+            // the document remains well-formed.
+            $synthetic = new JUnitSuiteNode('default');
+            $this->stack[] = $synthetic;
+        }
+
+        return $this->stack[\array_key_last($this->stack)];
+    }
+}

--- a/core/Output/JUnit/JUnitPlugin.php
+++ b/core/Output/JUnit/JUnitPlugin.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\JUnit;
+
+use Internal\Container\Container;
+use Internal\Path;
+use Testo\Common\EventListenerCollector;
+use Testo\Common\PluginConfigurator;
+use Testo\Core\Context\TestInfo;
+use Testo\Event\Framework\SessionFinished;
+use Testo\Event\Framework\SessionStarting;
+use Testo\Event\Test\TestBatchFinished;
+use Testo\Event\Test\TestBatchStarting;
+use Testo\Event\Test\TestDataSetFinished;
+use Testo\Event\Test\TestPipelineFinished;
+use Testo\Event\TestCase\TestCaseFinished;
+use Testo\Event\TestCase\TestCaseStarting;
+use Testo\Event\TestSuite\TestSuiteFinished;
+use Testo\Event\TestSuite\TestSuiteStarting;
+use Testo\Output\JUnit\Internal\JUnitInput;
+use Testo\Output\JUnit\Internal\JUnitWriter;
+
+/**
+ * Plugin that emits a JUnit XML (PHPUnit dialect) report on session end.
+ *
+ * The XML is the de-facto interchange format for CI test reporters (GitHub
+ * Actions, GitLab, Jenkins, Azure DevOps): adding this plugin to
+ * `ApplicationConfig::plugins` lets those platforms render the test tab,
+ * annotate failures on PR diffs, and track flaky tests without parsing
+ * stdout.
+ *
+ * The conventional output filename is `junit.xml`; Infection in particular
+ * expects it next to the `coverage-xml/` directory produced by
+ * {@see \Testo\Codecov\Report\PhpUnitXmlReport} (e.g. `build/coverage/junit.xml`).
+ *
+ * # How activation works
+ *
+ * The plugin is already part of {@see \Testo\Application\Config\Plugin\ApplicationPlugins::defaults()},
+ * so every project that doesn't replace the defaults gets one **inert** copy
+ * for free. Inert means: no listeners are registered and no file is written.
+ * The inert default exists so the `--log-junit=<path>` CLI flag has something to
+ * activate without any change to `testo.php`.
+ *
+ * Activation rules:
+ * - Constructor path is set → the plugin always writes to that path; the
+ *   `--log-junit` flag is ignored. Use this when you want JUnit output as part
+ *   of every run (e.g. on CI by default).
+ * - Constructor path is null → the plugin reads the `--log-junit=<path>` flag
+ *   on each run; if the flag is absent it stays inert. This is the mode
+ *   used by the default inert instance and by Infection (which passes the
+ *   path it expects via the flag).
+ *
+ * Multiple instances are fully independent — each one runs through the rules
+ * above on its own. A plugin instance with a constructor path will produce
+ * its file on **every** run, regardless of whether `--log-junit=…` was passed.
+ * This means manually-added instances write **additional** report files,
+ * they do not replace the default one. So this config:
+ *
+ * ```
+ * ApplicationPlugins::with(new JUnitPlugin('/always.xml'))
+ * ```
+ *
+ * yields one report at `/always.xml` on every run; if the same run is also
+ * invoked with `--log-junit=/from-cli.xml`, the default inert instance writes
+ * a second report at `/from-cli.xml` — both files end up on disk.
+ *
+ * To pin the report to a fixed path and prevent the CLI flag from creating
+ * a second file, drop the default first:
+ * `ApplicationPlugins::without(JUnitPlugin::class)->with(new JUnitPlugin('/always.xml'))`.
+ *
+ * @api
+ */
+final class JUnitPlugin implements PluginConfigurator
+{
+    /**
+     * Tracks whether we're inside a DataProvider batch, keyed by test
+     * definition object hash. Same guard `TeamcityPlugin` uses to avoid
+     * emitting both the per-dataset and the rolled-up `<testcase>`.
+     *
+     * @var array<non-empty-string, bool>
+     */
+    private array $isBatch = [];
+
+    /**
+     * Output path. Seeded from the constructor argument and, if that was
+     * absent, from the `--log-junit=<path>` CLI flag in {@see configure()}.
+     * Stays null when neither source provided a path — in that case the
+     * plugin remains inert.
+     */
+    private ?Path $resolvedPath;
+
+    /**
+     * Single-shot guard so the plugin attaches its listeners only to the
+     * outer dispatcher when the same instance is shared across containers.
+     * `ApplicationPlugins::defaults()` reuses one `JUnitPlugin` for every
+     * top-level run AND for every nested {@see \Testo\Testing\Traits\TestRunner::runTest()}
+     * sub-run; without this guard inner `SessionStarting` would clear the
+     * outer writer state, and inner `SessionFinished` would overwrite the
+     * file with inner-only suites.
+     */
+    private bool $configured = false;
+
+    private readonly JUnitWriter $writer;
+
+    /**
+     * @param non-empty-string|null $outputPath Where to write the JUnit XML.
+     *        When set, the plugin always writes to this path. When null, the
+     *        plugin falls back to the `--log-junit=<path>` CLI flag, and stays
+     *        inert if the flag is also absent.
+     * @param non-empty-string $rootName Value of the `name` attribute on the
+     *        root `<testsuites>` element. CI reporters display it as the title
+     *        of the run; useful for distinguishing multiple JUnit reports
+     *        produced by the same pipeline (e.g. `'Unit'` vs `'Integration'`).
+     */
+    public function __construct(
+        ?string $outputPath = null,
+        private readonly string $rootName = 'Testo',
+    ) {
+        $this->resolvedPath = $outputPath !== null && $outputPath !== ''
+            ? Path::create($outputPath)
+            : null;
+        $this->writer = new JUnitWriter();
+    }
+
+    #[\Override]
+    public function configure(Container $container): void
+    {
+        if ($this->configured) {
+            return;
+        }
+        $this->configured = true;
+
+        // Constructor path wins. CLI flag is consulted only when no explicit
+        // path was passed to the constructor — that's how the inert default
+        // instance in ApplicationPlugins::defaults() gets activated.
+        if ($this->resolvedPath === null) {
+            $cliPath = $container->get(JUnitInput::class)->outputPath;
+            if ($cliPath === null || $cliPath === '') {
+                return;
+            }
+            $this->resolvedPath = Path::create($cliPath);
+        }
+
+        $listeners = $container->get(EventListenerCollector::class);
+
+        // Framework events
+        $listeners->addListener(SessionStarting::class, $this->onSessionStarting(...));
+        $listeners->addListener(SessionFinished::class, $this->onSessionFinished(...));
+
+        // TestSuite events
+        $listeners->addListener(TestSuiteStarting::class, $this->onTestSuiteStarting(...));
+        $listeners->addListener(TestSuiteFinished::class, $this->onTestSuiteFinished(...));
+
+        // TestCase events
+        $listeners->addListener(TestCaseStarting::class, $this->onTestCaseStarting(...));
+        $listeners->addListener(TestCaseFinished::class, $this->onTestCaseFinished(...));
+
+        // Test Batch events (for DataProvider)
+        $listeners->addListener(TestBatchStarting::class, $this->onTestBatchStarting(...));
+        $listeners->addListener(TestBatchFinished::class, $this->onTestBatchFinished(...));
+
+        // DataSet events (for individual datasets within DataProvider)
+        $listeners->addListener(TestDataSetFinished::class, $this->onTestDataSetFinished(...));
+
+        // Test Pipeline events (final event in the test lifecycle)
+        $listeners->addListener(TestPipelineFinished::class, $this->onTestPipelineFinished(...));
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function getId(TestInfo $testInfo): string
+    {
+        return \spl_object_hash($testInfo->testDefinition);
+    }
+
+    private static function formatDatasetSuffix(string|int $datasetKey, ?int $providerIndex): string
+    {
+        return $providerIndex === null
+            ? (string) $datasetKey
+            : "{$providerIndex}:{$datasetKey}";
+    }
+
+    private function onSessionStarting(SessionStarting $event): void
+    {
+        $this->writer->reset();
+        $this->isBatch = [];
+    }
+
+    private function onSessionFinished(SessionFinished $event): void
+    {
+        \assert($this->resolvedPath !== null);
+        $this->writer->write($this->resolvedPath, $this->rootName);
+    }
+
+    private function onTestSuiteStarting(TestSuiteStarting $event): void
+    {
+        $this->writer->startSuite($event->suiteInfo->name);
+    }
+
+    private function onTestSuiteFinished(TestSuiteFinished $event): void
+    {
+        $this->writer->finishSuite();
+    }
+
+    private function onTestCaseStarting(TestCaseStarting $event): void
+    {
+        // For class-bound cases, emit the bare FQN as the suite name (no
+        // `[type]` suffix) and tag it with the class file. This matches
+        // PHPUnit's JUnit shape and is what Infection's `JUnitTestFileDataProvider`
+        // looks up via `//testsuite[@name="FQN"]`. Free-function cases keep
+        // the human-readable `caseInfo->name` and have no source file.
+        $caseInfo = $event->caseInfo;
+        $reflection = $caseInfo->definition->reflection;
+        $name = $reflection?->getName() ?? $caseInfo->name;
+        \assert($name !== '');
+
+        $file = $reflection?->getFileName();
+        $file = ($file === false || $file === null || $file === '') ? null : $file;
+
+        $this->writer->startSuite($name, $file);
+    }
+
+    private function onTestCaseFinished(TestCaseFinished $event): void
+    {
+        $this->writer->finishSuite();
+    }
+
+    private function onTestBatchStarting(TestBatchStarting $event): void
+    {
+        $id = self::getId($event->testInfo);
+        $this->isBatch[$id] = true;
+    }
+
+    private function onTestBatchFinished(TestBatchFinished $event): void
+    {
+        // Marker is cleared in TestPipelineFinished, which fires after this.
+    }
+
+    private function onTestDataSetFinished(TestDataSetFinished $event): void
+    {
+        $name = $event->testResult->info->name . ' [' . self::formatDatasetSuffix($event->datasetKey, $event->providerIndex) . ']';
+        \assert($name !== '');
+
+        $this->writer->addTestResult($event->testResult, $name);
+    }
+
+    private function onTestPipelineFinished(TestPipelineFinished $event): void
+    {
+        $id = self::getId($event->testInfo);
+        if (isset($this->isBatch[$id])) {
+            // DataProvider test — individual datasets were already emitted.
+            unset($this->isBatch[$id]);
+            return;
+        }
+
+        $this->writer->addTestResult($event->testResult);
+    }
+}

--- a/plugin/codecov/src/Report/PhpUnitXmlReport.php
+++ b/plugin/codecov/src/Report/PhpUnitXmlReport.php
@@ -10,14 +10,24 @@ use Testo\Codecov\Result\FileCoverage;
 use Testo\Codecov\Result\LineStatus;
 
 /**
- * Generates a PHPUnit-style coverage XML report directory.
+ * Generates a directory-based XML coverage report (a.k.a. "coverage XML").
+ *
+ * Primary consumer in the Testo ecosystem is **Infection**: it reads the
+ * directory through `IndexXmlCoverageParser` / `XmlCoverageParser` to map
+ * each mutated line back to the tests that cover it. Without this report
+ * Infection can't narrow the test set per mutant and runs everything.
  *
  * Output layout:
  * - `<outputDir>/index.xml` — overview with one `<file href="…">` per source file.
- * - `<outputDir>/<relative>/<basename>.xml` — per-source-file coverage with `<covered by="…">`.
+ * - `<outputDir>/<relative>/<basename>.xml` — per-source-file coverage
+ *   with `<covered by="…">` annotations linking lines to test methods.
  *
- * The format matches the PHPUnit `--coverage-xml` directory layout consumed by Infection's
- * `Infection\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser` / `XmlCoverageParser`.
+ * The conventional name for `<outputDir>` is `coverage-xml`, sibling to a
+ * `junit.xml` file under a shared parent (e.g. `build/coverage/coverage-xml`
+ * + `build/coverage/junit.xml`). That layout is what Infection's
+ * `--coverage=<dir>` flag expects when reusing reports between CI steps.
+ *
+ * Distinct from JUnit XML (test-results format, see {@see \Testo\Output\JUnit\JUnitPlugin}).
  *
  * @api
  */

--- a/psalm.xml
+++ b/psalm.xml
@@ -17,6 +17,7 @@
         <ignoreFiles>
             <directory name="vendor" />
             <directory name="core/Tokenizer" />
+            <directory name="core/Output/JUnit" />
             <directory name="core/Output/Teamcity" />
             <directory name="core/Output/Terminal" />
         </ignoreFiles>

--- a/tests/Output/Stub/JUnit/SampleTestClass.php
+++ b/tests/Output/Stub/JUnit/SampleTestClass.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Stub\JUnit;
+
+/**
+ * Stub class used to back `\ReflectionMethod` for JUnit writer tests.
+ */
+final class SampleTestClass
+{
+    public function passingTest(): void {}
+
+    public function failingTest(): void {}
+}

--- a/tests/Output/Stub/JUnit/free_function_helper.php
+++ b/tests/Output/Stub/JUnit/free_function_helper.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Stub\JUnit;
+
+if (!\function_exists(__NAMESPACE__ . '\\junitFreeFunction')) {
+    function junitFreeFunction(): void {}
+}

--- a/tests/Output/Unit/JUnit/JUnitPluginTest.php
+++ b/tests/Output/Unit/JUnit/JUnitPluginTest.php
@@ -1,0 +1,348 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Unit\JUnit;
+
+use Internal\Container\ObjectContainer;
+use Testo\Application\Internal\EventDispatcher;
+use Testo\Assert;
+use Testo\Common\EventListenerCollector;
+use Testo\Core\Context\CaseInfo;
+use Testo\Core\Context\CaseResult;
+use Testo\Core\Context\RunResult;
+use Testo\Core\Context\SuiteInfo;
+use Testo\Core\Context\SuiteResult;
+use Testo\Core\Context\TestInfo;
+use Testo\Core\Context\TestResult;
+use Testo\Core\Definition\CaseDefinition;
+use Testo\Core\Definition\CaseDefinitions;
+use Testo\Core\Definition\TestDefinition;
+use Testo\Core\Value\Status;
+use Testo\Event\Framework\SessionFinished;
+use Testo\Event\Framework\SessionStarting;
+use Testo\Event\Test\TestBatchFinished;
+use Testo\Event\Test\TestBatchStarting;
+use Testo\Event\Test\TestDataSetFinished;
+use Testo\Event\Test\TestPipelineFinished;
+use Testo\Event\TestCase\TestCaseFinished;
+use Testo\Event\TestCase\TestCaseStarting;
+use Testo\Event\TestSuite\TestSuiteFinished;
+use Testo\Event\TestSuite\TestSuiteStarting;
+use Testo\Output\JUnit\Internal\JUnitInput;
+use Testo\Output\JUnit\JUnitPlugin;
+use Testo\Test;
+use Tests\Output\Stub\JUnit\SampleTestClass;
+
+#[Test]
+final class JUnitPluginTest
+{
+    public function writesXmlOnSessionFinished(): void
+    {
+        // Arrange
+        $path = self::tmpPath();
+        try {
+            $dispatcher = self::wirePlugin(new JUnitPlugin($path, 'Testo'));
+
+            // Act — minimal lifecycle: session start/end with no tests.
+            $dispatcher->dispatch(new SessionStarting());
+            $dispatcher->dispatch(self::sessionFinished());
+
+            // Assert
+            Assert::true(\file_exists($path));
+            $xml = \simplexml_load_file($path);
+            Assert::notSame($xml, false);
+            Assert::same((string) $xml['name'], 'Testo');
+            Assert::same((string) $xml['tests'], '0');
+        } finally {
+            self::cleanup($path);
+        }
+    }
+
+    public function emitsCaseForRegularPipelineTest(): void
+    {
+        // Arrange
+        $path = self::tmpPath();
+        try {
+            $dispatcher = self::wirePlugin(new JUnitPlugin($path));
+
+            $suiteInfo = self::makeSuiteInfo('CoreSuite');
+            $caseInfo = self::makeCaseInfo();
+            $testInfo = self::makeTestInfo('passingTest');
+            $result = new TestResult(info: $testInfo, status: Status::Passed, attributes: ['duration' => 7]);
+
+            // Act
+            $dispatcher->dispatch(new SessionStarting());
+            $dispatcher->dispatch(new TestSuiteStarting($suiteInfo));
+            $dispatcher->dispatch(new TestCaseStarting($caseInfo));
+            $dispatcher->dispatch(new TestPipelineFinished($testInfo, $result));
+            $dispatcher->dispatch(new TestCaseFinished($caseInfo, new CaseResult([$result], Status::Passed)));
+            $dispatcher->dispatch(new TestSuiteFinished($suiteInfo, new SuiteResult([], Status::Passed)));
+            $dispatcher->dispatch(self::sessionFinished());
+
+            // Assert
+            $xml = \simplexml_load_file($path);
+            Assert::notSame($xml, false);
+            Assert::same((string) $xml['tests'], '1');
+            Assert::same((string) $xml->testsuite['name'], 'CoreSuite');
+            // Class-layer suite carries the bare FQN (Infection-compatible),
+            // not `caseInfo->name` which has the `[type]` suffix.
+            Assert::same((string) $xml->testsuite->testsuite['name'], SampleTestClass::class);
+            Assert::same((string) $xml->testsuite->testsuite['file'], (new \ReflectionClass(SampleTestClass::class))->getFileName());
+            Assert::same((string) $xml->testsuite->testsuite->testcase['name'], 'passingTest');
+        } finally {
+            self::cleanup($path);
+        }
+    }
+
+    public function dataProviderEmitsCasePerDataSetAndSuppressesPipelineCase(): void
+    {
+        // Arrange
+        $path = self::tmpPath();
+        try {
+            $dispatcher = self::wirePlugin(new JUnitPlugin($path));
+
+            $suiteInfo = self::makeSuiteInfo('CoreSuite');
+            $caseInfo = self::makeCaseInfo();
+            $testInfo = self::makeTestInfo('passingTest');
+
+            $datasetA = new TestResult(info: $testInfo, status: Status::Passed, attributes: ['duration' => 1]);
+            $datasetB = new TestResult(info: $testInfo, status: Status::Passed, attributes: ['duration' => 2]);
+            $aggregate = new TestResult(info: $testInfo, status: Status::Passed);
+
+            // Act — TestBatchStarting marks the test as a data-provider parent;
+            // TestPipelineFinished must skip emission so we don't double-count.
+            $dispatcher->dispatch(new SessionStarting());
+            $dispatcher->dispatch(new TestSuiteStarting($suiteInfo));
+            $dispatcher->dispatch(new TestCaseStarting($caseInfo));
+            $dispatcher->dispatch(new TestBatchStarting($testInfo));
+            $dispatcher->dispatch(new TestDataSetFinished($testInfo, $datasetA, 'alpha', null, 0));
+            $dispatcher->dispatch(new TestDataSetFinished($testInfo, $datasetB, 'beta', null, 1));
+            $dispatcher->dispatch(new TestBatchFinished($testInfo, $aggregate));
+            $dispatcher->dispatch(new TestPipelineFinished($testInfo, $aggregate));
+            $dispatcher->dispatch(new TestCaseFinished($caseInfo, new CaseResult([$aggregate], Status::Passed)));
+            $dispatcher->dispatch(new TestSuiteFinished($suiteInfo, new SuiteResult([], Status::Passed)));
+            $dispatcher->dispatch(self::sessionFinished());
+
+            // Assert — exactly two cases, no rolled-up duplicate.
+            $xml = \simplexml_load_file($path);
+            Assert::notSame($xml, false);
+            Assert::same((string) $xml['tests'], '2');
+            $cases = $xml->testsuite->testsuite->testcase;
+            Assert::count($cases, 2);
+            Assert::same((string) $cases[0]['name'], 'passingTest [alpha]');
+            Assert::same((string) $cases[1]['name'], 'passingTest [beta]');
+        } finally {
+            self::cleanup($path);
+        }
+    }
+
+    public function multipleProvidersIncludeProviderIndexInName(): void
+    {
+        // Arrange
+        $path = self::tmpPath();
+        try {
+            $dispatcher = self::wirePlugin(new JUnitPlugin($path));
+
+            $suiteInfo = self::makeSuiteInfo('CoreSuite');
+            $caseInfo = self::makeCaseInfo();
+            $testInfo = self::makeTestInfo('passingTest');
+            $result = new TestResult(info: $testInfo, status: Status::Passed);
+            $aggregate = new TestResult(info: $testInfo, status: Status::Passed);
+
+            // Act
+            $dispatcher->dispatch(new SessionStarting());
+            $dispatcher->dispatch(new TestSuiteStarting($suiteInfo));
+            $dispatcher->dispatch(new TestCaseStarting($caseInfo));
+            $dispatcher->dispatch(new TestBatchStarting($testInfo));
+            $dispatcher->dispatch(new TestDataSetFinished($testInfo, $result, 'k', 0, 0));
+            $dispatcher->dispatch(new TestDataSetFinished($testInfo, $result, 'k', 1, 1));
+            $dispatcher->dispatch(new TestBatchFinished($testInfo, $aggregate));
+            $dispatcher->dispatch(new TestPipelineFinished($testInfo, $aggregate));
+            $dispatcher->dispatch(new TestCaseFinished($caseInfo, new CaseResult([$aggregate], Status::Passed)));
+            $dispatcher->dispatch(new TestSuiteFinished($suiteInfo, new SuiteResult([], Status::Passed)));
+            $dispatcher->dispatch(self::sessionFinished());
+
+            // Assert
+            $xml = \simplexml_load_file($path);
+            Assert::notSame($xml, false);
+            $cases = $xml->testsuite->testsuite->testcase;
+            Assert::same((string) $cases[0]['name'], 'passingTest [0:k]');
+            Assert::same((string) $cases[1]['name'], 'passingTest [1:k]');
+        } finally {
+            self::cleanup($path);
+        }
+    }
+
+    public function constructorPathWinsOverCliFlag(): void
+    {
+        // Arrange — manually-added instances must obey their explicit path,
+        // ignoring `--log-junit=…` (which is intended for the default inert instance).
+        $constructorPath = self::tmpPath();
+        $cliPath = self::tmpPath();
+        try {
+            $dispatcher = self::wirePlugin(new JUnitPlugin($constructorPath), cliPath: $cliPath);
+
+            // Act
+            $dispatcher->dispatch(new SessionStarting());
+            $dispatcher->dispatch(self::sessionFinished());
+
+            // Assert — constructor path is written; CLI path is untouched.
+            Assert::true(\file_exists($constructorPath));
+            Assert::false(\file_exists($cliPath));
+        } finally {
+            self::cleanup($constructorPath);
+            self::cleanup($cliPath);
+        }
+    }
+
+    public function cliFlagActivatesInertInstance(): void
+    {
+        // Arrange — no constructor path (inert default); CLI flag should activate it.
+        $cliPath = self::tmpPath();
+        try {
+            $dispatcher = self::wirePlugin(new JUnitPlugin(), cliPath: $cliPath);
+
+            // Act
+            $dispatcher->dispatch(new SessionStarting());
+            $dispatcher->dispatch(self::sessionFinished());
+
+            // Assert
+            Assert::true(\file_exists($cliPath));
+        } finally {
+            self::cleanup($cliPath);
+        }
+    }
+
+    public function inertWithoutPathFromAnySource(): void
+    {
+        // Arrange — no constructor path, no CLI path → plugin must not register listeners.
+        $dispatcher = self::wirePlugin(new JUnitPlugin());
+
+        // Act — drive a full session; nothing should blow up and no file should appear.
+        $dispatcher->dispatch(new SessionStarting());
+        $dispatcher->dispatch(self::sessionFinished());
+
+        // Assert — listener registry is empty for our events; absence of crash already implies no-op.
+        Assert::same(\iterator_to_array($dispatcher->getListenersForEvent(new SessionStarting()), false), []);
+        Assert::same(\iterator_to_array($dispatcher->getListenersForEvent(self::sessionFinished()), false), []);
+    }
+
+    public function sessionStartingResetsBetweenRuns(): void
+    {
+        // Arrange — emit two sessions through the same plugin instance; the
+        // second run must not contain residue from the first.
+        $path = self::tmpPath();
+        try {
+            $plugin = new JUnitPlugin($path);
+            $dispatcher = self::wirePlugin($plugin);
+
+            $suiteInfo = self::makeSuiteInfo('Run1');
+            $caseInfo = self::makeCaseInfo();
+            $testInfo = self::makeTestInfo('passingTest');
+
+            // Run 1
+            $dispatcher->dispatch(new SessionStarting());
+            $dispatcher->dispatch(new TestSuiteStarting($suiteInfo));
+            $dispatcher->dispatch(new TestCaseStarting($caseInfo));
+            $dispatcher->dispatch(new TestPipelineFinished(
+                $testInfo,
+                new TestResult($testInfo, Status::Passed),
+            ));
+            $dispatcher->dispatch(new TestCaseFinished($caseInfo, new CaseResult([], Status::Passed)));
+            $dispatcher->dispatch(new TestSuiteFinished($suiteInfo, new SuiteResult([], Status::Passed)));
+            $dispatcher->dispatch(self::sessionFinished());
+
+            // Run 2 — fresh, but only one suite "Run2" with no cases.
+            $suiteInfo2 = self::makeSuiteInfo('Run2');
+            $dispatcher->dispatch(new SessionStarting());
+            $dispatcher->dispatch(new TestSuiteStarting($suiteInfo2));
+            $dispatcher->dispatch(new TestSuiteFinished($suiteInfo2, new SuiteResult([], Status::Passed)));
+            $dispatcher->dispatch(self::sessionFinished());
+
+            // Act
+            $xml = \simplexml_load_file($path);
+
+            // Assert — only Run2 is present, totals are zero.
+            Assert::notSame($xml, false);
+            Assert::same((string) $xml['tests'], '0');
+            Assert::same((string) $xml->testsuite['name'], 'Run2');
+            Assert::count($xml->testsuite, 1);
+        } finally {
+            self::cleanup($path);
+        }
+    }
+
+    /**
+     * Wires a freshly built plugin into a real {@see EventDispatcher}.
+     */
+    private static function wirePlugin(JUnitPlugin $plugin, ?string $cliPath = null): EventDispatcher
+    {
+        $dispatcher = new EventDispatcher();
+        $container = new ObjectContainer();
+        $container->set($dispatcher, EventListenerCollector::class);
+
+        $input = new JUnitInput();
+        $input->outputPath = $cliPath;
+        $container->set($input, JUnitInput::class);
+
+        $plugin->configure($container);
+
+        return $dispatcher;
+    }
+
+    private static function sessionFinished(): SessionFinished
+    {
+        return new SessionFinished(new RunResult([], Status::Passed, 0.0));
+    }
+
+    /**
+     * @param non-empty-string $name
+     */
+    private static function makeSuiteInfo(string $name): SuiteInfo
+    {
+        return new SuiteInfo(name: $name, testCases: new CaseDefinitions());
+    }
+
+    private static function makeCaseInfo(): CaseInfo
+    {
+        return new CaseInfo(
+            definition: new CaseDefinition(
+                name: SampleTestClass::class,
+                type: 'test',
+                reflection: new \ReflectionClass(SampleTestClass::class),
+            ),
+        );
+    }
+
+    /**
+     * @param non-empty-string $method
+     */
+    private static function makeTestInfo(string $method): TestInfo
+    {
+        return new TestInfo(
+            name: $method,
+            caseInfo: self::makeCaseInfo(),
+            testDefinition: new TestDefinition(new \ReflectionMethod(SampleTestClass::class, $method)),
+        );
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function tmpPath(): string
+    {
+        return \sys_get_temp_dir() . '/testo_junit_plugin_' . \uniqid() . '.xml';
+    }
+
+    private static function cleanup(string $path): void
+    {
+        \is_file($path) and \unlink($path);
+        $dir = \dirname($path);
+        // Don't blow up on nested temp dirs that other tests may share.
+        if (\is_dir($dir) && $dir !== \sys_get_temp_dir()) {
+            // Best-effort: only remove if empty.
+            @\rmdir($dir);
+        }
+    }
+}

--- a/tests/Output/Unit/JUnit/JUnitWriterTest.php
+++ b/tests/Output/Unit/JUnit/JUnitWriterTest.php
@@ -1,0 +1,502 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Unit\JUnit;
+
+use Testo\Assert;
+use Testo\Core\Context\CaseInfo;
+use Testo\Core\Context\TestInfo;
+use Testo\Core\Context\TestResult;
+use Testo\Core\Definition\CaseDefinition;
+use Testo\Core\Definition\TestDefinition;
+use Testo\Core\Value\Status;
+use Testo\Output\JUnit\Internal\JUnitWriter;
+use Testo\Test;
+use Tests\Output\Stub\JUnit\SampleTestClass;
+
+#[Test]
+final class JUnitWriterTest
+{
+    public function emptyRunProducesValidEmptyDocument(): void
+    {
+        // Arrange
+        $writer = new JUnitWriter();
+
+        // Act
+        $xml = self::loadXml($writer->generate('Testo'));
+
+        // Assert
+        Assert::same((string) $xml['name'], 'Testo');
+        Assert::same((string) $xml['tests'], '0');
+        Assert::same((string) $xml['failures'], '0');
+        Assert::same((string) $xml['errors'], '0');
+        Assert::same((string) $xml['skipped'], '0');
+        Assert::count($xml->testsuite, 0);
+    }
+
+    public function singleSuiteWithPassingTest(): void
+    {
+        // Arrange
+        $writer = new JUnitWriter();
+        $writer->startSuite('MySuite');
+        $writer->addTestResult(self::makeResult('passingTest', Status::Passed, durationMs: 12));
+        $writer->finishSuite();
+
+        // Act
+        $xml = self::loadXml($writer->generate('Testo'));
+
+        // Assert: rolled-up totals
+        Assert::same((string) $xml['tests'], '1');
+        Assert::same((string) $xml['failures'], '0');
+        Assert::same((string) $xml['errors'], '0');
+        Assert::same((string) $xml['skipped'], '0');
+
+        // Suite
+        $suite = $xml->testsuite;
+        Assert::same((string) $suite['name'], 'MySuite');
+        Assert::same((string) $suite['tests'], '1');
+        Assert::same((string) $suite['failures'], '0');
+
+        // Test case
+        $case = $suite->testcase;
+        Assert::same((string) $case['name'], 'passingTest');
+        Assert::same((string) $case['classname'], SampleTestClass::class);
+        Assert::same((string) $case['time'], '0.012000');
+        // No <failure>, <error>, <skipped>
+        Assert::count($case->failure, 0);
+        Assert::count($case->error, 0);
+        Assert::count($case->skipped, 0);
+    }
+
+    public function suiteCarriesOptionalFileAttribute(): void
+    {
+        // Arrange — `file` on `<testsuite>` is consumed by Infection's
+        // `JUnitTestFileDataProvider` to locate test source files.
+        $writer = new JUnitWriter();
+        $writer->startSuite(SampleTestClass::class, '/abs/path/SampleTestClass.php');
+        $writer->addTestResult(self::makeResult('passingTest', Status::Passed));
+        $writer->finishSuite();
+
+        // Act
+        $xml = self::loadXml($writer->generate('Testo'));
+
+        // Assert
+        Assert::same((string) $xml->testsuite['file'], '/abs/path/SampleTestClass.php');
+    }
+
+    public function failingTestRendersFailureElement(): void
+    {
+        // Arrange
+        $writer = new JUnitWriter();
+        $writer->startSuite('MySuite');
+        $exception = new \RuntimeException('Expected 5, got 4');
+        $writer->addTestResult(self::makeResult(
+            'failingTest',
+            Status::Failed,
+            durationMs: 5,
+            failure: $exception,
+        ));
+        $writer->finishSuite();
+
+        // Act
+        $xml = self::loadXml($writer->generate('Testo'));
+
+        // Assert
+        Assert::same((string) $xml['failures'], '1');
+        Assert::same((string) $xml['errors'], '0');
+
+        $failure = $xml->testsuite->testcase->failure;
+        Assert::count($failure, 1);
+        Assert::same((string) $failure['type'], \RuntimeException::class);
+        Assert::same((string) $failure['message'], 'Expected 5, got 4');
+        // CDATA payload should mention the file and "Stack trace:" header.
+        Assert::true(\str_contains((string) $failure, 'Stack trace:'));
+    }
+
+    public function erroredTestRendersErrorElement(): void
+    {
+        // Arrange
+        $writer = new JUnitWriter();
+        $writer->startSuite('MySuite');
+        $writer->addTestResult(self::makeResult(
+            'failingTest',
+            Status::Error,
+            failure: new \LogicException('Boom'),
+        ));
+        $writer->finishSuite();
+
+        // Act
+        $xml = self::loadXml($writer->generate('Testo'));
+
+        // Assert
+        Assert::same((string) $xml['errors'], '1');
+        Assert::same((string) $xml['failures'], '0');
+        $error = $xml->testsuite->testcase->error;
+        Assert::count($error, 1);
+        Assert::same((string) $error['type'], \LogicException::class);
+        Assert::same((string) $error['message'], 'Boom');
+    }
+
+    public function skippedTestRendersSkippedElement(): void
+    {
+        // Arrange
+        $writer = new JUnitWriter();
+        $writer->startSuite('MySuite');
+        $writer->addTestResult(self::makeResult('passingTest', Status::Skipped));
+        $writer->finishSuite();
+
+        // Act
+        $xml = self::loadXml($writer->generate('Testo'));
+
+        // Assert
+        Assert::same((string) $xml['skipped'], '1');
+        Assert::count($xml->testsuite->testcase->skipped, 1);
+    }
+
+    public function cancelledTestCountsAsSkipped(): void
+    {
+        // Arrange
+        $writer = new JUnitWriter();
+        $writer->startSuite('MySuite');
+        $writer->addTestResult(self::makeResult('passingTest', Status::Cancelled));
+        $writer->finishSuite();
+
+        // Act
+        $xml = self::loadXml($writer->generate('Testo'));
+
+        // Assert
+        Assert::same((string) $xml['skipped'], '1');
+        Assert::count($xml->testsuite->testcase->skipped, 1);
+    }
+
+    public function abortedTestCountsAsError(): void
+    {
+        // Arrange
+        $writer = new JUnitWriter();
+        $writer->startSuite('MySuite');
+        $writer->addTestResult(self::makeResult(
+            'failingTest',
+            Status::Aborted,
+            failure: new \RuntimeException('aborted by interceptor'),
+        ));
+        $writer->finishSuite();
+
+        // Act
+        $xml = self::loadXml($writer->generate('Testo'));
+
+        // Assert
+        Assert::same((string) $xml['errors'], '1');
+        $error = $xml->testsuite->testcase->error;
+        Assert::same((string) $error['type'], 'Aborted');
+        Assert::same((string) $error['message'], 'aborted by interceptor');
+    }
+
+    public function riskyTestCountsAsError(): void
+    {
+        // Arrange — Risky is mapped to <error type="Risky"> for broadest CI compatibility.
+        $writer = new JUnitWriter();
+        $writer->startSuite('MySuite');
+        $writer->addTestResult(self::makeResult('passingTest', Status::Risky));
+        $writer->finishSuite();
+
+        // Act
+        $xml = self::loadXml($writer->generate('Testo'));
+
+        // Assert
+        Assert::same((string) $xml['errors'], '1');
+        $error = $xml->testsuite->testcase->error;
+        Assert::same((string) $error['type'], 'Risky');
+    }
+
+    public function flakyTestCountsAsPass(): void
+    {
+        // Arrange
+        $writer = new JUnitWriter();
+        $writer->startSuite('MySuite');
+        $writer->addTestResult(self::makeResult('passingTest', Status::Flaky));
+        $writer->finishSuite();
+
+        // Act
+        $xml = self::loadXml($writer->generate('Testo'));
+
+        // Assert
+        Assert::same((string) $xml['tests'], '1');
+        Assert::same((string) $xml['failures'], '0');
+        Assert::same((string) $xml['errors'], '0');
+        $case = $xml->testsuite->testcase;
+        Assert::count($case->failure, 0);
+        Assert::count($case->error, 0);
+        Assert::count($case->skipped, 0);
+    }
+
+    public function mixedRunRollsCountersUp(): void
+    {
+        // Arrange
+        $writer = new JUnitWriter();
+        $writer->startSuite('MySuite');
+        $writer->addTestResult(self::makeResult('passingTest', Status::Passed, durationMs: 10));
+        $writer->addTestResult(self::makeResult(
+            'failingTest',
+            Status::Failed,
+            durationMs: 20,
+            failure: new \RuntimeException('boom'),
+        ));
+        $writer->addTestResult(self::makeResult('passingTest', Status::Skipped));
+        $writer->addTestResult(self::makeResult(
+            'failingTest',
+            Status::Error,
+            failure: new \LogicException('crash'),
+        ));
+        $writer->finishSuite();
+
+        // Act
+        $xml = self::loadXml($writer->generate('Testo'));
+
+        // Assert: top-level totals
+        Assert::same((string) $xml['tests'], '4');
+        Assert::same((string) $xml['failures'], '1');
+        Assert::same((string) $xml['errors'], '1');
+        Assert::same((string) $xml['skipped'], '1');
+
+        // Suite mirrors
+        Assert::same((string) $xml->testsuite['tests'], '4');
+        Assert::same((string) $xml->testsuite['failures'], '1');
+        Assert::same((string) $xml->testsuite['errors'], '1');
+        Assert::same((string) $xml->testsuite['skipped'], '1');
+    }
+
+    public function dataProviderProducesOneCasePerDataset(): void
+    {
+        // Arrange
+        $writer = new JUnitWriter();
+        $writer->startSuite('MySuite');
+        $writer->addTestResult(self::makeResult('passingTest', Status::Passed), 'passingTest [zero]');
+        $writer->addTestResult(self::makeResult(
+            'passingTest',
+            Status::Failed,
+            failure: new \RuntimeException('nope'),
+        ), 'passingTest [one]');
+        $writer->addTestResult(self::makeResult('passingTest', Status::Passed), 'passingTest [two]');
+        $writer->finishSuite();
+
+        // Act
+        $xml = self::loadXml($writer->generate('Testo'));
+
+        // Assert
+        Assert::same((string) $xml['tests'], '3');
+        Assert::same((string) $xml['failures'], '1');
+        $cases = $xml->testsuite->testcase;
+        Assert::count($cases, 3);
+        Assert::same((string) $cases[0]['name'], 'passingTest [zero]');
+        Assert::same((string) $cases[1]['name'], 'passingTest [one]');
+        Assert::same((string) $cases[2]['name'], 'passingTest [two]');
+    }
+
+    public function nestedSuiteRepresentsTheClassLayer(): void
+    {
+        // Arrange — outer suite (TestSuite) wraps inner suite (TestCase/class layer).
+        $writer = new JUnitWriter();
+        $writer->startSuite('OuterSuite');
+        $writer->startSuite('SampleTestClass [test]');
+        $writer->addTestResult(self::makeResult('passingTest', Status::Passed, durationMs: 5));
+        $writer->addTestResult(self::makeResult(
+            'failingTest',
+            Status::Failed,
+            durationMs: 10,
+            failure: new \RuntimeException('boom'),
+        ));
+        $writer->finishSuite(); // close class layer
+        $writer->finishSuite(); // close outer
+
+        // Act
+        $xml = self::loadXml($writer->generate('Testo'));
+
+        // Assert: nested structure
+        $outer = $xml->testsuite;
+        Assert::same((string) $outer['name'], 'OuterSuite');
+        // Counters bubble up across nesting
+        Assert::same((string) $outer['tests'], '2');
+        Assert::same((string) $outer['failures'], '1');
+
+        $inner = $outer->testsuite;
+        Assert::same((string) $inner['name'], 'SampleTestClass [test]');
+        Assert::same((string) $inner['tests'], '2');
+        Assert::same((string) $inner['failures'], '1');
+        Assert::count($inner->testcase, 2);
+    }
+
+    public function freeFunctionUsesNamespaceAsClassname(): void
+    {
+        // Arrange — closure declared in `Tests\Output\Stub\JUnit` namespace.
+        require_once __DIR__ . '/../../Stub/JUnit/free_function_helper.php';
+        $reflection = new \ReflectionFunction('Tests\\Output\\Stub\\JUnit\\junitFreeFunction');
+
+        $writer = new JUnitWriter();
+        $writer->startSuite('MySuite');
+        $writer->addTestResult(self::makeResultWithReflection($reflection, Status::Passed));
+        $writer->finishSuite();
+
+        // Act
+        $xml = self::loadXml($writer->generate('Testo'));
+
+        // Assert: namespace serves as classname for free-function tests.
+        Assert::same((string) $xml->testsuite->testcase['classname'], 'Tests\\Output\\Stub\\JUnit');
+    }
+
+    public function writeCreatesParentDirectory(): void
+    {
+        // Arrange
+        $tmpDir = \sys_get_temp_dir() . '/testo_junit_' . \uniqid();
+        $path = $tmpDir . '/nested/junit.xml';
+        try {
+            $writer = new JUnitWriter();
+            $writer->startSuite('MySuite');
+            $writer->addTestResult(self::makeResult('passingTest', Status::Passed));
+            $writer->finishSuite();
+
+            // Act
+            $writer->write(\Internal\Path::create($path), 'Testo');
+
+            // Assert
+            Assert::true(\file_exists($path));
+            $loaded = \simplexml_load_file($path);
+            Assert::notSame($loaded, false);
+            Assert::same((string) $loaded['name'], 'Testo');
+        } finally {
+            self::cleanup($tmpDir);
+        }
+    }
+
+    public function writeAutoClosesOpenSuites(): void
+    {
+        // Arrange — defensive: SessionFinished shouldn't crash on dangling suites.
+        $writer = new JUnitWriter();
+        $writer->startSuite('Outer');
+        $writer->startSuite('Inner');
+        $writer->addTestResult(self::makeResult('passingTest', Status::Passed));
+
+        // Act — generate without explicit finishSuite() calls.
+        $xml = self::loadXml($writer->generate('Testo'));
+
+        // Assert
+        Assert::same((string) $xml->testsuite['name'], 'Outer');
+        Assert::same((string) $xml->testsuite->testsuite['name'], 'Inner');
+    }
+
+    public function failureMessageWithSpecialCharsIsEncodedSafely(): void
+    {
+        // Arrange — embed a literal `]]>` in the message to verify the CDATA-escape path.
+        $writer = new JUnitWriter();
+        $writer->startSuite('MySuite');
+        $writer->addTestResult(self::makeResult(
+            'failingTest',
+            Status::Failed,
+            failure: new \RuntimeException('contains ]]> sequence'),
+        ));
+        $writer->finishSuite();
+        $xml = $writer->generate('Testo');
+
+        // Act — XML must remain well-formed.
+        $loaded = \simplexml_load_string($xml);
+
+        // Assert
+        Assert::notSame($loaded, false);
+        Assert::same((string) $loaded->testsuite->testcase->failure['message'], 'contains ]]> sequence');
+    }
+
+    public function resetClearsAccumulatedState(): void
+    {
+        // Arrange
+        $writer = new JUnitWriter();
+        $writer->startSuite('Discarded');
+        $writer->addTestResult(self::makeResult('passingTest', Status::Passed));
+        $writer->finishSuite();
+
+        // Act
+        $writer->reset();
+        $xml = self::loadXml($writer->generate('Testo'));
+
+        // Assert
+        Assert::same((string) $xml['tests'], '0');
+        Assert::count($xml->testsuite, 0);
+    }
+
+    /**
+     * @param non-empty-string $method
+     */
+    private static function makeResult(
+        string $method,
+        Status $status,
+        int $durationMs = 0,
+        ?\Throwable $failure = null,
+    ): TestResult {
+        $reflection = new \ReflectionMethod(SampleTestClass::class, $method);
+
+        $info = new TestInfo(
+            name: $method,
+            caseInfo: new CaseInfo(
+                definition: new CaseDefinition(
+                    name: SampleTestClass::class,
+                    type: 'test',
+                    reflection: new \ReflectionClass(SampleTestClass::class),
+                ),
+            ),
+            testDefinition: new TestDefinition($reflection),
+        );
+
+        return new TestResult(
+            info: $info,
+            status: $status,
+            failure: $failure,
+            attributes: ['duration' => $durationMs],
+        );
+    }
+
+    private static function makeResultWithReflection(
+        \ReflectionFunctionAbstract $reflection,
+        Status $status,
+    ): TestResult {
+        $info = new TestInfo(
+            name: 'free',
+            caseInfo: new CaseInfo(
+                definition: new CaseDefinition(
+                    name: null,
+                    type: 'test',
+                    reflection: null,
+                ),
+            ),
+            testDefinition: new TestDefinition($reflection),
+        );
+
+        return new TestResult(
+            info: $info,
+            status: $status,
+            attributes: ['duration' => 0],
+        );
+    }
+
+    private static function loadXml(string $raw): \SimpleXMLElement
+    {
+        $loaded = \simplexml_load_string($raw);
+        Assert::notSame($loaded, false);
+        \assert($loaded !== false);
+
+        return $loaded;
+    }
+
+    private static function cleanup(string $dir): void
+    {
+        if (!\is_dir($dir)) {
+            return;
+        }
+        $iter = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($iter as $info) {
+            $info->isDir() ? \rmdir($info->getPathname()) : \unlink($info->getPathname());
+        }
+        \rmdir($dir);
+    }
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! -->

## What was changed

- Added `JUnitPlugin` (`core/Output/JUnit/`) — emits a JUnit XML report (PHPUnit dialect) on session end. Modeled after `TeamcityPlugin`. All `Status` cases round-trip; data-provider tests produce one `<testcase>` per dataset.
- Added `--log-junit=<path>` CLI flag (mirrors PHPUnit / Pest / ParaTest naming). Constructor path takes precedence over the flag, so manual instances always write to their configured path; the inert default in `ApplicationPlugins::defaults()` activates only when the flag is passed.
- Wired Infection bridge to use JUnit when available: `--log-junit` is appended to the initial test run command, `hasJUnitReport()` is now dynamic (`is_file()` check), and `getMutantCommandLine()` prefers `TestLocation::getFilePath()` from JUnit before falling back to reflection-based path resolution.
- Improved `PhpUnitXmlReport` docblock: clarified naming, primary consumer (Infection), and the conventional `coverage-xml/` + `junit.xml` layout that pairs with `JUnitPlugin`.

## Why?

Testo had no machine-readable file-based test report — only the streaming TeamCity protocol. CI platforms (GitHub Actions, GitLab, Jenkins, Azure DevOps) consume JUnit XML natively to render the test tab, annotate failing tests on PR diffs, and track flaky-test history. Without this, pipelines using Testo only saw "tests passed/failed" as the final signal.

Second motivation is Infection: with a JUnit report present, Infection maps mutated lines to test files via `TestLocation::filePath` instead of reflection, which lets us drop reflection-only path discovery and makes mutation runs work for tests where the FQN doesn't trivially map to a file (free functions, dynamic classes).

## Checklist

- Closes #122
- Tested
  - [x] Tested manually <!-- ran infection end-to-end with the new bridge -->
  - [x] Unit tests added <!-- 26 cases under tests/Output/Unit/JUnit/ -->
- [ ] Documentation
