### PR TITLE
fix(codecov,junit): attribute inherited tests to the concrete class

### DIFF
--- a/core/Output/JUnit/Internal/JUnitWriter.php
+++ b/core/Output/JUnit/Internal/JUnitWriter.php
@@ -257,13 +257,19 @@ final class JUnitWriter
     {
         $reflection = $info->testDefinition->reflection;
 
-        if ($reflection instanceof \ReflectionMethod) {
-            return $reflection->getDeclaringClass()->getName();
-        }
-
+        // Class-bound tests: use the concrete (runtime) case class, not the
+        // method's declaring class. For a `#[Test]` inherited from an abstract
+        // base, getDeclaringClass() names the base — but the enclosing
+        // <testsuite> is named after the concrete subclass (see JUnitPlugin),
+        // and Infection joins coverage to a test file by matching this classname
+        // against that suite name. Diverging the two breaks the lookup.
         $caseReflection = $info->caseInfo->definition->reflection;
         if ($caseReflection !== null) {
             return $caseReflection->getName();
+        }
+
+        if ($reflection instanceof \ReflectionMethod) {
+            return $reflection->getDeclaringClass()->getName();
         }
 
         // Free-function test: use the function's FQN, matching the per-function

--- a/plugin/codecov/src/Internal/Middleware/CoverageTestInterceptor.php
+++ b/plugin/codecov/src/Internal/Middleware/CoverageTestInterceptor.php
@@ -90,6 +90,13 @@ final readonly class CoverageTestInterceptor implements TestRunInterceptor
      * - Class methods: `Tests\\FooTest::testBar`.
      * - Free functions: `Tests\\testFooBar` (FQN, no leading backslash).
      *
+     * For inherited tests the concrete (runtime) case class is used, NOT the
+     * declaring class: a `#[Test]` method declared on an abstract base and run
+     * through a subclass is attributed to the subclass. This keeps the coverage
+     * `<covered by="Concrete::method">` aligned with the JUnit `<testsuite
+     * name="Concrete">`, which Infection joins on by class name — `getDeclaringClass()`
+     * would name the abstract base, which has no testsuite, and the lookup would fail.
+     *
      * Data-set entries within data providers reuse the same identifier — Testo's
      * `--filter` selects by method, not by individual dataset, so per-dataset granularity
      * isn't useful for downstream consumers (e.g. Infection).
@@ -101,7 +108,9 @@ final readonly class CoverageTestInterceptor implements TestRunInterceptor
         $reflection = $info->testDefinition->reflection;
 
         if ($reflection instanceof \ReflectionMethod) {
-            $name = $reflection->getDeclaringClass()->getName() . '::' . $reflection->getName();
+            $class = $info->caseInfo->definition->reflection;
+            $className = $class?->getName() ?? $reflection->getDeclaringClass()->getName();
+            $name = $className . '::' . $reflection->getName();
             return $name === '' ? null : $name;
         }
 

--- a/plugin/codecov/tests/Stub/InheritedTestBase.php
+++ b/plugin/codecov/tests/Stub/InheritedTestBase.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Codecov\Stub;
+
+/**
+ * Abstract base whose test method is inherited (not overridden) by concrete
+ * subclasses. Carries no coverage attribute, so coverage is collected.
+ */
+abstract class InheritedTestBase
+{
+    public function testInherited(): void {}
+}

--- a/plugin/codecov/tests/Stub/InheritedTestChild.php
+++ b/plugin/codecov/tests/Stub/InheritedTestChild.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Codecov\Stub;
+
+/**
+ * Concrete subclass that inherits its test method from {@see InheritedTestBase}
+ * without overriding it. The runtime test identity must resolve to this class,
+ * not to the abstract declaring base.
+ */
+final class InheritedTestChild extends InheritedTestBase {}

--- a/plugin/codecov/tests/Unit/Middleware/CoverageTestInterceptorTest.php
+++ b/plugin/codecov/tests/Unit/Middleware/CoverageTestInterceptorTest.php
@@ -20,6 +20,7 @@ use Tests\Codecov\Stub\ChildOverridesWithCovers;
 use Tests\Codecov\Stub\ChildWithoutAttribute;
 use Tests\Codecov\Stub\ConflictingAttributes;
 use Tests\Codecov\Stub\CoveredCase;
+use Tests\Codecov\Stub\InheritedTestChild;
 use Tests\Codecov\Stub\SpyDriver;
 use Tests\Codecov\Stub\TargetClassA;
 use Tests\Codecov\Stub\UncoveredClass;
@@ -160,6 +161,33 @@ final class CoverageTestInterceptorTest
         // Filtered to TargetClassA only
         Assert::count($coverage->files, 1);
         Assert::true(isset($coverage->files[$fileA]));
+    }
+
+    public function inheritedMethodIsStampedWithConcreteClassNotDeclaringBase(): void
+    {
+        // `testInherited` is declared on the abstract InheritedTestBase but runs
+        // through the concrete child. The stamped test method id — which Infection
+        // matches against the JUnit `<testsuite name>` — must name the concrete
+        // class, otherwise the coverage `<covered by>` points at an abstract class
+        // that has no testsuite and the lookup fails.
+        $path = '/src/Subject.php';
+        $driver = new SpyDriver(new CoverageResult([
+            $path => new \Testo\Codecov\Result\FileCoverage($path, [
+                7 => new \Testo\Codecov\Result\LineCoverage(7, \Testo\Codecov\Result\LineStatus::Executed),
+            ]),
+        ]));
+        $interceptor = new CoverageTestInterceptor($driver);
+        $info = self::makeTestInfo(InheritedTestChild::class, 'testInherited');
+        $next = static fn(TestInfo $i): TestResult => new TestResult($i, Status::Passed);
+
+        $result = $interceptor->runTest($info, $next);
+
+        $coverage = $result->getAttribute(CoverageResult::class);
+        Assert::instanceOf($coverage, CoverageResult::class);
+        Assert::same(
+            $coverage->files[$path]->lines[7]->testMethods,
+            [InheritedTestChild::class . '::testInherited'],
+        );
     }
 
     public function throwsOnConflictingCoversAndCoversNothing(): never

