### PR TITLE
Assert not null

### DIFF
--- a/plugin/assert/Assert.php
+++ b/plugin/assert/Assert.php
@@ -253,6 +253,32 @@ final class Assert
     }
 
     /**
+     * Asserts that the given value is not null.
+     *
+     * @param mixed $actual The actual value to check for non-null.
+     * @param string $message Short description about what exactly is being asserted.
+     * @throws AssertionException when the assertion fails.
+     *
+     * @psalm-assert !null $actual
+     * @phpstan-assert !null $actual
+     */
+    #[AssertMethod]
+    public static function notNull(
+        mixed $actual,
+        string $message = '',
+    ): void {
+        $actual !== null
+            ? StaticState::success($actual, 'is not `null`', $message)
+            : StaticState::fail(new AssertionException(
+                value: 'null',
+                assertion: 'is not `null`',
+                context: $message,
+                reason: 'expected a non-null value, got `null`',
+                details: '',
+            ));
+    }
+
+    /**
      * Checks if a value is blank.
      *
      * Successful only for values representing absence of data:

--- a/plugin/assert/Assert.php
+++ b/plugin/assert/Assert.php
@@ -264,17 +264,18 @@ final class Assert
      */
     #[AssertMethod]
     public static function notNull(
-        mixed $actual,
+        mixed  $actual,
         string $message = '',
     ): void {
         $actual !== null
             ? StaticState::success($actual, 'is not `null`', $message)
-            : StaticState::fail(new AssertionException(
-                value: 'null',
+            : StaticState::fail(new ComparisonFailure(
+                expected: 'non-null',
+                actual: $actual,
+                value: Support::stringify($actual),
                 assertion: 'is not `null`',
                 context: $message,
                 reason: 'expected a non-null value, got `null`',
-                details: '',
             ));
     }
 

--- a/plugin/assert/Assert.php
+++ b/plugin/assert/Assert.php
@@ -264,7 +264,7 @@ final class Assert
      */
     #[AssertMethod]
     public static function notNull(
-        mixed  $actual,
+        mixed $actual,
         string $message = '',
     ): void {
         $actual !== null

--- a/plugin/assert/tests/Feature/AssertNotNullTest.php
+++ b/plugin/assert/tests/Feature/AssertNotNullTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Assert\Feature;
+
+use Testo\Assert;
+use Testo\Assert\State\Assertion;
+use Testo\Core\Value\Status;
+use Testo\Test;
+use Testo\Testing\Attribute\TestingSuite;
+use Testo\Testing\Traits\TestRunner;
+use Tests\Assert\Stub\AssertNotNullNegative;
+
+#[TestingSuite(path: __DIR__ . '/../Stub')]
+final class AssertNotNullTest
+{
+    #[Test]
+    public function nullFails(): void
+    {
+        $result = TestRunner::runTest([AssertNotNullNegative::class, 'nullFails']);
+
+        Assert::same($result->status, Status::Failed);
+        Assert::instanceOf($result->failure, Assertion::class);
+        Assert::string($result->failure->getFailReason())
+            ->contains('expected a non-null value, got `null`');
+    }
+
+    #[Test]
+    public function nullFailsWithMessage(): void
+    {
+        $result = TestRunner::runTest([AssertNotNullNegative::class, 'nullFailsWithMessage']);
+
+        Assert::same($result->status, Status::Failed);
+        Assert::instanceOf($result->failure, Assertion::class);
+        Assert::string($result->failure->getFailReason())
+            ->contains('expected a non-null value, got `null`');
+        Assert::same($result->failure->getContext(), 'Value must not be null.');
+    }
+}

--- a/plugin/assert/tests/Feature/AssertNotNullTest.php
+++ b/plugin/assert/tests/Feature/AssertNotNullTest.php
@@ -11,10 +11,19 @@ use Testo\Test;
 use Testo\Testing\Attribute\TestingSuite;
 use Testo\Testing\Traits\TestRunner;
 use Tests\Assert\Stub\AssertNotNullNegative;
+use Tests\Assert\Stub\AssertNotNullPositive;
 
 #[TestingSuite(path: __DIR__ . '/../Stub')]
 final class AssertNotNullTest
 {
+    #[Test]
+    public function nonNullValuePasses(): void
+    {
+        $result = TestRunner::runTest([AssertNotNullPositive::class, 'falsyNonNullValues']);
+
+        Assert::same($result->status, Status::Passed);
+    }
+
     #[Test]
     public function nullFails(): void
     {

--- a/plugin/assert/tests/Self/AssertNotNull.php
+++ b/plugin/assert/tests/Self/AssertNotNull.php
@@ -34,4 +34,22 @@ final class AssertNotNull
         Expect::exception(AssertionException::class);
         Assert::notNull(null, 'Value must not be null.');
     }
+
+    #[Test]
+    public function checkExceptionContext(): void
+    {
+        try {
+            Assert::notNull(null, 'my context');
+        } catch (AssertionException $e) {
+            Assert::same($e->getContext(), 'my context');
+            return;
+        }
+        Assert::fail('Expected AssertionException to be thrown');
+    }
+
+    #[Test]
+    public function checkObjectIsNotNull(): void
+    {
+        Assert::notNull(new \stdClass());
+    }
 }

--- a/plugin/assert/tests/Self/AssertNotNull.php
+++ b/plugin/assert/tests/Self/AssertNotNull.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Assert\Self;
+
+use Testo\Assert;
+use Testo\Assert\State\Assertion\AssertionException;
+use Testo\Expect;
+use Testo\Test;
+
+final class AssertNotNull
+{
+    #[Test]
+    public function checkNonNullValues(): void
+    {
+        Assert::notNull(0);
+        Assert::notNull('');
+        Assert::notNull(false);
+        Assert::notNull([]);
+        Assert::notNull(0.0);
+    }
+
+    #[Test]
+    public function checkNullFails(): void
+    {
+        Expect::exception(AssertionException::class);
+        Assert::notNull(null);
+    }
+
+    #[Test]
+    public function checkNullFailsWithMessage(): void
+    {
+        Expect::exception(AssertionException::class);
+        Assert::notNull(null, 'Value must not be null.');
+    }
+}

--- a/plugin/assert/tests/Stub/AssertNotNullNegative.php
+++ b/plugin/assert/tests/Stub/AssertNotNullNegative.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Assert\Stub;
+
+use Testo\Assert;
+use Testo\Test;
+
+/**
+ * Stubs for negative {@see Assert::notNull()} scenarios.
+ */
+final class AssertNotNullNegative
+{
+    #[Test]
+    public function nullFails(): void
+    {
+        Assert::notNull(null);
+    }
+
+    #[Test]
+    public function nullFailsWithMessage(): void
+    {
+        Assert::notNull(null, 'Value must not be null.');
+    }
+}

--- a/plugin/assert/tests/Stub/AssertNotNullPositive.php
+++ b/plugin/assert/tests/Stub/AssertNotNullPositive.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Assert\Stub;
+
+use Testo\Assert;
+use Testo\Test;
+
+/**
+ * Stubs for positive {@see Assert::notNull()} scenarios.
+ */
+final class AssertNotNullPositive
+{
+    #[Test]
+    public function falsyNonNullValues(): void
+    {
+        Assert::notNull(0);
+        Assert::notNull('');
+        Assert::notNull(false);
+        Assert::notNull([]);
+        Assert::notNull(0.0);
+    }
+}

--- a/tests/Testo/Self/AssertTest.php
+++ b/tests/Testo/Self/AssertTest.php
@@ -38,6 +38,7 @@ final class AssertTest
     {
         Assert::same(1, 1);
         Assert::null(null);
+        Assert::notNull(0);
         Assert::notSame('42', 42);
         Assert::true(true);
         Assert::false(false);


### PR DESCRIPTION
 What was changed                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                           
  Added Assert::notNull() method — the complement of the existing Assert::null(). Throws AssertionException when the actual value is null, narrows the type via @psalm-assert !null / @phpstan-assert !null.                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                           
  Why?                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                           
  Assert::null() existed but its counterpart was missing, forcing users to work around with Assert::notSame(null, $value) or similar.                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                           
  Checklist                                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                           
  - Closes #                                                                                                                                                                                                                                                                                                                                               
  - Tested                                                                                                                                                                                                                                                                                                                                                 
    - Tested manually                                                                                                                                                                                                                                                                                                                                      
    - Unit tests added (plugin/assert/tests/Self/AssertNotNull.php)                                                                                                                                                                                                                                                                                        
  - Documentation   