### PR TITLE
Add missing psalm-, phpstan-assert annotation

### DIFF
--- a/plugin/assert/Assert.php
+++ b/plugin/assert/Assert.php
@@ -36,10 +36,15 @@ final class Assert
     /**
      * Asserts that two values are the same (identical).
      *
+     * @template ExpectedType
+     *
      * @param mixed $actual The actual value to compare against the expected value.
-     * @param mixed $expected The expected value.
+     * @param ExpectedType $expected The expected value.
      * @param string $message Short description about what exactly is being asserted.
      * @throws AssertionException when the assertion fails.
+     *
+     * @psalm-assert =ExpectedType $actual
+     * @phpstan-assert =ExpectedType $actual
      */
     #[AssertMethod]
     public static function same(mixed $actual, mixed $expected, string $message = ''): void

--- a/plugin/assert/Assert.php
+++ b/plugin/assert/Assert.php
@@ -131,6 +131,9 @@ final class Assert
      * @param mixed $actual The actual value to check.
      * @param string $message Short description about what exactly is being asserted.
      * @throws AssertionException when the assertion fails.
+     *
+     * @psalm-assert true $actual
+     * @phpstan-assert true $actual
      */
     #[AssertMethod]
     public static function true(mixed $actual, string $message = ''): void
@@ -153,6 +156,9 @@ final class Assert
      * @param mixed $actual The actual value to check.
      * @param string $message Short description about what exactly is being asserted.
      * @throws AssertionException when the assertion fails.
+     *
+     * @psalm-assert false $actual
+     * @phpstan-assert false $actual
      */
     #[AssertMethod]
     public static function false(mixed $actual, string $message = ''): void
@@ -220,6 +226,9 @@ final class Assert
      * @param mixed $actual The actual value to check for null.
      * @param string $message Short description about what exactly is being asserted.
      * @throws AssertionException when the assertion fails.
+     *
+     * @psalm-assert null $actual
+     * @phpstan-assert null $actual
      */
     #[AssertMethod]
     public static function null(
@@ -306,6 +315,9 @@ final class Assert
      * Asserts that the given value is of `string` data type.
      *
      * @throws AssertionException when the assertion fails.
+     *
+     * @psalm-assert string $actual
+     * @phpstan-assert string $actual
      */
     #[AssertMethod]
     public static function string(mixed $actual): StringType
@@ -317,6 +329,9 @@ final class Assert
      * Asserts that the given value is of `int` data type.
      *
      * @throws AssertionException
+     *
+     * @psalm-assert int $actual
+     * @phpstan-assert int $actual
      */
     public static function int(mixed $actual): IntType
     {
@@ -327,6 +342,9 @@ final class Assert
      * Asserts that the given value is of `float` data type.
      *
      * @throws AssertionException
+     *
+     * @psalm-assert float $actual
+     * @phpstan-assert float $actual
      */
     public static function float(mixed $actual): FloatType
     {
@@ -365,6 +383,9 @@ final class Assert
      * Does not work with Generators.
      *
      * @throws AssertionException
+     *
+     * @psalm-assert iterable $actual
+     * @phpstan-assert iterable<mixed> $actual
      */
     public static function iterable(mixed $actual): IterableType
     {
@@ -375,6 +396,9 @@ final class Assert
      * Asserts that the given value is of `array` data type.
      *
      * @throws AssertionException
+     *
+     * @psalm-assert array $actual
+     * @phpstan-assert array<mixed, mixed> $actual
      */
     public static function array(mixed $actual): ArrayType
     {
@@ -386,6 +410,8 @@ final class Assert
      *
      * @throws AssertionException
      *
+     * @psalm-assert object $actual
+     * @phpstan-assert object $actual
      */
     public static function object(mixed $actual): ObjectType
     {


### PR DESCRIPTION
## What was changed

Added missing `@phpstan-assert` and `@psalm-assert` annotations to the static methods of the `Assert` class (`int`, `string`, `true`, `false`, `null`, etc).

## Why?

Without these annotations, PHPStan / Psalm don't narrow types after an `Assert::*` call, so user code following the assertion still has to deal with the pre-assertion type.