--- a/tests/Output/Stub/JUnit/AbstractSampleTest.php
+++ b/tests/Output/Stub/JUnit/AbstractSampleTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Stub\JUnit;
+
+/**
+ * Abstract base whose test method is inherited by concrete subclasses, used to
+ * back `\ReflectionMethod` for JUnit writer tests of the inheritance case.
+ */
+abstract class AbstractSampleTest
+{
+    public function inheritedTest(): void {}
+}

--- a/tests/Output/Stub/JUnit/ConcreteSampleTest.php
+++ b/tests/Output/Stub/JUnit/ConcreteSampleTest.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Stub\JUnit;
+
+/**
+ * Concrete subclass that inherits its test method from {@see AbstractSampleTest}
+ * without overriding it.
+ */
+final class ConcreteSampleTest extends AbstractSampleTest {}

--- a/tests/Output/Unit/JUnit/JUnitWriterTest.php
+++ b/tests/Output/Unit/JUnit/JUnitWriterTest.php
@@ -13,6 +13,7 @@ use Testo\Core\Definition\TestDefinition;
 use Testo\Core\Value\Status;
 use Testo\Output\JUnit\Internal\JUnitWriter;
 use Testo\Test;
+use Tests\Output\Stub\JUnit\ConcreteSampleTest;
 use Tests\Output\Stub\JUnit\SampleTestClass;
 
 #[Test]
@@ -349,6 +350,22 @@ final class JUnitWriterTest
         );
     }
 
+    public function inheritedTestMethodUsesConcreteCaseClassAsClassname(): void
+    {
+        $writer = new JUnitWriter();
+        $writer->startSuite(ConcreteSampleTest::class, '/abs/ConcreteSampleTest.php');
+        $writer->addTestResult(self::makeInheritedResult(Status::Passed));
+        $writer->finishSuite();
+
+        $xml = self::loadXml($writer->generate('Testo'));
+
+        // The <testsuite> is named after the concrete class; the <testcase>
+        // classname must match it so Infection's `//testsuite[@name="FQN"]`
+        // lookup — keyed on the coverage `<covered by>` class — resolves.
+        // getDeclaringClass() would name the abstract base and break the mapping.
+        Assert::same((string) $xml->testsuite->testcase['classname'], ConcreteSampleTest::class);
+    }
+
     public function writeCreatesParentDirectory(): void
     {
         // Arrange
@@ -455,6 +472,32 @@ final class JUnitWriterTest
             status: $status,
             failure: $failure,
             attributes: ['duration' => $durationMs],
+        );
+    }
+
+    private static function makeInheritedResult(Status $status): TestResult
+    {
+        // Method declared on the abstract base, run through the concrete child:
+        // ReflectionMethod::getDeclaringClass() resolves to AbstractSampleTest,
+        // while the case reflection is the concrete ConcreteSampleTest.
+        $reflection = new \ReflectionMethod(ConcreteSampleTest::class, 'inheritedTest');
+
+        $info = new TestInfo(
+            name: 'inheritedTest',
+            caseInfo: new CaseInfo(
+                definition: new CaseDefinition(
+                    name: ConcreteSampleTest::class,
+                    type: 'test',
+                    reflection: new \ReflectionClass(ConcreteSampleTest::class),
+                ),
+            ),
+            testDefinition: new TestDefinition($reflection),
+        );
+
+        return new TestResult(
+            info: $info,
+            status: $status,
+            attributes: ['duration' => 0],
         );
     }
 


### PR DESCRIPTION
## What was changed

A `#[Test]` method declared on an **abstract base** class and run through a concrete subclass was identified by its **declaring** (abstract) class in two reports:

- coverage XML — `<covered by="Abstract\Base::method">`
- JUnit XML — `<testcase classname="Abstract\Base">`

…while the surrounding JUnit `<testsuite>` is named after the **concrete** subclass.

Both `CoverageTestInterceptor::buildMethodId()` and `JUnitWriter::classnameFor()` now use the concrete (runtime) case class (`caseInfo->definition->reflection`) instead of `ReflectionMethod::getDeclaringClass()`, with a fallback to the declaring class when no case reflection is available (free functions are unaffected).

Added regression tests + stubs (abstract base + concrete child) in both modules.

See commit history for details.

## Why?

Infection joins coverage to a test file by matching the covered class against `//testsuite[@name="FQN"]` in the JUnit report. Because coverage named the abstract base but the JUnit suite named the concrete subclass, the lookup never resolved and Infection threw `TestFileNameNotFoundException` for **every mutant covered only by an inherited test** — breaking mutation runs on any codebase that uses an abstract test class with final subclasses.

Reproduced end-to-end (abstract `AbstractCalculatorTest` + final `IntCalculatorTest`) and verified against Infection's own `JUnitTestFileDataProvider` lookup:

- **Before:** `TestFileNameNotFoundException` — no `<testsuite name="...AbstractCalculatorTest">`.
- **After:** resolves via `//testsuite[@name="...IntCalculatorTest"]` → `IntCalculatorTest.php`.

Bonus: coverage no longer collapses several subclasses into a single `Abstract::method` entry — each concrete subclass is attributed distinctly.

## Checklist

- Closes #<!-- add issue number here -->
- Tested
  - [x] Tested manually
  - [x] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->
