### PR TITLE
feat(output): add JSON output plugin with `--json` and `--log-json` flags

### DIFF
--- a/bridge/symfony-console/src/Command/Run.php
+++ b/bridge/symfony-console/src/Command/Run.php
@@ -170,9 +170,17 @@ final class Run extends Base
         InputInterface  $input,
         OutputInterface $output,
     ): int {
+        // Exactly one renderer owns stdout — reject conflicting flags instead of silently picking one.
+        $teamcity = (bool) $input->getOption('teamcity');
+        $json = (bool) $input->getOption('json');
+        $teamcity && $json and throw new \InvalidArgumentException(
+            'Options --teamcity and --json are mutually exclusive: both render to stdout. Pick one, '
+            . 'or use --log-json=<path> to write JSON to a file alongside another renderer.',
+        );
+
         $renderer = match (true) {
-            (bool) $input->getOption('teamcity') => TeamcityPlugin::class,
-            (bool) $input->getOption('json') => JsonPlugin::class,
+            $teamcity => TeamcityPlugin::class,
+            $json => JsonPlugin::class,
             default => TerminalPlugin::class,
         };
         $this->container->get($renderer)->configure($this->container);

--- a/bridge/symfony-console/src/Command/Run.php
+++ b/bridge/symfony-console/src/Command/Run.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Testo\Output\Json\JsonPlugin;
 use Testo\Output\Teamcity\TeamcityPlugin;
 use Testo\Output\Terminal\TerminalPlugin;
 
@@ -78,6 +79,20 @@ final class Run extends Base
     {
         parent::configure();
         $this->addOption('teamcity', null, InputOption::VALUE_NONE);
+        $this->addOption(
+            'json',
+            null,
+            InputOption::VALUE_NONE,
+            'Render the run as a single minimalistic JSON object on stdout '
+            . '(run summary + failed tests). Intended for LLM agents and CI scripts.',
+        );
+        $this->addOption(
+            'log-json',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Write the minimalistic JSON report (run summary + failed tests) to the given path. '
+            . 'Unlike --json this keeps the human-readable terminal output; mirrors --log-junit.',
+        );
         $this->addOption(
             'filter',
             null,
@@ -155,9 +170,17 @@ final class Run extends Base
         InputInterface  $input,
         OutputInterface $output,
     ): int {
-        $input->getOption('teamcity')
-            ? $this->container->get(TeamcityPlugin::class)->configure($this->container)
-            : $this->container->get(TerminalPlugin::class)->configure($this->container);
+        $renderer = match (true) {
+            (bool) $input->getOption('teamcity') => TeamcityPlugin::class,
+            (bool) $input->getOption('json') => JsonPlugin::class,
+            default => TerminalPlugin::class,
+        };
+        $this->container->get($renderer)->configure($this->container);
+
+        // --log-json writes the JSON report to a file alongside the stdout renderer above.
+        $logJson = $input->getOption('log-json');
+        \is_string($logJson) && $logJson !== ''
+            and (new JsonPlugin($logJson))->configure($this->container);
 
         $result = $this->application->run();
 

--- a/core/Output/Json/Internal/JsonReport.php
+++ b/core/Output/Json/Internal/JsonReport.php
@@ -34,9 +34,13 @@ final class JsonReport
             'failures' => self::failures($result),
         ];
 
+        // JSON_INVALID_UTF8_SUBSTITUTE: failure messages, traces and captured output are raw strings
+        // from user code and may contain malformed UTF-8 (binary stdout, non-UTF-8 encodings). Without
+        // it JSON_THROW_ON_ERROR would abort the whole report; instead bad bytes become U+FFFD.
         return \json_encode(
             $payload,
-            \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR,
+            \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE
+            | \JSON_INVALID_UTF8_SUBSTITUTE | \JSON_THROW_ON_ERROR,
         );
     }
 

--- a/core/Output/Json/Internal/JsonReport.php
+++ b/core/Output/Json/Internal/JsonReport.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Json\Internal;
+
+use Testo\Core\Context\RunResult;
+use Testo\Core\Context\TestResult;
+use Testo\Core\Log\MessageLog;
+use Testo\Core\Value\Status;
+use Testo\Core\Value\Summary;
+use Testo\Output\Rendering\StackTrace;
+
+/**
+ * Builds a minimalistic JSON report from a {@see RunResult}.
+ *
+ * The report is intentionally lean: a top-level run summary plus a flat list of
+ * failed tests ({@see Status::Failed}/{@see Status::Error}) with everything needed
+ * to locate and fix a failure — the throwable, its `previous` chain, the stack
+ * trace, and any output the test captured. Passing/skipped/risky tests are
+ * collapsed into the counts and never listed individually, which keeps the
+ * payload small enough to feed straight into an LLM agent reading stdout.
+ *
+ * @internal
+ */
+final class JsonReport
+{
+    public function generate(RunResult $result): string
+    {
+        $payload = [
+            'status' => self::statusName($result->status),
+            'duration' => $result->duration,
+            'totals' => self::totals($result->summary),
+            'failures' => self::failures($result),
+        ];
+
+        return \json_encode(
+            $payload,
+            \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR,
+        );
+    }
+
+    /**
+     * Test counts keyed by lowercased {@see Status} name, with the grand total first.
+     * Zero-count statuses are omitted to keep the object compact.
+     *
+     * @return array<non-empty-string, int<0, max>>
+     */
+    private static function totals(Summary $summary): array
+    {
+        $totals = ['total' => $summary->total()];
+        foreach ($summary->counts as $name => $count) {
+            if ($count > 0) {
+                $totals[\strtolower($name)] = $count;
+            }
+        }
+
+        return $totals;
+    }
+
+    /**
+     * Walks the result tree and collects every failed/errored test in encounter order.
+     *
+     * @return list<array<non-empty-string, mixed>>
+     */
+    private static function failures(RunResult $result): array
+    {
+        $failures = [];
+        foreach ($result as $suite) {
+            foreach ($suite as $case) {
+                foreach ($case as $test) {
+                    $test->status->isFailure() and $failures[] = self::failure($test);
+                }
+            }
+        }
+
+        return $failures;
+    }
+
+    /**
+     * @return array<non-empty-string, mixed>
+     */
+    private static function failure(TestResult $test): array
+    {
+        $data = [
+            'test' => self::testId($test),
+            'status' => self::statusName($test->status),
+        ];
+
+        $failure = $test->failure;
+        if ($failure !== null) {
+            $data['exception'] = $failure::class;
+            $data['message'] = $failure->getMessage();
+            $data['file'] = $failure->getFile();
+            $data['line'] = $failure->getLine();
+            $data['trace'] = self::trace($failure, $test->info->testDefinition->reflection);
+
+            $causedBy = self::causedBy($failure);
+            $causedBy === [] or $data['causedBy'] = $causedBy;
+        }
+
+        $output = self::output($test->messages);
+        $output === [] or $data['output'] = $output;
+
+        return $data;
+    }
+
+    /**
+     * Fully-qualified test identifier: `Class::method` for class-bound tests,
+     * the function FQN for free-function tests.
+     *
+     * @return non-empty-string
+     */
+    private static function testId(TestResult $test): string
+    {
+        $info = $test->info;
+        $class = $info->caseInfo->definition->reflection?->getName();
+
+        return $class !== null
+            ? "{$class}::{$info->name}"
+            : $info->testDefinition->reflection->getName();
+    }
+
+    /**
+     * Stack trace as a list of `#n file(line): call` frames, trimmed at the test
+     * function boundary so it stops at user code instead of trailing off into
+     * dozens of internal runner/pipeline frames — the bulk of which are noise for
+     * anyone (or anything) trying to fix the test.
+     *
+     * @return list<non-empty-string>
+     */
+    private static function trace(\Throwable $failure, \ReflectionFunctionAbstract $boundary): array
+    {
+        $frames = StackTrace::cutStackTrace($failure->getTrace(), $boundary);
+
+        $lines = [];
+        foreach ($frames as $i => $frame) {
+            $file = $frame['file'] ?? '[internal function]';
+            $line = isset($frame['line']) ? ":{$frame['line']}" : '';
+            $class = $frame['class'] ?? '';
+            $type = $frame['type'] ?? '';
+            $function = $frame['function'] ?? '';
+
+            $location = $file === '[internal function]' ? $file : "{$file}{$line}";
+            $call = $class !== '' ? "{$class}{$type}{$function}()" : "{$function}()";
+            $lines[] = "#{$i} {$location}: {$call}";
+        }
+
+        return $lines;
+    }
+
+    /**
+     * The `previous` chain of a throwable, outermost cause first. Each link carries
+     * just its location — the outermost trace already covers the call path.
+     *
+     * @return list<array<non-empty-string, mixed>>
+     */
+    private static function causedBy(\Throwable $failure): array
+    {
+        $chain = [];
+        $current = $failure->getPrevious();
+        while ($current !== null) {
+            $chain[] = [
+                'exception' => $current::class,
+                'message' => $current->getMessage(),
+                'file' => $current->getFile(),
+                'line' => $current->getLine(),
+            ];
+            $current = $current->getPrevious();
+        }
+
+        return $chain;
+    }
+
+    /**
+     * Test-captured messages (stdout, logs, custom channels) in recorded order.
+     *
+     * @return list<array{channel: non-empty-string, content: non-empty-string}>
+     */
+    private static function output(MessageLog $messages): array
+    {
+        $output = [];
+        foreach ($messages as $message) {
+            $output[] = ['channel' => $message->channel, 'content' => $message->content];
+        }
+
+        return $output;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function statusName(Status $status): string
+    {
+        return \strtolower($status->name);
+    }
+}

--- a/core/Output/Json/JsonPlugin.php
+++ b/core/Output/Json/JsonPlugin.php
@@ -47,15 +47,16 @@ final class JsonPlugin implements PluginConfigurator
     private readonly JsonReport $report;
 
     /**
-     * @param non-empty-string|null $outputPath When set, the report is written to this file and
-     *        the active stdout renderer is left untouched (`--log-json` / file mode). When null,
-     *        the report is written to {@see $stream} (`--json` / stdout mode).
+     * @param string|null $outputPath When set to a non-empty path, the report is written to that
+     *        file and the active stdout renderer is left untouched (`--log-json` / file mode). When
+     *        null or an empty string, the report is written to {@see $stream} (`--json` / stdout
+     *        mode) — empty is normalized to null, matching {@see \Testo\Output\JUnit\JUnitPlugin}.
      * @param resource|null $stream Stream for stdout mode; defaults to {@see \STDOUT}. Ignored
-     *        when $outputPath is set.
+     *        when a file path is set.
      */
     public function __construct(?string $outputPath = null, $stream = null)
     {
-        $this->path = $outputPath !== null ? Path::create($outputPath) : null;
+        $this->path = $outputPath !== null && $outputPath !== '' ? Path::create($outputPath) : null;
         $this->stream = $stream;
         $this->report = new JsonReport();
     }

--- a/core/Output/Json/JsonPlugin.php
+++ b/core/Output/Json/JsonPlugin.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Json;
+
+use Internal\Container\Container;
+use Internal\Path;
+use Testo\Common\EventListenerCollector;
+use Testo\Common\PluginConfigurator;
+use Testo\Event\Framework\SessionFinished;
+use Testo\Output\Json\Internal\JsonReport;
+
+/**
+ * Renders the whole run as a single minimalistic JSON object on session end.
+ *
+ * Designed for machine consumers — CI scripts and, above all, LLM coding agents
+ * that run the suite and read the result. Instead of the human-oriented progress
+ * stream the {@see \Testo\Output\Terminal\TerminalPlugin} produces, this plugin
+ * emits only what an agent needs to act on a failing run: the run status, the
+ * per-status counts, and a flat list of failed tests with their throwable,
+ * `previous` chain, stack trace, and captured output. See {@see JsonReport} for
+ * the exact shape.
+ *
+ * # Two modes
+ *
+ * - **stdout** (default, `--json`) — the report is the only thing written to
+ *   stdout, so it can be parsed without stripping anything. This is a stdout
+ *   renderer: the `run` command activates exactly one of terminal/teamcity/json.
+ * - **file** (`new JsonPlugin('build/report.json')`, `--log-json=<path>`) — the
+ *   report is written to a file (parent directories created as needed) and the
+ *   active stdout renderer is left untouched, so the human-readable terminal
+ *   output and the machine-readable file coexist. Same idea as `--log-junit`.
+ *
+ * @api
+ */
+final class JsonPlugin implements PluginConfigurator
+{
+    /**
+     * Destination file in file mode, or null in stdout mode.
+     */
+    private readonly ?Path $path;
+
+    /** @var resource|null Stream used in stdout mode; resolved to {@see \STDOUT} on write. */
+    private $stream;
+
+    private readonly JsonReport $report;
+
+    /**
+     * @param non-empty-string|null $outputPath When set, the report is written to this file and
+     *        the active stdout renderer is left untouched (`--log-json` / file mode). When null,
+     *        the report is written to {@see $stream} (`--json` / stdout mode).
+     * @param resource|null $stream Stream for stdout mode; defaults to {@see \STDOUT}. Ignored
+     *        when $outputPath is set.
+     */
+    public function __construct(?string $outputPath = null, $stream = null)
+    {
+        $this->path = $outputPath !== null ? Path::create($outputPath) : null;
+        $this->stream = $stream;
+        $this->report = new JsonReport();
+    }
+
+    #[\Override]
+    public function configure(Container $container): void
+    {
+        $container->get(EventListenerCollector::class)
+            ->addListener(SessionFinished::class, $this->onSessionFinished(...));
+    }
+
+    private function onSessionFinished(SessionFinished $event): void
+    {
+        $json = $this->report->generate($event->result) . "\n";
+
+        if ($this->path === null) {
+            \fwrite($this->stream ?? \STDOUT, $json);
+            return;
+        }
+
+        $dir = (string) $this->path->parent();
+        \is_dir($dir) or \mkdir($dir, 0o755, true) or throw new \RuntimeException("Failed to create directory: {$dir}");
+        \file_put_contents((string) $this->path, $json);
+    }
+}

--- a/skills/testo-configure/SKILL.md
+++ b/skills/testo-configure/SKILL.md
@@ -172,6 +172,8 @@ vendor/bin/testo --coverage-clover=build/clover.xml        # write Clover report
 vendor/bin/testo --coverage-cobertura=build/cobertura.xml  # write Cobertura report
 vendor/bin/testo --coverage-xml=build/coverage-xml         # write coverage XML dir (Infection)
 vendor/bin/testo --teamcity            # TeamCity output (CI/IDE)
+vendor/bin/testo --json                # minimal JSON on stdout: run summary + failed tests (for LLM agents / CI scripts)
+vendor/bin/testo --log-json=build/report.json  # same JSON to a file, keeps the terminal output (like --log-junit)
 vendor/bin/testo --config=path/to/testo.php
 ```
 

--- a/tests/Output/Unit/Json/JsonPluginTest.php
+++ b/tests/Output/Unit/Json/JsonPluginTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Unit\Json;
+
+use Internal\Container\ObjectContainer;
+use Testo\Application\Internal\EventDispatcher;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Common\EventListenerCollector;
+use Testo\Core\Context\CaseInfo;
+use Testo\Core\Context\CaseResult;
+use Testo\Core\Context\RunResult;
+use Testo\Core\Context\SuiteResult;
+use Testo\Core\Context\TestInfo;
+use Testo\Core\Context\TestResult;
+use Testo\Core\Definition\CaseDefinition;
+use Testo\Core\Definition\TestDefinition;
+use Testo\Core\Value\Status;
+use Testo\Core\Value\Summary;
+use Testo\Event\Framework\SessionFinished;
+use Testo\Output\Json\JsonPlugin;
+use Testo\Test;
+use Tests\Output\Stub\JUnit\SampleTestClass;
+
+#[Test]
+#[Covers(JsonPlugin::class)]
+final class JsonPluginTest
+{
+    public function writesReportToFileOnSessionFinished(): void
+    {
+        $path = self::tmpPath();
+        try {
+            self::dispatch(new JsonPlugin($path), self::failedRun());
+
+            Assert::true(\file_exists($path));
+            $report = self::decode((string) \file_get_contents($path));
+            Assert::same($report['status'], 'failed');
+            Assert::count($report['failures'], 1);
+            Assert::same($report['failures'][0]['test'], SampleTestClass::class . '::failingTest');
+        } finally {
+            \is_file($path) and \unlink($path);
+        }
+    }
+
+    public function createsMissingParentDirectories(): void
+    {
+        $dir = self::tmpDir() . '/testo_json_' . \uniqid();
+        $path = $dir . '/nested/report.json';
+        try {
+            self::dispatch(new JsonPlugin($path), self::failedRun());
+
+            Assert::true(\file_exists($path));
+        } finally {
+            \is_file($path) and \unlink($path);
+            \is_dir($dir . '/nested') and \rmdir($dir . '/nested');
+            \is_dir($dir) and \rmdir($dir);
+        }
+    }
+
+    private static function dispatch(JsonPlugin $plugin, RunResult $result): void
+    {
+        $dispatcher = new EventDispatcher();
+        $container = new ObjectContainer();
+        $container->set($dispatcher, EventListenerCollector::class);
+        $plugin->configure($container);
+
+        $dispatcher->dispatch(new SessionFinished($result));
+    }
+
+    private static function failedRun(): RunResult
+    {
+        $info = new TestInfo(
+            name: 'failingTest',
+            caseInfo: new CaseInfo(
+                definition: new CaseDefinition(
+                    name: SampleTestClass::class,
+                    type: 'test',
+                    reflection: new \ReflectionClass(SampleTestClass::class),
+                ),
+            ),
+            testDefinition: new TestDefinition(new \ReflectionMethod(SampleTestClass::class, 'failingTest')),
+        );
+        $test = new TestResult(info: $info, status: Status::Failed, failure: new \RuntimeException('boom'));
+        $summary = new Summary(['Failed' => 1]);
+
+        return new RunResult(
+            [new SuiteResult([new CaseResult([$test], Status::Failed, $summary)], Status::Failed, $summary)],
+            Status::Failed,
+            0.0,
+            $summary,
+        );
+    }
+
+    /**
+     * @return array<non-empty-string, mixed>
+     */
+    private static function decode(string $json): array
+    {
+        /** @var array<non-empty-string, mixed> */
+        return \json_decode($json, true, flags: \JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function tmpPath(): string
+    {
+        return self::tmpDir() . '/testo_json_plugin_' . \uniqid() . '.json';
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function tmpDir(): string
+    {
+        $dir = \sys_get_temp_dir();
+        \assert($dir !== '');
+
+        return $dir;
+    }
+}

--- a/tests/Output/Unit/Json/JsonPluginTest.php
+++ b/tests/Output/Unit/Json/JsonPluginTest.php
@@ -59,6 +59,21 @@ final class JsonPluginTest
         }
     }
 
+    public function emptyOutputPathIsTreatedAsStdoutMode(): void
+    {
+        $stream = \fopen('php://memory', 'rb+');
+        \assert($stream !== false);
+
+        self::dispatch(new JsonPlugin('', $stream), self::failedRun());
+
+        \rewind($stream);
+        $written = (string) \stream_get_contents($stream);
+        \fclose($stream);
+
+        $report = self::decode($written);
+        Assert::same($report['status'], 'failed');
+    }
+
     private static function dispatch(JsonPlugin $plugin, RunResult $result): void
     {
         $dispatcher = new EventDispatcher();

--- a/tests/Output/Unit/Json/JsonReportTest.php
+++ b/tests/Output/Unit/Json/JsonReportTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Unit\Json;
+
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Core\Context\CaseInfo;
+use Testo\Core\Context\CaseResult;
+use Testo\Core\Context\RunResult;
+use Testo\Core\Context\SuiteResult;
+use Testo\Core\Context\TestInfo;
+use Testo\Core\Context\TestResult;
+use Testo\Core\Definition\CaseDefinition;
+use Testo\Core\Definition\TestDefinition;
+use Testo\Core\Log\Level;
+use Testo\Core\Log\Message;
+use Testo\Core\Log\MessageLog;
+use Testo\Core\Value\Status;
+use Testo\Core\Value\Summary;
+use Testo\Output\Json\Internal\JsonReport;
+use Testo\Test;
+use Tests\Output\Stub\JUnit\SampleTestClass;
+
+#[Test]
+#[Covers(JsonReport::class)]
+final class JsonReportTest
+{
+    public function passingRunReportsStatusTotalsAndEmptyFailures(): void
+    {
+        $report = self::decode(self::run(
+            Status::Passed,
+            duration: 1.25,
+            summary: new Summary(['Passed' => 3], duration: 1.25),
+            results: [self::test('passingTest', Status::Passed)],
+        ));
+
+        Assert::same($report['status'], 'passed');
+        Assert::same($report['duration'], 1.25);
+        Assert::same($report['totals'], ['total' => 3, 'passed' => 3]);
+        Assert::same($report['failures'], []);
+    }
+
+    public function failedTestCarriesThrowableLocationAndTrace(): void
+    {
+        $failure = new \RuntimeException('boom');
+        $report = self::decode(self::run(
+            Status::Failed,
+            results: [self::test('failingTest', Status::Failed, $failure)],
+        ));
+
+        Assert::count($report['failures'], 1);
+        $failed = $report['failures'][0];
+
+        Assert::same($failed['test'], SampleTestClass::class . '::failingTest');
+        Assert::same($failed['status'], 'failed');
+        Assert::same($failed['exception'], \RuntimeException::class);
+        Assert::same($failed['message'], 'boom');
+        Assert::same($failed['file'], $failure->getFile());
+        Assert::same($failed['line'], $failure->getLine());
+        Assert::true(\is_array($failed['trace']));
+        Assert::false(\array_key_exists('causedBy', $failed));
+        Assert::false(\array_key_exists('output', $failed));
+    }
+
+    public function onlyFailedAndErrorTestsAreListed(): void
+    {
+        $report = self::decode(self::run(
+            Status::Failed,
+            results: [
+                self::test('passingTest', Status::Passed),
+                self::test('failingTest', Status::Failed, new \RuntimeException('f')),
+                self::test('passingTest', Status::Skipped),
+                self::test('failingTest', Status::Error, new \LogicException('e')),
+                self::test('passingTest', Status::Risky),
+            ],
+        ));
+
+        $statuses = \array_map(static fn(array $f): string => $f['status'], $report['failures']);
+        Assert::same($statuses, ['failed', 'error']);
+    }
+
+    public function previousChainIsReportedAsCausedBy(): void
+    {
+        $root = new \LogicException('root cause');
+        $middle = new \DomainException('wrapping', previous: $root);
+        $failure = new \RuntimeException('top', previous: $middle);
+
+        $report = self::decode(self::run(
+            Status::Failed,
+            results: [self::test('failingTest', Status::Error, $failure)],
+        ));
+        $failed = $report['failures'][0];
+
+        Assert::count($failed['causedBy'], 2);
+        Assert::same($failed['causedBy'][0]['exception'], \DomainException::class);
+        Assert::same($failed['causedBy'][0]['message'], 'wrapping');
+        Assert::same($failed['causedBy'][1]['exception'], \LogicException::class);
+        Assert::same($failed['causedBy'][1]['message'], 'root cause');
+    }
+
+    public function capturedOutputIsReported(): void
+    {
+        $messages = new MessageLog([
+            new Message(0.0, 'stdout', Level::Info, 'hello from test'),
+            new Message(0.0, 'sql-log', Level::Debug, 'SELECT 1'),
+        ]);
+
+        $report = self::decode(self::run(
+            Status::Failed,
+            results: [self::test('failingTest', Status::Failed, new \RuntimeException('x'), $messages)],
+        ));
+
+        Assert::same($report['failures'][0]['output'], [
+            ['channel' => 'stdout', 'content' => 'hello from test'],
+            ['channel' => 'sql-log', 'content' => 'SELECT 1'],
+        ]);
+    }
+
+    public function freeFunctionTestUsesFunctionFqn(): void
+    {
+        $reflection = new \ReflectionFunction('strlen');
+        $info = new TestInfo(
+            name: 'free',
+            caseInfo: new CaseInfo(
+                definition: new CaseDefinition(name: null, type: 'test', reflection: null),
+            ),
+            testDefinition: new TestDefinition($reflection),
+        );
+        $result = new TestResult(info: $info, status: Status::Failed, failure: new \RuntimeException('boom'));
+
+        $report = self::decode(self::run(Status::Failed, results: [$result]));
+
+        Assert::same($report['failures'][0]['test'], 'strlen');
+    }
+
+    public function totalsOmitZeroCountStatuses(): void
+    {
+        $report = self::decode(self::run(
+            Status::Failed,
+            summary: new Summary(['Passed' => 2, 'Failed' => 1]),
+            results: [self::test('failingTest', Status::Failed, new \RuntimeException('x'))],
+        ));
+
+        Assert::same($report['totals'], ['total' => 3, 'passed' => 2, 'failed' => 1]);
+    }
+
+    /**
+     * @return array<non-empty-string, mixed>
+     */
+    private static function decode(string $json): array
+    {
+        /** @var array<non-empty-string, mixed> */
+        return \json_decode($json, true, flags: \JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Wraps the given test results in a single suite/case and renders the report.
+     *
+     * @param list<TestResult> $results
+     */
+    private static function run(
+        Status $status,
+        float $duration = 0.0,
+        ?Summary $summary = null,
+        array $results = [],
+    ): string {
+        $summary ??= new Summary();
+        $case = new CaseResult($results, $status, $summary);
+        $suite = new SuiteResult([$case], $status, $summary);
+        $run = new RunResult([$suite], $status, $duration, $summary);
+
+        return (new JsonReport())->generate($run);
+    }
+
+    private static function test(
+        string $method,
+        Status $status,
+        ?\Throwable $failure = null,
+        ?MessageLog $messages = null,
+    ): TestResult {
+        $info = new TestInfo(
+            name: $method,
+            caseInfo: new CaseInfo(
+                definition: new CaseDefinition(
+                    name: SampleTestClass::class,
+                    type: 'test',
+                    reflection: new \ReflectionClass(SampleTestClass::class),
+                ),
+            ),
+            testDefinition: new TestDefinition(new \ReflectionMethod(SampleTestClass::class, $method)),
+        );
+
+        return new TestResult(
+            info: $info,
+            status: $status,
+            failure: $failure,
+            messages: $messages ?? new MessageLog(),
+        );
+    }
+}

--- a/tests/Output/Unit/Json/JsonReportTest.php
+++ b/tests/Output/Unit/Json/JsonReportTest.php
@@ -118,6 +118,20 @@ final class JsonReportTest
         ]);
     }
 
+    public function malformedUtf8InMessagesIsSubstitutedNotThrown(): void
+    {
+        $messages = new MessageLog([new Message(0.0, 'stdout', Level::Info, "bad \x80\xFF byte")]);
+
+        $report = self::decode(self::run(
+            Status::Failed,
+            results: [self::test('failingTest', Status::Failed, new \RuntimeException("msg \xFF"), $messages)],
+        ));
+
+        Assert::same($report['status'], 'failed');
+        Assert::count($report['failures'], 1);
+        Assert::same($report['failures'][0]['output'][0]['channel'], 'stdout');
+    }
+
     public function freeFunctionTestUsesFunctionFqn(): void
     {
         $reflection = new \ReflectionFunction('strlen');


### PR DESCRIPTION
Introduce JsonPlugin for structured JSON output, enabling LLM agents and CI scripts to consume test results programmatically.

- Add `--json` flag for minimal JSON summary to stdout
- Add `--log-json=<file>` flag to write JSON report to a file while keeping terminal output (mirrors `--log-junit` behavior)
- Implement `JsonPlugin` and `JsonReport` internal model
- Register new options in the Run command
- Document new flags in testo-configure skill

<!-- Thanks for opening a PR! -->

## What was changed

A new JSON output format aimed at machine consumers — LLM coding agents and CI scripts — that need test results without parsing the human-oriented terminal stream.

- **`JsonReport`** (`core/Output/Json/Internal/JsonReport.php`) — pure builder `RunResult → JSON`. Emits the run `status`, `duration`, per-status `totals`, and a flat `failures[]` list (only `Failed`/`Error`) with `test` FQN, `exception`, `message`, `file`, `line`, `trace`, optional `causedBy` (the `previous` chain) and `output` (captured messages). The stack trace is trimmed at the test-function boundary and formatted identically to the terminal renderer, so it stays signal, not noise.
- **`JsonPlugin`** (`core/Output/Json/JsonPlugin.php`) — listens to `SessionFinished` and writes the report in one of two modes:
  - stdout (`--json`): the report is the only thing on stdout; activated as the single stdout renderer (terminal/teamcity/json are mutually exclusive).
  - file (`--log-json=<path>`): writes to a file (parent dirs created as needed) and leaves the active terminal/teamcity renderer untouched — same idea as `--log-junit`.
- **Run command** — registers `--json` and `--log-json`; `--log-json` activates the file writer in addition to whichever stdout renderer is selected.
- **Docs** — `--json` and `--log-json` added to the `testo-configure` skill CLI cheat-sheet.
- **Tests** — `JsonReportTest` (report shape: totals, failures filtering, trace, causedBy, output, free-function FQN) and `JsonPluginTest` (file mode + parent-directory creation).

## Why?

Testo's existing renderers (terminal, TeamCity) are built for humans and CI dashboards. An LLM agent running the suite has to scrape ANSI-colored progress output to find what failed. A compact, parseable JSON summary — just the run totals and the failing tests with their throwables and traces — lets agents and scripts act on results directly, which is exactly what the linked issue asks for.

## Checklist

- Closes #120
- Tested
  - [x] Tested manually
  - [x] Unit tests added
- [x] Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
