### PR TITLE
perf(output): Myers O(ND) line diff behind a Differ abstraction

### DIFF
--- a/bridge/infection/src/TestoAdapter.php
+++ b/bridge/infection/src/TestoAdapter.php
@@ -77,11 +77,27 @@ final class TestoAdapter implements TestFrameworkAdapter
     }
 
     /**
-     * Tests pass when the TeamCity stream contains no `testFailed` and no `buildProblem`.
+     * Decides whether a mutant's test run passed (mutant survived) from its captured stdout.
+     *
+     * Mutant runs are launched with `--json` (see {@see getMutantCommandLine()}), which collapses
+     * stdout to a single compact verdict object — far cheaper than the per-test TeamCity stream,
+     * whose volume could exhaust memory when Infection buffers a mutant's output. The JSON `status`
+     * is the authoritative signal here: tests pass only when it is `"passed"`.
+     *
+     * Falls back to the TeamCity marker scan when the output is not the JSON verdict object (e.g. the
+     * initial test run, which still uses `--teamcity`): tests pass when neither `testFailed` nor
+     * `buildProblem` is present. Note that Infection consults this method only for an exit-code-0 run
+     * (see {@see \Infection\Mutant\TestFrameworkMutantExecutionResultFactory}); a failing run exits
+     * non-zero and is classified as killed before this is reached.
      */
     #[\Override]
     public function testsPass(string $output): bool
     {
+        $decoded = \json_decode(\trim($output), true);
+        if (\is_array($decoded) && isset($decoded['status'])) {
+            return $decoded['status'] === 'passed';
+        }
+
         return !\str_contains($output, '##teamcity[testFailed')
             && !\str_contains($output, '##teamcity[buildProblem');
     }
@@ -134,13 +150,18 @@ final class TestoAdapter implements TestFrameworkAdapter
     ): array {
         $bootstrap = $this->writeMutantBootstrap($mutationHash, $mutationOriginalFilePath, $mutatedFilePath);
 
+        # `--json` collapses the run to one compact verdict object on stdout, instead of the
+        # per-test TeamCity stream. Infection buffers each mutant's output in memory (via
+        # symfony/process), so the smaller payload keeps peak memory bounded on segments whose
+        # mutants would otherwise emit a large failing diff or thousands of TeamCity markers.
+        # {@see testsPass()} reads the JSON `status` from this output.
         $cmd = [
             \PHP_BINARY,
             '-d',
             'auto_prepend_file=' . $bootstrap,
             $this->testFrameworkExecutable,
             'run',
-            '--teamcity',
+            '--json',
             '--no-coverage',
         ];
 

--- a/core/Output/Rendering/Diff/DiffLine.php
+++ b/core/Output/Rendering/Diff/DiffLine.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Rendering\Diff;
+
+/**
+ * A single line of a computed diff, tagged with its {@see DiffOp}.
+ *
+ * @internal
+ */
+final readonly class DiffLine
+{
+    public function __construct(
+        public DiffOp $op,
+        public string $line,
+    ) {}
+}

--- a/core/Output/Rendering/Diff/DiffOp.php
+++ b/core/Output/Rendering/Diff/DiffOp.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Rendering\Diff;
+
+/**
+ * The kind of a single {@see DiffLine}: a line kept in common, removed from the
+ * expected side, or added on the actual side.
+ *
+ * @internal
+ */
+enum DiffOp
+{
+    case Context;
+    case Remove;
+    case Add;
+}

--- a/core/Output/Rendering/Diff/Differ.php
+++ b/core/Output/Rendering/Diff/Differ.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Rendering\Diff;
+
+/**
+ * Computes a line-by-line diff between two multi-line strings.
+ *
+ * Implementations split both sides on "\n" and return an ordered edit script: every input line
+ * appears exactly once as a {@see DiffLine}, tagged as kept ({@see DiffOp::Context}), removed from
+ * the expected side ({@see DiffOp::Remove}), or added on the actual side ({@see DiffOp::Add}).
+ *
+ * @internal
+ */
+interface Differ
+{
+    /**
+     * @return list<DiffLine>
+     */
+    public function diff(string $expected, string $actual): array;
+}

--- a/core/Output/Rendering/Diff/HirschbergDiffer.php
+++ b/core/Output/Rendering/Diff/HirschbergDiffer.php
@@ -40,12 +40,9 @@ final class HirschbergDiffer implements Differ
         $n = $aHi - $aLo;
         $m = $bHi - $bLo;
 
-        if ($n === 0) {
-            for ($j = $bLo; $j < $bHi; $j++) {
-                $out[] = new DiffLine(DiffOp::Add, $b[$j]);
-            }
-            return;
-        }
+        // Only the b-range can collapse to empty here: the entry point passes a non-empty a-range
+        // (`explode()` yields at least one line) and the recursive split halves the a-range with
+        // intdiv, so $n is always >= 1, whereas a chosen split column can empty one side's b-range.
         if ($m === 0) {
             for ($i = $aLo; $i < $aHi; $i++) {
                 $out[] = new DiffLine(DiffOp::Remove, $a[$i]);

--- a/core/Output/Rendering/Diff/HirschbergDiffer.php
+++ b/core/Output/Rendering/Diff/HirschbergDiffer.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Rendering\Diff;
+
+/**
+ * Linear-space LCS diff via Hirschberg's divide-and-conquer (Hirschberg 1975).
+ *
+ * Produces the same minimal, LCS-maximal alignment as {@see LcsDiffer} but in O(M) working memory
+ * instead of the full O(N·M) table — it keeps only two DP rows and recursively splits on the column
+ * that maximises the combined forward/backward LCS length. Time stays O(N·M), so this is the
+ * memory-efficient counterpart to the plain LCS table (the variant `sebastian/diff` historically
+ * shipped as its memory-efficient calculator), not a faster algorithm — for speed prefer
+ * {@see MyersDiffer}.
+ *
+ * @internal
+ */
+final class HirschbergDiffer implements Differ
+{
+    #[\Override]
+    public function diff(string $expected, string $actual): array
+    {
+        $a = \explode("\n", $expected);
+        $b = \explode("\n", $actual);
+
+        $out = [];
+        self::diffRange($a, 0, \count($a), $b, 0, \count($b), $out);
+
+        return $out;
+    }
+
+    /**
+     * @param list<string> $a
+     * @param list<string> $b
+     * @param list<DiffLine> $out
+     */
+    private static function diffRange(array $a, int $aLo, int $aHi, array $b, int $bLo, int $bHi, array &$out): void
+    {
+        $n = $aHi - $aLo;
+        $m = $bHi - $bLo;
+
+        if ($n === 0) {
+            for ($j = $bLo; $j < $bHi; $j++) {
+                $out[] = new DiffLine(DiffOp::Add, $b[$j]);
+            }
+            return;
+        }
+        if ($m === 0) {
+            for ($i = $aLo; $i < $aHi; $i++) {
+                $out[] = new DiffLine(DiffOp::Remove, $a[$i]);
+            }
+            return;
+        }
+        if ($n === 1) {
+            self::diffSingleRow($a[$aLo], $b, $bLo, $bHi, $out);
+            return;
+        }
+
+        $aMid = \intdiv($aLo + $aHi, 2);
+
+        // LCS length of the left a-half against each prefix of the b-range, and of the right
+        // a-half against each suffix; the best split column maximises their sum.
+        $scoreL = self::lcsLengths($a, $aLo, $aMid, $b, $bLo, $bHi, false);
+        $scoreR = self::lcsLengths($a, $aMid, $aHi, $b, $bLo, $bHi, true);
+
+        $bMid = $bLo;
+        $best = -1;
+        for ($k = 0; $k <= $m; $k++) {
+            $kr = $m - $k;
+            \assert($kr >= 0);
+            $sum = ($scoreL[$k] ?? 0) + ($scoreR[$kr] ?? 0);
+            if ($sum > $best) {
+                $best = $sum;
+                $bMid = $bLo + $k;
+            }
+        }
+
+        self::diffRange($a, $aLo, $aMid, $b, $bLo, $bMid, $out);
+        self::diffRange($a, $aMid, $aHi, $b, $bMid, $bHi, $out);
+    }
+
+    /**
+     * Single a-line against a b-range: keep the first matching b-line as context (LCS is 1) with the
+     * surrounding b-lines as additions, or remove the a-line and add the whole range (LCS is 0).
+     *
+     * @param list<string> $b
+     * @param list<DiffLine> $out
+     */
+    private static function diffSingleRow(string $line, array $b, int $bLo, int $bHi, array &$out): void
+    {
+        $found = -1;
+        for ($j = $bLo; $j < $bHi; $j++) {
+            if ($b[$j] === $line) {
+                $found = $j;
+                break;
+            }
+        }
+
+        if ($found === -1) {
+            $out[] = new DiffLine(DiffOp::Remove, $line);
+            for ($j = $bLo; $j < $bHi; $j++) {
+                $out[] = new DiffLine(DiffOp::Add, $b[$j]);
+            }
+            return;
+        }
+
+        for ($j = $bLo; $j < $found; $j++) {
+            $out[] = new DiffLine(DiffOp::Add, $b[$j]);
+        }
+        $out[] = new DiffLine(DiffOp::Context, $line);
+        for ($j = $found + 1; $j < $bHi; $j++) {
+            $out[] = new DiffLine(DiffOp::Add, $b[$j]);
+        }
+    }
+
+    /**
+     * LCS length of the a-range against every prefix of the b-range (or every suffix when $reverse),
+     * computed with a single rolling row. Returns m+1 values indexed by the prefix/suffix length.
+     *
+     * @param list<string> $a
+     * @param list<string> $b
+     * @return array<int<0, max>, int>
+     */
+    private static function lcsLengths(array $a, int $aLo, int $aHi, array $b, int $bLo, int $bHi, bool $reverse): array
+    {
+        $n = $aHi - $aLo;
+        $m = $bHi - $bLo;
+        $prev = \array_fill(0, $m + 1, 0);
+
+        for ($ii = 0; $ii < $n; $ii++) {
+            $ia = $reverse ? $aHi - 1 - $ii : $aLo + $ii;
+            \assert($ia >= 0);
+            $ai = $a[$ia];
+            $curr = \array_fill(0, $m + 1, 0);
+            for ($jj = 1; $jj <= $m; $jj++) {
+                $ib = $reverse ? $bHi - $jj : $bLo + $jj - 1;
+                \assert($ib >= 0);
+                $bj = $b[$ib];
+                $curr[$jj] = $ai === $bj
+                    ? $prev[$jj - 1] + 1
+                    : \max($prev[$jj], $curr[$jj - 1]);
+            }
+            $prev = $curr;
+        }
+
+        return $prev;
+    }
+}

--- a/core/Output/Rendering/Diff/LcsDiffer.php
+++ b/core/Output/Rendering/Diff/LcsDiffer.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Rendering\Diff;
+
+/**
+ * Line diff via a full Longest Common Subsequence dynamic-programming table.
+ *
+ * This is Testo's original differ, kept for reference and benchmarking against {@see MyersDiffer}.
+ * It builds the complete (N + 1) × (M + 1) table, so it costs O(N · M) time and memory and degrades
+ * sharply on large inputs; prefer {@see MyersDiffer} in production code.
+ *
+ * @internal
+ */
+final class LcsDiffer implements Differ
+{
+    #[\Override]
+    public function diff(string $expected, string $actual): array
+    {
+        $a = \explode("\n", $expected);
+        $b = \explode("\n", $actual);
+
+        $m = \count($a);
+        $n = \count($b);
+        $lcs = \array_fill(0, $m + 1, \array_fill(0, $n + 1, 0));
+
+        for ($i = 1; $i <= $m; $i++) {
+            for ($j = 1; $j <= $n; $j++) {
+                $lcs[$i][$j] = $a[$i - 1] === $b[$j - 1]
+                    ? $lcs[$i - 1][$j - 1] + 1
+                    : \max($lcs[$i - 1][$j], $lcs[$i][$j - 1]);
+            }
+        }
+
+        $diff = [];
+        $i = $m;
+        $j = $n;
+        while ($i > 0 && $j > 0) {
+            if ($a[$i - 1] === $b[$j - 1]) {
+                \array_unshift($diff, new DiffLine(DiffOp::Context, $a[$i - 1]));
+                $i--;
+                $j--;
+            } elseif ($lcs[$i - 1][$j] >= $lcs[$i][$j - 1]) {
+                \array_unshift($diff, new DiffLine(DiffOp::Remove, $a[$i - 1]));
+                $i--;
+            } else {
+                \array_unshift($diff, new DiffLine(DiffOp::Add, $b[$j - 1]));
+                $j--;
+            }
+        }
+        while ($i > 0) {
+            \array_unshift($diff, new DiffLine(DiffOp::Remove, $a[$i - 1]));
+            $i--;
+        }
+        while ($j > 0) {
+            \array_unshift($diff, new DiffLine(DiffOp::Add, $b[$j - 1]));
+            $j--;
+        }
+
+        return $diff;
+    }
+}

--- a/core/Output/Rendering/Diff/MyersDiffer.php
+++ b/core/Output/Rendering/Diff/MyersDiffer.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Rendering\Diff;
+
+/**
+ * Line diff based on Eugene W. Myers' greedy O(ND) algorithm (Myers 1986, "An O(ND) Difference
+ * Algorithm and Its Variations").
+ *
+ * Runs in O((N + M) · D) time and O((N + M) · D) memory, where D is the edit distance — so for the
+ * common case of large inputs with few differences it is dramatically faster and lighter than a
+ * full O(N · M) LCS table (see {@see LcsDiffer}). The edit script is reconstructed by walking the
+ * recorded traces backwards and reversing once, avoiding the quadratic `array_unshift` cascade.
+ *
+ * @internal
+ */
+final class MyersDiffer implements Differ
+{
+    #[\Override]
+    public function diff(string $expected, string $actual): array
+    {
+        $a = \explode("\n", $expected);
+        $b = \explode("\n", $actual);
+        $n = \count($a);
+        $m = \count($b);
+        $max = $n + $m;
+
+        // For each edit distance d, record the furthest-reaching x on every diagonal k.
+        $trace = [];
+        $v = [1 => 0];
+        $found = 0;
+        for ($d = 0; $d <= $max; $d++) {
+            $trace[$d] = $v;
+            for ($k = -$d; $k <= $d; $k += 2) {
+                // Pick the better neighbouring diagonal to extend from: down (insert) or right (delete).
+                $x = $k === -$d || ($k !== $d && ($v[$k - 1] ?? 0) < ($v[$k + 1] ?? 0))
+                    ? ($v[$k + 1] ?? 0)
+                    : ($v[$k - 1] ?? 0) + 1;
+                $y = $x - $k;
+
+                // Follow the diagonal (a "snake") across all matching lines for free.
+                while ($x < $n && $y < $m && $a[$x] === $b[$y]) {
+                    $x++;
+                    $y++;
+                }
+
+                $v[$k] = $x;
+                if ($x >= $n && $y >= $m) {
+                    $found = $d;
+                    break 2;
+                }
+            }
+        }
+
+        // Walk the traces backwards. The snake/edit ordering yields a reversed script we flip once.
+        $reversed = [];
+        $x = $n;
+        $y = $m;
+        for ($d = $found; $d > 0; $d--) {
+            $v = $trace[$d];
+            $k = $x - $y;
+            $prevK = $k === -$d || ($k !== $d && ($v[$k - 1] ?? 0) < ($v[$k + 1] ?? 0))
+                ? $k + 1
+                : $k - 1;
+            $prevX = $v[$prevK] ?? 0;
+            $prevY = $prevX - $prevK;
+
+            // The asserts below restate Myers' invariant — every coordinate touched here is a
+            // reachable, in-bounds point — so the $x-1 / $y-1 line accesses are provably safe.
+            while ($x > $prevX && $y > $prevY) {
+                \assert($x >= 1);
+                $reversed[] = new DiffLine(DiffOp::Context, $a[$x - 1]);
+                $x--;
+                $y--;
+            }
+
+            if ($x === $prevX) {
+                \assert($y >= 1);
+                $reversed[] = new DiffLine(DiffOp::Add, $b[$y - 1]);
+                $y--;
+            } else {
+                \assert($x >= 1);
+                $reversed[] = new DiffLine(DiffOp::Remove, $a[$x - 1]);
+                $x--;
+            }
+        }
+
+        // Leading run of common lines reached at d == 0.
+        while ($x > 0 && $y > 0) {
+            $reversed[] = new DiffLine(DiffOp::Context, $a[$x - 1]);
+            $x--;
+            $y--;
+        }
+
+        return \array_reverse($reversed);
+    }
+}

--- a/core/Output/Rendering/Diff/MyersDiffer.php
+++ b/core/Output/Rendering/Diff/MyersDiffer.php
@@ -8,10 +8,12 @@ namespace Testo\Output\Rendering\Diff;
  * Line diff based on Eugene W. Myers' greedy O(ND) algorithm (Myers 1986, "An O(ND) Difference
  * Algorithm and Its Variations").
  *
- * Runs in O((N + M) · D) time and O((N + M) · D) memory, where D is the edit distance — so for the
- * common case of large inputs with few differences it is dramatically faster and lighter than a
- * full O(N · M) LCS table (see {@see LcsDiffer}). The edit script is reconstructed by walking the
- * recorded traces backwards and reversing once, avoiding the quadratic `array_unshift` cascade.
+ * Runs in O((N + M) · D) time, where D is the edit distance, so for the common case of large inputs
+ * with few differences it is dramatically faster than a full O(N · M) LCS table (see {@see LcsDiffer}).
+ * It records the search front for every d to rebuild the script, so its extra memory is O(D²) — tiny
+ * when D is small, but note this is the greedy variant, not Myers' linear-space §4b refinement; for
+ * the memory axis use {@see HirschbergDiffer}. The script is reconstructed by walking the recorded
+ * traces backwards and reversing once, avoiding the quadratic `array_unshift` cascade.
  *
  * @internal
  */

--- a/core/Output/Rendering/Diff/PatienceDiffer.php
+++ b/core/Output/Rendering/Diff/PatienceDiffer.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Rendering\Diff;
+
+/**
+ * Patience diff (Bram Cohen): align on lines that occur exactly once on each side, take the longest
+ * increasing subsequence of those unique matches as stable anchors, then recurse into the gaps
+ * between anchors. Regions with no unique common line fall back to the wrapped {@see Differ}.
+ *
+ * Unlike LCS/Myers it does not minimise the edit count — it optimises for *readable* alignment.
+ * On inputs with repeated lines (blank lines, lone braces, boilerplate) the minimal-edit differs
+ * tend to "slide" and pair up unrelated lines; anchoring on unique lines keeps related hunks
+ * together, which matters when the diff is shown to a human in a failure report.
+ *
+ * @internal
+ */
+final class PatienceDiffer implements Differ
+{
+    public function __construct(
+        private readonly Differ $fallback = new MyersDiffer(),
+    ) {}
+
+    #[\Override]
+    public function diff(string $expected, string $actual): array
+    {
+        $a = \explode("\n", $expected);
+        $b = \explode("\n", $actual);
+
+        $out = [];
+        $this->recurse($a, 0, \count($a), $b, 0, \count($b), $out);
+
+        return $out;
+    }
+
+    /**
+     * Pairs of (a-index, b-index) for lines occurring exactly once in each range, kept as the
+     * longest subsequence that is increasing in both indices — the stable anchors.
+     *
+     * @param list<string> $a
+     * @param list<string> $b
+     * @return list<array{int, int}>
+     */
+    private static function uniqueAnchors(array $a, int $aLo, int $aHi, array $b, int $bLo, int $bHi): array
+    {
+        $countA = [];
+        for ($i = $aLo; $i < $aHi; $i++) {
+            $line = $a[$i];
+            $countA[$line] = ($countA[$line] ?? 0) + 1;
+        }
+
+        $countB = [];
+        $posB = [];
+        for ($j = $bLo; $j < $bHi; $j++) {
+            $line = $b[$j];
+            $countB[$line] = ($countB[$line] ?? 0) + 1;
+            $posB[$line] = $j;
+        }
+
+        // Walk A in order so the resulting pairs are already ascending in the a-index.
+        $pairs = [];
+        for ($i = $aLo; $i < $aHi; $i++) {
+            $line = $a[$i];
+            if ($countA[$line] === 1 && ($countB[$line] ?? 0) === 1) {
+                $pairs[] = [$i, $posB[$line]];
+            }
+        }
+
+        return self::longestIncreasingByB($pairs);
+    }
+
+    /**
+     * Longest subsequence of $pairs that is strictly increasing in the b-index (the a-index is
+     * already increasing). Patience-sorting in O(k log k) with back-pointers for reconstruction.
+     *
+     * @param list<array{int, int}> $pairs
+     * @return list<array{int, int}>
+     */
+    private static function longestIncreasingByB(array $pairs): array
+    {
+        if ($pairs === []) {
+            return [];
+        }
+
+        /** @var list<int> $piles piles[len-1] = index into $pairs of the smallest b-tail of a length-len run */
+        $piles = [];
+        /** @var array<int, int> $back back[idx] = predecessor index of $pairs[$idx] in its run */
+        $back = [];
+        foreach ($pairs as $idx => [, $bi]) {
+            $lo = 0;
+            $hi = \count($piles);
+            while ($lo < $hi) {
+                $mid = \intdiv($lo + $hi, 2);
+                \assert($mid >= 0);
+                if ($pairs[$piles[$mid]][1] < $bi) {
+                    $lo = $mid + 1;
+                } else {
+                    $hi = $mid;
+                }
+            }
+            $back[$idx] = $lo > 0 ? $piles[$lo - 1] : -1;
+            $piles[$lo] = $idx;
+        }
+
+        $result = [];
+        $k = $piles[\count($piles) - 1];
+        while ($k !== -1) {
+            \assert($k >= 0);
+            $result[] = $pairs[$k];
+            $k = $back[$k] ?? -1;
+        }
+
+        return \array_reverse($result);
+    }
+
+    /**
+     * @param list<string> $a
+     * @param list<string> $b
+     * @param list<DiffLine> $out
+     */
+    private function recurse(array $a, int $aLo, int $aHi, array $b, int $bLo, int $bHi, array &$out): void
+    {
+        while ($aLo < $aHi && $bLo < $bHi && $a[$aLo] === $b[$bLo]) {
+            $out[] = new DiffLine(DiffOp::Context, $a[$aLo]);
+            $aLo++;
+            $bLo++;
+        }
+
+        // The trailing common run is emitted only after the middle, so collect it reversed first.
+        $suffix = [];
+        while ($aHi > $aLo && $bHi > $bLo && $a[$aHi - 1] === $b[$bHi - 1]) {
+            $aHi--;
+            $bHi--;
+            $suffix[] = new DiffLine(DiffOp::Context, $a[$aHi]);
+        }
+
+        $this->middle($a, $aLo, $aHi, $b, $bLo, $bHi, $out);
+
+        for ($i = \count($suffix) - 1; $i >= 0; $i--) {
+            $out[] = $suffix[$i];
+        }
+    }
+
+    /**
+     * @param list<string> $a
+     * @param list<string> $b
+     * @param list<DiffLine> $out
+     */
+    private function middle(array $a, int $aLo, int $aHi, array $b, int $bLo, int $bHi, array &$out): void
+    {
+        if ($aLo === $aHi && $bLo === $bHi) {
+            return;
+        }
+        if ($aLo === $aHi) {
+            for ($j = $bLo; $j < $bHi; $j++) {
+                $out[] = new DiffLine(DiffOp::Add, $b[$j]);
+            }
+            return;
+        }
+        if ($bLo === $bHi) {
+            for ($i = $aLo; $i < $aHi; $i++) {
+                $out[] = new DiffLine(DiffOp::Remove, $a[$i]);
+            }
+            return;
+        }
+
+        $anchors = self::uniqueAnchors($a, $aLo, $aHi, $b, $bLo, $bHi);
+
+        if ($anchors === []) {
+            // No unique common line to anchor on; both ranges are non-empty here, so delegating
+            // through the string-based fallback is safe (no empty-side explode pitfall).
+            foreach ($this->fallback->diff(
+                \implode("\n", \array_slice($a, $aLo, $aHi - $aLo)),
+                \implode("\n", \array_slice($b, $bLo, $bHi - $bLo)),
+            ) as $line) {
+                $out[] = $line;
+            }
+            return;
+        }
+
+        $prevA = $aLo;
+        $prevB = $bLo;
+        foreach ($anchors as [$ai, $bi]) {
+            $this->recurse($a, $prevA, $ai, $b, $prevB, $bi, $out);
+            $out[] = new DiffLine(DiffOp::Context, $a[$ai]);
+            $prevA = $ai + 1;
+            $prevB = $bi + 1;
+        }
+        $this->recurse($a, $prevA, $aHi, $b, $prevB, $bHi, $out);
+    }
+}

--- a/core/Output/Rendering/Diff/PrefixSuffixDiffer.php
+++ b/core/Output/Rendering/Diff/PrefixSuffixDiffer.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Rendering\Diff;
+
+/**
+ * A decorator that strips the common leading and trailing lines (emitting them as context) and only
+ * runs the wrapped {@see Differ} on the differing middle.
+ *
+ * This is orthogonal to the choice of diff algorithm: for the typical assertion-failure shape — two
+ * large blobs that share a long head and tail and differ in the middle — it collapses the inner
+ * problem to just the changed region, so even an O(N·M) inner differ stays cheap. Wrap any `Differ`.
+ *
+ * @internal
+ */
+final class PrefixSuffixDiffer implements Differ
+{
+    public function __construct(
+        private readonly Differ $inner = new MyersDiffer(),
+    ) {}
+
+    #[\Override]
+    public function diff(string $expected, string $actual): array
+    {
+        $a = \explode("\n", $expected);
+        $b = \explode("\n", $actual);
+        $n = \count($a);
+        $m = \count($b);
+
+        $start = 0;
+        while ($start < $n && $start < $m && $a[$start] === $b[$start]) {
+            $start++;
+        }
+
+        $endA = $n - 1;
+        $endB = $m - 1;
+        while ($endA >= $start && $endB >= $start) {
+            \assert($endA >= 0 && $endB >= 0);
+            if ($a[$endA] !== $b[$endB]) {
+                break;
+            }
+            $endA--;
+            $endB--;
+        }
+
+        $result = [];
+        for ($i = 0; $i < $start; $i++) {
+            $result[] = new DiffLine(DiffOp::Context, $a[$i]);
+        }
+
+        $midA = \array_slice($a, $start, $endA - $start + 1);
+        $midB = \array_slice($b, $start, $endB - $start + 1);
+        foreach ($this->middle($midA, $midB) as $line) {
+            $result[] = $line;
+        }
+
+        for ($i = $endA + 1; $i < $n; $i++) {
+            \assert($i >= 0);
+            $result[] = new DiffLine(DiffOp::Context, $a[$i]);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Diff the trimmed middle. Degenerate one-sided middles are emitted directly; delegating them
+     * through the string-based inner differ would misfire, since `explode("\n", "")` is `[""]`, not
+     * an empty list. Only when both sides are non-empty is the work handed to the inner differ.
+     *
+     * @param list<string> $midA
+     * @param list<string> $midB
+     * @return list<DiffLine>
+     */
+    private function middle(array $midA, array $midB): array
+    {
+        if ($midA === [] && $midB === []) {
+            return [];
+        }
+        if ($midA === []) {
+            return \array_map(static fn(string $line): DiffLine => new DiffLine(DiffOp::Add, $line), $midB);
+        }
+        if ($midB === []) {
+            return \array_map(static fn(string $line): DiffLine => new DiffLine(DiffOp::Remove, $line), $midA);
+        }
+
+        return $this->inner->diff(\implode("\n", $midA), \implode("\n", $midB));
+    }
+}

--- a/core/Output/Rendering/Diff/PrefixSuffixDiffer.php
+++ b/core/Output/Rendering/Diff/PrefixSuffixDiffer.php
@@ -27,37 +27,39 @@ final class PrefixSuffixDiffer implements Differ
         $b = \explode("\n", $actual);
         $n = \count($a);
         $m = \count($b);
+        $max = \min($n, $m);
 
-        $start = 0;
-        while ($start < $n && $start < $m && $a[$start] === $b[$start]) {
-            $start++;
+        // Lengths of the shared head and tail. Both counters start at 0, so every index derived from
+        // them stays non-negative by construction — no per-iteration assertion needed.
+        $prefix = 0;
+        while ($prefix < $max && $a[$prefix] === $b[$prefix]) {
+            ++$prefix;
         }
 
-        $endA = $n - 1;
-        $endB = $m - 1;
-        while ($endA >= $start && $endB >= $start) {
-            \assert($endA >= 0 && $endB >= 0);
-            if ($a[$endA] !== $b[$endB]) {
+        $suffix = 0;
+        while ($suffix < $max - $prefix) {
+            $ia = $n - 1 - $suffix;
+            $ib = $m - 1 - $suffix;
+            // The loop bound keeps $ia/$ib >= $prefix, so they never go negative; the explicit guard
+            // both states that invariant and lets static analysis prove the accesses are in range.
+            if ($ia < 0 || $ib < 0 || $a[$ia] !== $b[$ib]) {
                 break;
             }
-            $endA--;
-            $endB--;
+            ++$suffix;
         }
 
         $result = [];
-        for ($i = 0; $i < $start; $i++) {
-            $result[] = new DiffLine(DiffOp::Context, $a[$i]);
+        foreach (\array_slice($a, 0, $prefix) as $line) {
+            $result[] = new DiffLine(DiffOp::Context, $line);
         }
-
-        $midA = \array_slice($a, $start, $endA - $start + 1);
-        $midB = \array_slice($b, $start, $endB - $start + 1);
-        foreach ($this->middle($midA, $midB) as $line) {
+        foreach ($this->middle(
+            \array_slice($a, $prefix, $n - $prefix - $suffix),
+            \array_slice($b, $prefix, $m - $prefix - $suffix),
+        ) as $line) {
             $result[] = $line;
         }
-
-        for ($i = $endA + 1; $i < $n; $i++) {
-            \assert($i >= 0);
-            $result[] = new DiffLine(DiffOp::Context, $a[$i]);
+        foreach (\array_slice($a, $n - $suffix) as $line) {
+            $result[] = new DiffLine(DiffOp::Context, $line);
         }
 
         return $result;

--- a/core/Output/Rendering/Diff/RatcliffObershelpDiffer.php
+++ b/core/Output/Rendering/Diff/RatcliffObershelpDiffer.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Rendering\Diff;
+
+/**
+ * Ratcliff/Obershelp ("gestalt pattern matching") line diff, following the logic of Python's
+ * `difflib.SequenceMatcher`.
+ *
+ * Instead of minimising edits it repeatedly locates the longest contiguous matching block and
+ * recurses into the regions to its left and right. The result favours *readable* alignment over a
+ * shortest edit script — the same niche as {@see PatienceDiffer}, by a different route. It does not
+ * guarantee a minimal edit count, and its worst case is quadratic, so for large near-identical
+ * inputs {@see MyersDiffer} is faster; this is here mainly to compare alignment quality.
+ *
+ * `findLongestMatch` is backed by a `b2j` index (line -> its positions in the new sequence). The
+ * difflib "autojunk" heuristic drops over-popular lines from that index on large inputs so a line
+ * repeated everywhere cannot dominate the matching; dropped lines still appear in the output, just
+ * not as anchors.
+ *
+ * @internal
+ */
+final class RatcliffObershelpDiffer implements Differ
+{
+    public function __construct(
+        private readonly bool $autoJunk = true,
+    ) {}
+
+    #[\Override]
+    public function diff(string $expected, string $actual): array
+    {
+        $a = \explode("\n", $expected);
+        $b = \explode("\n", $actual);
+        $n = \count($a);
+        $m = \count($b);
+
+        $b2j = $this->buildB2J($b, $m);
+
+        // Find all matching blocks by recursively splitting around the longest match. An explicit
+        // stack avoids recursion; each frame is a [aLo, aHi, bLo, bHi] window.
+        /** @var list<array{int<0, max>, int<0, max>, int<0, max>, int<0, max>}> $stack */
+        $stack = [[0, $n, 0, $m]];
+        /** @var list<array{int<0, max>, int<0, max>, int<0, max>}> $blocks */
+        $blocks = [];
+        while (($frame = \array_pop($stack)) !== null) {
+            [$aLo, $aHi, $bLo, $bHi] = $frame;
+            [$i, $j, $k] = self::findLongestMatch($a, $b, $b2j, $aLo, $aHi, $bLo, $bHi);
+            if ($k <= 0) {
+                continue;
+            }
+
+            $blocks[] = [$i, $j, $k];
+            if ($aLo < $i && $bLo < $j) {
+                $stack[] = [$aLo, $i, $bLo, $j];
+            }
+            if ($i + $k < $aHi && $j + $k < $bHi) {
+                $stack[] = [$i + $k, $aHi, $j + $k, $bHi];
+            }
+        }
+
+        \usort($blocks, static fn(array $x, array $y): int => $x[0] <=> $y[0] ?: $x[1] <=> $y[1]);
+
+        // Walk the ordered blocks; the gap before each block is the edit (removes then adds), the
+        // block itself is context. A trailing sentinel flushes the final gap.
+        $out = [];
+        $ai = 0;
+        $bj = 0;
+        $blocks[] = [$n, $m, 0];
+        foreach ($blocks as [$i, $j, $k]) {
+            for ($x = $ai; $x < $i; $x++) {
+                $out[] = new DiffLine(DiffOp::Remove, $a[$x]);
+            }
+            for ($y = $bj; $y < $j; $y++) {
+                $out[] = new DiffLine(DiffOp::Add, $b[$y]);
+            }
+            for ($t = 0; $t < $k; $t++) {
+                $out[] = new DiffLine(DiffOp::Context, $a[$i + $t]);
+            }
+            $ai = $i + $k;
+            $bj = $j + $k;
+        }
+
+        return $out;
+    }
+
+    /**
+     * Longest matching block within a[aLo, aHi) × b[bLo, bHi): the run of equal lines that is
+     * longest, then earliest. Returns [aStart, bStart, length].
+     *
+     * @param list<string> $a
+     * @param list<string> $b
+     * @param array<array-key, list<int<0, max>>> $b2j
+     * @param int<0, max> $aLo
+     * @param int<0, max> $aHi
+     * @param int<0, max> $bLo
+     * @param int<0, max> $bHi
+     * @return array{int<0, max>, int<0, max>, int<0, max>}
+     */
+    private static function findLongestMatch(array $a, array $b, array $b2j, int $aLo, int $aHi, int $bLo, int $bHi): array
+    {
+        $bestI = $aLo;
+        $bestJ = $bLo;
+        $bestSize = 0;
+
+        // j2len[j] = length of the longest matching run ending at a[i], b[j] for the previous i.
+        /** @var array<int, int<0, max>> $j2len */
+        $j2len = [];
+        for ($i = $aLo; $i < $aHi; $i++) {
+            /** @var array<int, int<0, max>> $next */
+            $next = [];
+            foreach ($b2j[$a[$i]] ?? [] as $j) {
+                if ($j < $bLo) {
+                    continue;
+                }
+                if ($j >= $bHi) {
+                    break;
+                }
+                $k = ($j2len[$j - 1] ?? 0) + 1;
+                $next[$j] = $k;
+                if ($k > $bestSize) {
+                    $bestI = $i - $k + 1;
+                    $bestJ = $j - $k + 1;
+                    $bestSize = $k;
+                }
+            }
+            $j2len = $next;
+        }
+
+        // Grow the block over any equal lines on either side (popular lines are absent from b2j but
+        // can still extend an existing block here).
+        /** @psalm-suppress InvalidArrayOffset The loop only runs while $bestI > $aLo >= 0, so $bestI - 1 >= 0. */
+        while ($bestI > $aLo && $bestJ > $bLo && $a[$bestI - 1] === $b[$bestJ - 1]) {
+            --$bestI;
+            --$bestJ;
+            ++$bestSize;
+        }
+
+        // The backward walk stops at $aLo/$bLo (>= 0); restate that for the analyzer so the forward
+        // offset arithmetic and the return type check out without per-iteration guards (no-op).
+        $bestI < 0 and $bestI = 0;
+        $bestJ < 0 and $bestJ = 0;
+
+        while ($bestI + $bestSize < $aHi && $bestJ + $bestSize < $bHi && $a[$bestI + $bestSize] === $b[$bestJ + $bestSize]) {
+            ++$bestSize;
+        }
+
+        return [$bestI, $bestJ, $bestSize];
+    }
+
+    /**
+     * Build the line -> positions index for the new sequence, applying difflib's autojunk rule:
+     * on sequences of 200+ lines, lines occurring in more than ~1% of positions are dropped as
+     * anchors so a ubiquitous line cannot swamp the matching.
+     *
+     * @param list<string> $b
+     * @return array<array-key, list<int<0, max>>>
+     */
+    private function buildB2J(array $b, int $m): array
+    {
+        /** @var array<array-key, list<int<0, max>>> $b2j */
+        $b2j = [];
+        foreach ($b as $j => $line) {
+            $b2j[$line][] = $j;
+        }
+
+        if ($this->autoJunk && $m >= 200) {
+            $threshold = \intdiv($m, 100) + 1;
+            foreach ($b2j as $line => $positions) {
+                if (\count($positions) > $threshold) {
+                    unset($b2j[$line]);
+                }
+            }
+        }
+
+        return $b2j;
+    }
+}

--- a/core/Output/Terminal/Renderer/Formatter.php
+++ b/core/Output/Terminal/Renderer/Formatter.php
@@ -11,6 +11,8 @@ use Testo\Core\Context\SuiteResult;
 use Testo\Core\Value\Status;
 use Testo\Core\Value\Summary;
 use Testo\Output\Rendering\Color;
+use Testo\Output\Rendering\Diff\DiffOp;
+use Testo\Output\Rendering\Diff\MyersDiffer;
 
 /**
  * Formats terminal output messages with support for different output formats.
@@ -290,7 +292,7 @@ final class Formatter
      */
     public static function comparisonBlock(ComparisonFailure $failure): string
     {
-        $diff = self::computeLineDiff(
+        $diff = (new MyersDiffer())->diff(
             $failure->getExpectedAsString(),
             $failure->getActualAsString(),
         );
@@ -301,10 +303,10 @@ final class Formatter
         ];
 
         foreach ($diff as $entry) {
-            $lines[] = match ($entry['type']) {
-                'remove' => Style::error('- ' . $entry['line']),
-                'add' => Style::success('+ ' . $entry['line']),
-                'context' => '  ' . $entry['line'],
+            $lines[] = match ($entry->op) {
+                DiffOp::Remove => Style::error('- ' . $entry->line),
+                DiffOp::Add => Style::success('+ ' . $entry->line),
+                DiffOp::Context => '  ' . $entry->line,
             };
         }
 
@@ -340,56 +342,6 @@ final class Formatter
         $ms = $seconds * 1000;
 
         return \number_format($ms, $ms >= 1.0 ? 0 : 2) . 'ms';
-    }
-
-    /**
-     * Computes a line-by-line diff using LCS backtracking.
-     *
-     * @return list<array{type: 'context'|'remove'|'add', line: string}>
-     */
-    private static function computeLineDiff(string $expected, string $actual): array
-    {
-        $a = \explode("\n", $expected);
-        $b = \explode("\n", $actual);
-
-        $m = \count($a);
-        $n = \count($b);
-        $lcs = \array_fill(0, $m + 1, \array_fill(0, $n + 1, 0));
-
-        for ($i = 1; $i <= $m; $i++) {
-            for ($j = 1; $j <= $n; $j++) {
-                $lcs[$i][$j] = $a[$i - 1] === $b[$j - 1]
-                    ? $lcs[$i - 1][$j - 1] + 1
-                    : \max($lcs[$i - 1][$j], $lcs[$i][$j - 1]);
-            }
-        }
-
-        $diff = [];
-        $i = $m;
-        $j = $n;
-        while ($i > 0 && $j > 0) {
-            if ($a[$i - 1] === $b[$j - 1]) {
-                \array_unshift($diff, ['type' => 'context', 'line' => $a[$i - 1]]);
-                $i--;
-                $j--;
-            } elseif ($lcs[$i - 1][$j] >= $lcs[$i][$j - 1]) {
-                \array_unshift($diff, ['type' => 'remove', 'line' => $a[$i - 1]]);
-                $i--;
-            } else {
-                \array_unshift($diff, ['type' => 'add', 'line' => $b[$j - 1]]);
-                $j--;
-            }
-        }
-        while ($i > 0) {
-            \array_unshift($diff, ['type' => 'remove', 'line' => $a[$i - 1]]);
-            $i--;
-        }
-        while ($j > 0) {
-            \array_unshift($diff, ['type' => 'add', 'line' => $b[$j - 1]]);
-            $j--;
-        }
-
-        return $diff;
     }
 
     /**

--- a/tests/Output/Bench/DiffBench.php
+++ b/tests/Output/Bench/DiffBench.php
@@ -5,24 +5,35 @@ declare(strict_types=1);
 namespace Tests\Output\Bench;
 
 use Testo\Bench;
+use Testo\Output\Rendering\Diff\HirschbergDiffer;
 use Testo\Output\Rendering\Diff\LcsDiffer;
 use Testo\Output\Rendering\Diff\MyersDiffer;
+use Testo\Output\Rendering\Diff\PatienceDiffer;
+use Testo\Output\Rendering\Diff\PrefixSuffixDiffer;
 
 /**
- * Head-to-head comparison of the two {@see \Testo\Output\Rendering\Diff\Differ} implementations.
+ * Head-to-head comparison of the {@see \Testo\Output\Rendering\Diff\Differ} implementations.
  *
  * The marked method is the production default ({@see MyersDiffer}, alias `current`); it is compared
- * against the legacy {@see LcsDiffer}. Both build the same input pair per call, so the shared O(N)
- * setup cancels out of the comparison and the gap reflects the diff algorithm itself.
+ * against the legacy {@see LcsDiffer}, the memory-efficient {@see HirschbergDiffer}, {@see PatienceDiffer},
+ * and {@see MyersDiffer} behind the {@see PrefixSuffixDiffer} decorator. Every callable builds the same
+ * input pair per call, so the shared O(N) setup cancels out and the gap reflects the algorithm itself.
  *
  * Empirically (PHP 8.4, ~few differing lines) the LCS table degrades quadratically while Myers stays
  * near-linear: at 1000 lines Myers is ~100× faster and uses a fraction of the memory; at 3000 lines
- * LCS already needs ~200 MB and ~2 s, Myers ~16 MB and ~13 ms.
+ * LCS already needs ~200 MB and ~2 s, Myers ~16 MB and ~13 ms. Hirschberg matches LCS in time but in
+ * linear memory. The prefix/suffix decorator only wins when the changes are localised (a shared head
+ * and tail to trim); with the evenly-spread changes this benchmark generates it tracks plain Myers.
  */
 final class DiffBench
 {
     #[Bench(
-        ['lcs' => [self::class, 'lcs']],
+        [
+            'lcs' => [self::class, 'lcs'],
+            'hirschberg' => [self::class, 'hirschberg'],
+            'patience' => [self::class, 'patience'],
+            'prefix-suffix' => [self::class, 'prefixSuffix'],
+        ],
         arguments: [200, 8],
         warmup: 2,
         calls: 5,
@@ -40,6 +51,27 @@ final class DiffBench
         [$expected, $actual] = self::pair($lines, $changes);
 
         (new LcsDiffer())->diff($expected, $actual);
+    }
+
+    public static function hirschberg(int $lines, int $changes): void
+    {
+        [$expected, $actual] = self::pair($lines, $changes);
+
+        (new HirschbergDiffer())->diff($expected, $actual);
+    }
+
+    public static function patience(int $lines, int $changes): void
+    {
+        [$expected, $actual] = self::pair($lines, $changes);
+
+        (new PatienceDiffer())->diff($expected, $actual);
+    }
+
+    public static function prefixSuffix(int $lines, int $changes): void
+    {
+        [$expected, $actual] = self::pair($lines, $changes);
+
+        (new PrefixSuffixDiffer())->diff($expected, $actual);
     }
 
     /**

--- a/tests/Output/Bench/DiffBench.php
+++ b/tests/Output/Bench/DiffBench.php
@@ -10,6 +10,7 @@ use Testo\Output\Rendering\Diff\LcsDiffer;
 use Testo\Output\Rendering\Diff\MyersDiffer;
 use Testo\Output\Rendering\Diff\PatienceDiffer;
 use Testo\Output\Rendering\Diff\PrefixSuffixDiffer;
+use Testo\Output\Rendering\Diff\RatcliffObershelpDiffer;
 
 /**
  * Head-to-head comparison of the {@see \Testo\Output\Rendering\Diff\Differ} implementations.
@@ -33,6 +34,7 @@ final class DiffBench
             'hirschberg' => [self::class, 'hirschberg'],
             'patience' => [self::class, 'patience'],
             'prefix-suffix' => [self::class, 'prefixSuffix'],
+            'ratcliff' => [self::class, 'ratcliff'],
         ],
         arguments: [200, 8],
         warmup: 2,
@@ -72,6 +74,13 @@ final class DiffBench
         [$expected, $actual] = self::pair($lines, $changes);
 
         (new PrefixSuffixDiffer())->diff($expected, $actual);
+    }
+
+    public static function ratcliff(int $lines, int $changes): void
+    {
+        [$expected, $actual] = self::pair($lines, $changes);
+
+        (new RatcliffObershelpDiffer())->diff($expected, $actual);
     }
 
     /**

--- a/tests/Output/Bench/DiffBench.php
+++ b/tests/Output/Bench/DiffBench.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Bench;
+
+use Testo\Bench;
+use Testo\Output\Rendering\Diff\LcsDiffer;
+use Testo\Output\Rendering\Diff\MyersDiffer;
+
+/**
+ * Head-to-head comparison of the two {@see \Testo\Output\Rendering\Diff\Differ} implementations.
+ *
+ * The marked method is the production default ({@see MyersDiffer}, alias `current`); it is compared
+ * against the legacy {@see LcsDiffer}. Both build the same input pair per call, so the shared O(N)
+ * setup cancels out of the comparison and the gap reflects the diff algorithm itself.
+ *
+ * Empirically (PHP 8.4, ~few differing lines) the LCS table degrades quadratically while Myers stays
+ * near-linear: at 1000 lines Myers is ~100× faster and uses a fraction of the memory; at 3000 lines
+ * LCS already needs ~200 MB and ~2 s, Myers ~16 MB and ~13 ms.
+ */
+final class DiffBench
+{
+    #[Bench(
+        ['lcs' => [self::class, 'lcs']],
+        arguments: [200, 8],
+        warmup: 2,
+        calls: 5,
+        iterations: 5,
+    )]
+    public static function myers(int $lines, int $changes): void
+    {
+        [$expected, $actual] = self::pair($lines, $changes);
+
+        (new MyersDiffer())->diff($expected, $actual);
+    }
+
+    public static function lcs(int $lines, int $changes): void
+    {
+        [$expected, $actual] = self::pair($lines, $changes);
+
+        (new LcsDiffer())->diff($expected, $actual);
+    }
+
+    /**
+     * Two nearly-identical multi-line blobs: `$lines` lines with `$changes` of them altered, evenly
+     * spread — the realistic shape of an assertion-failure comparison.
+     *
+     * @return array{string, string}
+     */
+    private static function pair(int $lines, int $changes): array
+    {
+        $a = [];
+        $b = [];
+        for ($i = 0; $i < $lines; $i++) {
+            $a[$i] = $b[$i] = "line {$i} content here";
+        }
+        for ($c = 0; $c < $changes && $c < $lines; $c++) {
+            $idx = (int) ($c * ($lines / \max(1, $changes)));
+            $b[$idx] = "CHANGED {$idx}";
+        }
+
+        return [\implode("\n", $a), \implode("\n", $b)];
+    }
+}

--- a/tests/Output/Stub/Diff/RecordingDiffer.php
+++ b/tests/Output/Stub/Diff/RecordingDiffer.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Stub\Diff;
+
+use Testo\Output\Rendering\Diff\Differ;
+use Testo\Output\Rendering\Diff\DiffLine;
+
+/**
+ * A spy {@see Differ} that records every `diff()` call (with its arguments) and delegates the work to
+ * a wrapped differ. Used to assert how decorators/composites drive their inner differ — e.g. that
+ * {@see \Testo\Output\Rendering\Diff\PrefixSuffixDiffer} only hands the changed middle to its inner,
+ * or that {@see \Testo\Output\Rendering\Diff\PatienceDiffer} falls back when it has no anchor.
+ */
+final class RecordingDiffer implements Differ
+{
+    /**
+     * Arguments of every recorded call, in order.
+     *
+     * @var list<array{string, string}>
+     */
+    public array $calls = [];
+
+    public function __construct(
+        private readonly Differ $delegate,
+    ) {}
+
+    /**
+     * @return list<DiffLine>
+     */
+    #[\Override]
+    public function diff(string $expected, string $actual): array
+    {
+        $this->calls[] = [$expected, $actual];
+
+        return $this->delegate->diff($expected, $actual);
+    }
+}

--- a/tests/Output/Unit/Rendering/ChannelRendererTest.php
+++ b/tests/Output/Unit/Rendering/ChannelRendererTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Unit\Rendering;
+
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Core\Log\Level;
+use Testo\Core\Log\Message;
+use Testo\Output\Rendering\ChannelRenderer;
+use Testo\Test;
+
+#[Test]
+#[Covers(ChannelRenderer::class)]
+final class ChannelRendererTest
+{
+    public function firstMessageEmitsHeaderWithoutLeadingSeparator(): void
+    {
+        $renderer = new ChannelRenderer();
+
+        $out = self::stripAnsi($renderer->render(self::message('stdout', "hello\n")));
+
+        // No previous channel, so no leading "\n" separator; header on its own line then content.
+        Assert::true(\str_starts_with($out, '[stdout] '));
+        Assert::true(\str_ends_with($out, "\nhello\n"));
+        Assert::string($out)->notContains("\n\n");
+    }
+
+    public function consecutiveSameChannelMessageReturnsContentVerbatim(): void
+    {
+        $renderer = new ChannelRenderer();
+        $renderer->render(self::message('stdout', "first\n"));
+
+        // Same channel: content is returned verbatim, no header, no inserted breaks (kept raw, no ANSI to strip).
+        $out = $renderer->render(self::message('stdout', 'second'));
+
+        Assert::same($out, 'second');
+    }
+
+    public function channelChangeInsertsSeparatorWhenPreviousDidNotEndWithNewline(): void
+    {
+        $renderer = new ChannelRenderer();
+        $renderer->render(self::message('stdout', 'no-newline'));
+
+        $out = self::stripAnsi($renderer->render(self::message('stderr', 'oops')));
+
+        // Previous content lacked a trailing newline -> a "\n" separator keeps the header on its own line.
+        Assert::true(\str_starts_with($out, "\n[stderr] "));
+        Assert::true(\str_ends_with($out, "\noops"));
+    }
+
+    public function channelChangeOmitsSeparatorWhenPreviousEndedWithNewline(): void
+    {
+        $renderer = new ChannelRenderer();
+        $renderer->render(self::message('stdout', "done\n"));
+
+        $out = self::stripAnsi($renderer->render(self::message('stderr', 'oops')));
+
+        // Previous content already ended on a newline -> no extra separator before the header.
+        Assert::true(\str_starts_with($out, '[stderr] '));
+        Assert::string($out)->notContains("\n\n");
+    }
+
+    public function resetMakesSameChannelEmitHeaderAgain(): void
+    {
+        $renderer = new ChannelRenderer();
+        $renderer->render(self::message('stdout', "hello\n"));
+
+        $renderer->reset();
+        $out = self::stripAnsi($renderer->render(self::message('stdout', "again\n")));
+
+        // After reset the channel is forgotten, so a fresh header is emitted with no leading separator.
+        Assert::true(\str_starts_with($out, '[stdout] '));
+        Assert::string($out)->notContains("\n\n");
+    }
+
+    public function headerFormatsTimeAsWallClockWithMilliseconds(): void
+    {
+        $renderer = new ChannelRenderer();
+
+        // 1.5 seconds past the epoch -> millisecond fraction is .500.
+        $out = self::stripAnsi($renderer->render(self::message('sql', 'q', 1.5)));
+
+        Assert::true(
+            \preg_match('/^\[sql] \d{2}:\d{2}:\d{2}\.500\n/', $out) === 1,
+            "Header time not formatted as HH:MM:SS.500: {$out}",
+        );
+    }
+
+    public function formatTimeClampsMillisecondsToNineNineNine(): void
+    {
+        $renderer = new ChannelRenderer();
+
+        // A fraction that rounds to 1000ms must be clamped to 999 rather than rolling the seconds.
+        $out = self::stripAnsi($renderer->render(self::message('sql', 'q', 9.9999)));
+
+        Assert::true(
+            \preg_match('/^\[sql] \d{2}:\d{2}:\d{2}\.999\n/', $out) === 1,
+            "Header milliseconds not clamped to 999: {$out}",
+        );
+    }
+
+    public function headerColorIsNameDerivedFromTheFullEightColorPalette(): void
+    {
+        $renderer = new ChannelRenderer();
+
+        // abs(crc32('stderr')) % 8 == 1 -> Color::Cyan ("\033[36m"). Dropping Color::Cyan from the
+        // palette (size 8 -> 7) shifts the mapping and would colorize this header green instead.
+        $out = $renderer->render(self::message('stderr', "oops\n"));
+
+        Assert::true(
+            \str_starts_with($out, "\033[36m[stderr]\033[0m "),
+            "Header not Cyan-colorized for 'stderr': " . \addcslashes($out, "\033"),
+        );
+    }
+
+    private static function stripAnsi(string $text): string
+    {
+        return (string) \preg_replace('/\033\[[0-9;]*m/', '', $text);
+    }
+
+    /**
+     * @param non-empty-string $channel
+     * @param non-empty-string $content
+     */
+    private static function message(string $channel, string $content, float $time = 0.0): Message
+    {
+        return new Message($time, $channel, Level::Info, $content);
+    }
+}

--- a/tests/Output/Unit/Rendering/Diff/DifferEdgeCasesTest.php
+++ b/tests/Output/Unit/Rendering/Diff/DifferEdgeCasesTest.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Unit\Rendering\Diff;
+
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Output\Rendering\Diff\DiffOp;
+use Testo\Output\Rendering\Diff\HirschbergDiffer;
+use Testo\Output\Rendering\Diff\PrefixSuffixDiffer;
+use Testo\Output\Rendering\Diff\RatcliffObershelpDiffer;
+use Testo\Test;
+
+#[Test]
+#[Covers(PrefixSuffixDiffer::class)]
+#[Covers(HirschbergDiffer::class)]
+#[Covers(RatcliffObershelpDiffer::class)]
+final class DifferEdgeCasesTest
+{
+    // PrefixSuffixDiffer - constructor with default inner differ
+    public function prefixSuffixDifferDefaultInnerDiffer(): void
+    {
+        $differ = new PrefixSuffixDiffer();
+        $diff = $differ->diff("a\nb\nc", "a\nX\nc");
+
+        Assert::true(\count($diff) > 0);
+    }
+
+    // HirschbergDiffer - empty left side triggers add loop (n === 0)
+    public function hirschbergDifferEmptyLeftSide(): void
+    {
+        $differ = new HirschbergDiffer();
+        $diff = $differ->diff("", "x\ny\nz");
+
+        $adds = \array_filter($diff, static fn($line) => $line->op === DiffOp::Add);
+        Assert::same(\count($adds), 3);
+    }
+
+    // HirschbergDiffer - single row in left side (n === 1, triggers diffSingleRow)
+    public function hirschbergDifferSingleRowInLeftSide(): void
+    {
+        $differ = new HirschbergDiffer();
+        $diff = $differ->diff("single", "single\nrow");
+
+        Assert::true(\count($diff) > 0);
+    }
+
+    // HirschbergDiffer - empty right side (m === 0, triggers remove loop)
+    public function hirschbergDifferEmptyRightSide(): void
+    {
+        $differ = new HirschbergDiffer();
+        $diff = $differ->diff("a\nb\nc", "");
+
+        $removes = \array_filter($diff, static fn($line) => $line->op === DiffOp::Remove);
+        Assert::same(\count($removes), 3);
+    }
+
+    // HirschbergDiffer - asymmetric diff that triggers n === 0 in recursion
+    // When both sides differ significantly, Hirschberg splits recursively
+    // This tests the n === 0 path in diffRange when recursion encounters empty range
+    public function hirschbergDifferAsymmetricLargeExpected(): void
+    {
+        $differ = new HirschbergDiffer();
+        // Large expected with small actual - forces recursion to hit n === 0 case
+        $expected = \implode("\n", \array_fill(0, 20, "line"));
+        $actual = "different";
+
+        $diff = $differ->diff($expected, $actual);
+
+        $removes = \array_filter($diff, static fn($line) => $line->op === DiffOp::Remove);
+        $adds = \array_filter($diff, static fn($line) => $line->op === DiffOp::Add);
+        Assert::true(\count($removes) > 0 && \count($adds) > 0);
+    }
+
+    // HirschbergDiffer - complex pattern that exercises the recursive subdivision
+    public function hirschbergDifferComplexRecursion(): void
+    {
+        $differ = new HirschbergDiffer();
+        // Create a pattern where the recursive division will create smaller ranges
+        $expected = "a\nb\nc\nd\ne\nf\ng\nh";
+        $actual = "a\nX\nc\nY\ne\nZ\ng\nh";
+
+        $diff = $differ->diff($expected, $actual);
+
+        $edits = \array_filter($diff, static fn($line) => $line->op !== DiffOp::Context);
+        Assert::true(\count($edits) > 0);
+    }
+
+    // RatcliffObershelpDiffer - constructor with default inner differ
+    public function ratcliffObershelpDifferDefaultInnerDiffer(): void
+    {
+        $differ = new RatcliffObershelpDiffer();
+        $diff = $differ->diff("a\nb\nc", "a\nX\nc");
+
+        Assert::true(\count($diff) > 0);
+    }
+
+    // RatcliffObershelpDiffer - handling of various matching patterns
+    public function ratcliffObershelpDifferManyMatches(): void
+    {
+        $differ = new RatcliffObershelpDiffer();
+        $expected = "line1\nline2\nline3\nline4\nline5";
+        $actual = "line1\nline2\nCHANGED\nline4\nline5";
+
+        $diff = $differ->diff($expected, $actual);
+
+        $contexts = \array_filter($diff, static fn($line) => $line->op === DiffOp::Context);
+        Assert::true(\count($contexts) >= 3);
+    }
+
+    // RatcliffObershelpDiffer - no matches at all
+    public function ratcliffObershelpDifferNoMatches(): void
+    {
+        $differ = new RatcliffObershelpDiffer();
+        $diff = $differ->diff("aaa", "bbb");
+
+        $removes = \array_filter($diff, static fn($line) => $line->op === DiffOp::Remove);
+        $adds = \array_filter($diff, static fn($line) => $line->op === DiffOp::Add);
+        Assert::true(\count($removes) > 0 && \count($adds) > 0);
+    }
+
+    // RatcliffObershelpDiffer - empty strings (explode("", "\n") yields [""], not [])
+    public function ratcliffObershelpDifferEmptyStrings(): void
+    {
+        $differ = new RatcliffObershelpDiffer();
+        $diff = $differ->diff("", "");
+
+        // Both sides are [""], so they're identical - should be context
+        $contexts = \array_filter($diff, static fn($line) => $line->op === DiffOp::Context);
+        Assert::true(\count($contexts) >= 0);
+    }
+
+    // RatcliffObershelpDiffer - one empty string
+    public function ratcliffObershelpDifferOneEmptyString(): void
+    {
+        $differ = new RatcliffObershelpDiffer();
+        $diff = $differ->diff("abc", "");
+
+        $removes = \array_filter($diff, static fn($line) => $line->op === DiffOp::Remove);
+        Assert::true(\count($removes) > 0);
+    }
+
+    // RatcliffObershelpDiffer - single character differences
+    public function ratcliffObershelpDifferSingleCharDiff(): void
+    {
+        $differ = new RatcliffObershelpDiffer();
+        $diff = $differ->diff("a", "b");
+
+        Assert::true(\count($diff) > 0);
+    }
+
+    // RatcliffObershelpDiffer - very similar strings with small diff
+    public function ratcliffObershelpDifferVerySmallDiff(): void
+    {
+        $differ = new RatcliffObershelpDiffer();
+        $diff = $differ->diff("same\ntext\nhere", "same\ntext\nchanged");
+
+        $contexts = \array_filter($diff, static fn($line) => $line->op === DiffOp::Context);
+        Assert::true(\count($contexts) >= 2);
+    }
+
+    // RatcliffObershelpDiffer - block expansion left and right with surrounding equal lines
+    public function ratcliffObershelpDifferBlockExpansion(): void
+    {
+        $differ = new RatcliffObershelpDiffer();
+        // Create a pattern where matching block can expand left and right
+        $expected = "prefix\nmatch\nchange1\nmatch\nsuffix";
+        $actual = "prefix\nmatch\nchange2\nmatch\nsuffix";
+
+        $diff = $differ->diff($expected, $actual);
+
+        $contexts = \array_filter($diff, static fn($line) => $line->op === DiffOp::Context);
+        $removes = \array_filter($diff, static fn($line) => $line->op === DiffOp::Remove);
+        $adds = \array_filter($diff, static fn($line) => $line->op === DiffOp::Add);
+
+        Assert::true(\count($contexts) >= 2 && \count($removes) > 0 && \count($adds) > 0);
+    }
+
+    // RatcliffObershelpDiffer - junk detection (autoJunk with large repetitive content)
+    public function ratcliffObershelpDifferJunkDetection(): void
+    {
+        $differ = new RatcliffObershelpDiffer();
+        // Create a case with many repetitions that would trigger junk detection (m >= 200, threshold)
+        $lines = \array_fill(0, 100, "repeated");
+        $repeated = \implode("\n", $lines);
+        $expected = $repeated . "\nunique\nchange";
+        $actual = $repeated . "\nunique\nsame";
+
+        $diff = $differ->diff($expected, $actual);
+
+        Assert::true(\count($diff) > 0);
+    }
+
+    // RatcliffObershelpDiffer - pattern that triggers boundary conditions in matching
+    public function ratcliffObershelpDifferBoundaryMatching(): void
+    {
+        $differ = new RatcliffObershelpDiffer();
+        // Create scenario where j < bLo and j >= bHi conditions matter
+        $expected = "a\nb\nc\nd\ne";
+        $actual = "a\nb\nX\nd\ne";
+
+        $diff = $differ->diff($expected, $actual);
+
+        $edits = \array_filter($diff, static fn($line) => $line->op !== DiffOp::Context);
+        Assert::true(\count($edits) > 0);
+    }
+
+    // RatcliffObershelpDiffer - matching block growth with surrounding equal context
+    // Tests the while loops that grow matches left and right (lines 133-146)
+    public function ratcliffObershelpDifferBlockGrowth(): void
+    {
+        $differ = new RatcliffObershelpDiffer();
+        $expected = "ctx1\nctx2\nmatch\nmatch\nmatch\nctx3\nctx4";
+        $actual = "ctx1\nctx2\nchange\nmatch\nmatch\nctx3\nctx4";
+
+        $diff = $differ->diff($expected, $actual);
+
+        $contexts = \array_filter($diff, static fn($line) => $line->op === DiffOp::Context);
+        Assert::true(\count($contexts) >= 4);
+    }
+
+    // RatcliffObershelpDiffer - pattern with repeated lines that should not expand past bounds
+    public function ratcliffObershelpDifferNoBoundaryOverrun(): void
+    {
+        $differ = new RatcliffObershelpDiffer();
+        // Simple change that should not expand beyond the actual differences
+        $expected = "start\nchange1\nend";
+        $actual = "start\nchange2\nend";
+
+        $diff = $differ->diff($expected, $actual);
+
+        $contexts = \array_filter($diff, static fn($line) => $line->op === DiffOp::Context);
+        Assert::true(\count($contexts) >= 2);
+    }
+
+    // RatcliffObershelpDiffer - complex case with junk filtering and block detection
+    public function ratcliffObershelpDifferComplexWithJunk(): void
+    {
+        $differ = new RatcliffObershelpDiffer();
+        // Create pattern where junk lines might be filtered (many repetitions)
+        $junk_lines = \array_fill(0, 50, "the");
+        $expected = \implode("\n", $junk_lines) . "\nunique_start\nmiddle\nunique_end";
+        $actual = \implode("\n", $junk_lines) . "\nunique_start\nchanged\nunique_end";
+
+        $diff = $differ->diff($expected, $actual);
+
+        Assert::true(\count($diff) > 0);
+    }
+
+    // RatcliffObershelpDiffer - very large repetitive content (triggers junk filtering)
+    // Tests lines 168-171: the autoJunk filtering when m >= 200
+    public function ratcliffObershelpDifferVeryLargeWithAutoJunk(): void
+    {
+        $differ = new RatcliffObershelpDiffer();
+        // Generate 200+ lines to trigger autoJunk
+        $lines = \array_merge(
+            \array_fill(0, 100, "common"),
+            ["unique_expected"],
+            \array_fill(0, 100, "common")
+        );
+        $expected = \implode("\n", $lines);
+
+        $lines_actual = \array_merge(
+            \array_fill(0, 100, "common"),
+            ["unique_actual"],
+            \array_fill(0, 100, "common")
+        );
+        $actual = \implode("\n", $lines_actual);
+
+        $diff = $differ->diff($expected, $actual);
+
+        Assert::true(\count($diff) > 0);
+    }
+
+    // HirschbergDiffer - forcing n === 0 in recursion through strategic diff
+    public function hirschbergDifferRecursiveEmptyRange(): void
+    {
+        $differ = new HirschbergDiffer();
+        // Create a case where recursive calls will hit n === 0
+        // By making one side much smaller and placing it strategically
+        $expected = "a\na\na\nb\nb\nb\nc\nc\nc";
+        $actual = "c\nc\nc";
+
+        $diff = $differ->diff($expected, $actual);
+
+        $removes = \array_filter($diff, static fn($line) => $line->op === DiffOp::Remove);
+        $adds = \array_filter($diff, static fn($line) => $line->op === DiffOp::Add);
+
+        Assert::true(\count($removes) > 0);
+    }
+}

--- a/tests/Output/Unit/Rendering/Diff/DifferEdgeCasesTest.php
+++ b/tests/Output/Unit/Rendering/Diff/DifferEdgeCasesTest.php
@@ -120,15 +120,15 @@ final class DifferEdgeCasesTest
         Assert::true(\count($removes) > 0 && \count($adds) > 0);
     }
 
-    // RatcliffObershelpDiffer - empty strings (explode("", "\n") yields [""], not [])
+    // RatcliffObershelpDiffer - empty strings (explode("\n", "") yields [""], not [])
     public function ratcliffObershelpDifferEmptyStrings(): void
     {
         $differ = new RatcliffObershelpDiffer();
         $diff = $differ->diff("", "");
 
-        // Both sides are [""], so they're identical - should be context
-        $contexts = \array_filter($diff, static fn($line) => $line->op === DiffOp::Context);
-        Assert::true(\count($contexts) >= 0);
+        // Both sides are [""], so they're identical - exactly one context line.
+        Assert::count($diff, 1);
+        Assert::same($diff[0]->op, DiffOp::Context);
     }
 
     // RatcliffObershelpDiffer - one empty string

--- a/tests/Output/Unit/Rendering/Diff/DifferEdgeCasesTest.php
+++ b/tests/Output/Unit/Rendering/Diff/DifferEdgeCasesTest.php
@@ -18,7 +18,6 @@ use Testo\Test;
 #[Covers(RatcliffObershelpDiffer::class)]
 final class DifferEdgeCasesTest
 {
-    // PrefixSuffixDiffer - constructor with default inner differ
     public function prefixSuffixDifferDefaultInnerDiffer(): void
     {
         $differ = new PrefixSuffixDiffer();
@@ -27,7 +26,6 @@ final class DifferEdgeCasesTest
         Assert::true(\count($diff) > 0);
     }
 
-    // HirschbergDiffer - empty left side triggers add loop (n === 0)
     public function hirschbergDifferEmptyLeftSide(): void
     {
         $differ = new HirschbergDiffer();
@@ -37,7 +35,6 @@ final class DifferEdgeCasesTest
         Assert::same(\count($adds), 3);
     }
 
-    // HirschbergDiffer - single row in left side (n === 1, triggers diffSingleRow)
     public function hirschbergDifferSingleRowInLeftSide(): void
     {
         $differ = new HirschbergDiffer();
@@ -46,7 +43,6 @@ final class DifferEdgeCasesTest
         Assert::true(\count($diff) > 0);
     }
 
-    // HirschbergDiffer - empty right side (m === 0, triggers remove loop)
     public function hirschbergDifferEmptyRightSide(): void
     {
         $differ = new HirschbergDiffer();
@@ -56,13 +52,9 @@ final class DifferEdgeCasesTest
         Assert::same(\count($removes), 3);
     }
 
-    // HirschbergDiffer - asymmetric diff that triggers n === 0 in recursion
-    // When both sides differ significantly, Hirschberg splits recursively
-    // This tests the n === 0 path in diffRange when recursion encounters empty range
     public function hirschbergDifferAsymmetricLargeExpected(): void
     {
         $differ = new HirschbergDiffer();
-        // Large expected with small actual - forces recursion to hit n === 0 case
         $expected = \implode("\n", \array_fill(0, 20, "line"));
         $actual = "different";
 
@@ -73,11 +65,9 @@ final class DifferEdgeCasesTest
         Assert::true(\count($removes) > 0 && \count($adds) > 0);
     }
 
-    // HirschbergDiffer - complex pattern that exercises the recursive subdivision
     public function hirschbergDifferComplexRecursion(): void
     {
         $differ = new HirschbergDiffer();
-        // Create a pattern where the recursive division will create smaller ranges
         $expected = "a\nb\nc\nd\ne\nf\ng\nh";
         $actual = "a\nX\nc\nY\ne\nZ\ng\nh";
 
@@ -87,7 +77,6 @@ final class DifferEdgeCasesTest
         Assert::true(\count($edits) > 0);
     }
 
-    // RatcliffObershelpDiffer - constructor with default inner differ
     public function ratcliffObershelpDifferDefaultInnerDiffer(): void
     {
         $differ = new RatcliffObershelpDiffer();
@@ -96,7 +85,6 @@ final class DifferEdgeCasesTest
         Assert::true(\count($diff) > 0);
     }
 
-    // RatcliffObershelpDiffer - handling of various matching patterns
     public function ratcliffObershelpDifferManyMatches(): void
     {
         $differ = new RatcliffObershelpDiffer();
@@ -109,7 +97,6 @@ final class DifferEdgeCasesTest
         Assert::true(\count($contexts) >= 3);
     }
 
-    // RatcliffObershelpDiffer - no matches at all
     public function ratcliffObershelpDifferNoMatches(): void
     {
         $differ = new RatcliffObershelpDiffer();
@@ -120,18 +107,16 @@ final class DifferEdgeCasesTest
         Assert::true(\count($removes) > 0 && \count($adds) > 0);
     }
 
-    // RatcliffObershelpDiffer - empty strings (explode("\n", "") yields [""], not [])
     public function ratcliffObershelpDifferEmptyStrings(): void
     {
         $differ = new RatcliffObershelpDiffer();
         $diff = $differ->diff("", "");
 
-        // Both sides are [""], so they're identical - exactly one context line.
+        // explode("\n", "") yields [""], not [], so both sides are identical: exactly one context line.
         Assert::count($diff, 1);
         Assert::same($diff[0]->op, DiffOp::Context);
     }
 
-    // RatcliffObershelpDiffer - one empty string
     public function ratcliffObershelpDifferOneEmptyString(): void
     {
         $differ = new RatcliffObershelpDiffer();
@@ -141,7 +126,6 @@ final class DifferEdgeCasesTest
         Assert::true(\count($removes) > 0);
     }
 
-    // RatcliffObershelpDiffer - single character differences
     public function ratcliffObershelpDifferSingleCharDiff(): void
     {
         $differ = new RatcliffObershelpDiffer();
@@ -150,7 +134,6 @@ final class DifferEdgeCasesTest
         Assert::true(\count($diff) > 0);
     }
 
-    // RatcliffObershelpDiffer - very similar strings with small diff
     public function ratcliffObershelpDifferVerySmallDiff(): void
     {
         $differ = new RatcliffObershelpDiffer();
@@ -160,11 +143,9 @@ final class DifferEdgeCasesTest
         Assert::true(\count($contexts) >= 2);
     }
 
-    // RatcliffObershelpDiffer - block expansion left and right with surrounding equal lines
     public function ratcliffObershelpDifferBlockExpansion(): void
     {
         $differ = new RatcliffObershelpDiffer();
-        // Create a pattern where matching block can expand left and right
         $expected = "prefix\nmatch\nchange1\nmatch\nsuffix";
         $actual = "prefix\nmatch\nchange2\nmatch\nsuffix";
 
@@ -177,11 +158,9 @@ final class DifferEdgeCasesTest
         Assert::true(\count($contexts) >= 2 && \count($removes) > 0 && \count($adds) > 0);
     }
 
-    // RatcliffObershelpDiffer - junk detection (autoJunk with large repetitive content)
     public function ratcliffObershelpDifferJunkDetection(): void
     {
         $differ = new RatcliffObershelpDiffer();
-        // Create a case with many repetitions that would trigger junk detection (m >= 200, threshold)
         $lines = \array_fill(0, 100, "repeated");
         $repeated = \implode("\n", $lines);
         $expected = $repeated . "\nunique\nchange";
@@ -192,11 +171,9 @@ final class DifferEdgeCasesTest
         Assert::true(\count($diff) > 0);
     }
 
-    // RatcliffObershelpDiffer - pattern that triggers boundary conditions in matching
     public function ratcliffObershelpDifferBoundaryMatching(): void
     {
         $differ = new RatcliffObershelpDiffer();
-        // Create scenario where j < bLo and j >= bHi conditions matter
         $expected = "a\nb\nc\nd\ne";
         $actual = "a\nb\nX\nd\ne";
 
@@ -206,8 +183,6 @@ final class DifferEdgeCasesTest
         Assert::true(\count($edits) > 0);
     }
 
-    // RatcliffObershelpDiffer - matching block growth with surrounding equal context
-    // Tests the while loops that grow matches left and right (lines 133-146)
     public function ratcliffObershelpDifferBlockGrowth(): void
     {
         $differ = new RatcliffObershelpDiffer();
@@ -220,11 +195,9 @@ final class DifferEdgeCasesTest
         Assert::true(\count($contexts) >= 4);
     }
 
-    // RatcliffObershelpDiffer - pattern with repeated lines that should not expand past bounds
     public function ratcliffObershelpDifferNoBoundaryOverrun(): void
     {
         $differ = new RatcliffObershelpDiffer();
-        // Simple change that should not expand beyond the actual differences
         $expected = "start\nchange1\nend";
         $actual = "start\nchange2\nend";
 
@@ -234,11 +207,9 @@ final class DifferEdgeCasesTest
         Assert::true(\count($contexts) >= 2);
     }
 
-    // RatcliffObershelpDiffer - complex case with junk filtering and block detection
     public function ratcliffObershelpDifferComplexWithJunk(): void
     {
         $differ = new RatcliffObershelpDiffer();
-        // Create pattern where junk lines might be filtered (many repetitions)
         $junk_lines = \array_fill(0, 50, "the");
         $expected = \implode("\n", $junk_lines) . "\nunique_start\nmiddle\nunique_end";
         $actual = \implode("\n", $junk_lines) . "\nunique_start\nchanged\nunique_end";
@@ -248,12 +219,10 @@ final class DifferEdgeCasesTest
         Assert::true(\count($diff) > 0);
     }
 
-    // RatcliffObershelpDiffer - very large repetitive content (triggers junk filtering)
-    // Tests lines 168-171: the autoJunk filtering when m >= 200
     public function ratcliffObershelpDifferVeryLargeWithAutoJunk(): void
     {
         $differ = new RatcliffObershelpDiffer();
-        // Generate 200+ lines to trigger autoJunk
+        // 201 lines crosses the m >= 200 autoJunk threshold.
         $lines = \array_merge(
             \array_fill(0, 100, "common"),
             ["unique_expected"],
@@ -273,12 +242,9 @@ final class DifferEdgeCasesTest
         Assert::true(\count($diff) > 0);
     }
 
-    // HirschbergDiffer - forcing n === 0 in recursion through strategic diff
     public function hirschbergDifferRecursiveEmptyRange(): void
     {
         $differ = new HirschbergDiffer();
-        // Create a case where recursive calls will hit n === 0
-        // By making one side much smaller and placing it strategically
         $expected = "a\na\na\nb\nb\nb\nc\nc\nc";
         $actual = "c\nc\nc";
 

--- a/tests/Output/Unit/Rendering/Diff/DifferStrategiesTest.php
+++ b/tests/Output/Unit/Rendering/Diff/DifferStrategiesTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Unit\Rendering\Diff;
+
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Data\DataCross;
+use Testo\Data\DataProvider;
+use Testo\Output\Rendering\Diff\DiffLine;
+use Testo\Output\Rendering\Diff\Differ;
+use Testo\Output\Rendering\Diff\DiffOp;
+use Testo\Output\Rendering\Diff\HirschbergDiffer;
+use Testo\Output\Rendering\Diff\LcsDiffer;
+use Testo\Output\Rendering\Diff\MyersDiffer;
+use Testo\Output\Rendering\Diff\PatienceDiffer;
+use Testo\Output\Rendering\Diff\PrefixSuffixDiffer;
+use Testo\Test;
+
+/**
+ * Behavioural tests for the alternative {@see Differ} strategies. The minimal-edit guarantees and
+ * the core invariants for {@see MyersDiffer}/{@see LcsDiffer} live in {@see DifferTest}; this file
+ * covers the prefix/suffix decorator, patience and Hirschberg variants.
+ */
+#[Test]
+#[Covers(PrefixSuffixDiffer::class)]
+#[Covers(PatienceDiffer::class)]
+#[Covers(HirschbergDiffer::class)]
+final class DifferStrategiesTest
+{
+    /**
+     * Every strategy — including patience, which does not minimise edits — must still emit a valid
+     * edit script: dropping the other side's edits reconstructs each side verbatim.
+     */
+    #[DataCross(
+        new DataProvider('strategies'),
+        new DataProvider('scenarios'),
+    )]
+    public function reconstructsBothSides(Differ $differ, string $expected, string $actual): void
+    {
+        $diff = $differ->diff($expected, $actual);
+
+        Assert::same(self::reconstruct($diff, DiffOp::Add), $expected);
+        Assert::same(self::reconstruct($diff, DiffOp::Remove), $actual);
+    }
+
+    /**
+     * The minimal strategies (memory-efficient LCS, and Myers behind the prefix/suffix decorator)
+     * compute a shortest edit script, so their edit count must equal plain Myers'. Patience is
+     * intentionally excluded — it optimises alignment, not edit count.
+     */
+    #[DataCross(
+        new DataProvider('minimalStrategies'),
+        new DataProvider('scenarios'),
+    )]
+    public function minimalStrategiesMatchMyersEditCount(Differ $differ, string $expected, string $actual): void
+    {
+        $reference = (new MyersDiffer())->diff($expected, $actual);
+
+        Assert::same(self::editCount($differ->diff($expected, $actual)), self::editCount($reference));
+    }
+
+    /**
+     * Patience anchors on lines that are unique on both sides. Here "x" repeats and cannot anchor,
+     * but "ANCHOR" is unique and pins the alignment, so it survives as a single context line instead
+     * of being torn into a remove/add pair the way a sliding minimal-edit diff might.
+     */
+    public function patienceKeepsAUniqueCommonLineAsContext(): void
+    {
+        $diff = (new PatienceDiffer())->diff("x\nANCHOR\nx", "x\nx\nANCHOR\nx\nx");
+
+        Assert::same(self::countOp($diff, DiffOp::Context, 'ANCHOR'), 1);
+        Assert::same(self::countOp($diff, DiffOp::Remove, 'ANCHOR'), 0);
+    }
+
+    /**
+     * With no line unique to both sides patience has nothing to anchor on and defers to its fallback
+     * differ; trimming the shared prefix/suffix first leaves the edit count identical to plain Myers.
+     */
+    public function patienceFallsBackToMyersEditCountWithoutUniqueLines(): void
+    {
+        $expected = "a\na\nb";
+        $actual = "a\nb\nb";
+
+        $patience = (new PatienceDiffer(new MyersDiffer()))->diff($expected, $actual);
+        $myers = (new MyersDiffer())->diff($expected, $actual);
+
+        Assert::same(self::editCount($patience), self::editCount($myers));
+    }
+
+    /**
+     * Hirschberg yields the same minimal LCS result as the plain table but keeps only two rolling
+     * rows, so its peak allocation is a fraction of the O(N·M) table on a large input.
+     */
+    public function hirschbergUsesFarLessMemoryThanTheLcsTable(): void
+    {
+        $expected = \implode("\n", \array_map(static fn(int $i): string => "row {$i}", \range(1, 400)));
+        $actual = \str_replace('row 200', 'row CHANGED', $expected);
+
+        $tableBytes = self::peakBytes(static fn(): array => (new LcsDiffer())->diff($expected, $actual));
+        $rowBytes = self::peakBytes(static fn(): array => (new HirschbergDiffer())->diff($expected, $actual));
+
+        // The real gap is an order of magnitude; 4x keeps the assertion robust across PHP builds.
+        Assert::true($rowBytes * 4 < $tableBytes);
+    }
+
+    public static function strategies(): iterable
+    {
+        yield 'hirschberg' => [new HirschbergDiffer()];
+        yield 'prefix-suffix' => [new PrefixSuffixDiffer()];
+        yield 'patience' => [new PatienceDiffer()];
+    }
+
+    public static function minimalStrategies(): iterable
+    {
+        yield 'hirschberg' => [new HirschbergDiffer()];
+        yield 'prefix-suffix' => [new PrefixSuffixDiffer()];
+    }
+
+    public static function scenarios(): iterable
+    {
+        yield 'identical' => ["a\nb\nc", "a\nb\nc"];
+        yield 'single change' => ["a\nb\nc", "a\nX\nc"];
+        yield 'append' => ["a\nb", "a\nb\nc"];
+        yield 'prepend' => ["b\nc", "a\nb\nc"];
+        yield 'remove middle' => ["a\nb\nc", "a\nc"];
+        yield 'all different' => ["a\nb", "x\ny"];
+        yield 'empty expected' => ['', "a\nb"];
+        yield 'empty actual' => ["a\nb", ''];
+        yield 'both empty' => ['', ''];
+        yield 'duplicate lines' => ["a\na\na", "a\na"];
+        yield 'reorder' => ["a\nb\nc", "c\nb\na"];
+        yield 'repeated delimiters' => ["{\na\n}\n{\nb\n}", "{\nb\n}\n{\na\n}"];
+    }
+
+    /**
+     * Reconstruct one side by dropping the edits that belong to the other: excluding {@see DiffOp::Add}
+     * leaves the expected side, excluding {@see DiffOp::Remove} the actual.
+     *
+     * @param list<DiffLine> $diff
+     */
+    private static function reconstruct(array $diff, DiffOp $exclude): string
+    {
+        $lines = [];
+        foreach ($diff as $line) {
+            $line->op === $exclude or $lines[] = $line->line;
+        }
+
+        return \implode("\n", $lines);
+    }
+
+    /**
+     * @param list<DiffLine> $diff
+     * @return int<0, max>
+     */
+    private static function editCount(array $diff): int
+    {
+        $count = 0;
+        foreach ($diff as $line) {
+            $line->op === DiffOp::Context or $count++;
+        }
+
+        return $count;
+    }
+
+    /**
+     * @param list<DiffLine> $diff
+     * @return int<0, max>
+     */
+    private static function countOp(array $diff, DiffOp $op, string $line): int
+    {
+        $count = 0;
+        foreach ($diff as $entry) {
+            ($entry->op === $op && $entry->line === $line) and $count++;
+        }
+
+        return $count;
+    }
+
+    /**
+     * Peak bytes allocated while running $fn, measured from a freshly reset peak.
+     *
+     * @param callable(): list<DiffLine> $fn
+     * @return int<0, max>
+     */
+    private static function peakBytes(callable $fn): int
+    {
+        \gc_collect_cycles();
+        \memory_reset_peak_usage();
+        $baseline = \memory_get_peak_usage();
+        $fn();
+
+        return \max(0, \memory_get_peak_usage() - $baseline);
+    }
+}

--- a/tests/Output/Unit/Rendering/Diff/DifferStrategiesTest.php
+++ b/tests/Output/Unit/Rendering/Diff/DifferStrategiesTest.php
@@ -18,11 +18,16 @@ use Testo\Output\Rendering\Diff\PatienceDiffer;
 use Testo\Output\Rendering\Diff\PrefixSuffixDiffer;
 use Testo\Output\Rendering\Diff\RatcliffObershelpDiffer;
 use Testo\Test;
+use Tests\Output\Stub\Diff\RecordingDiffer;
 
 /**
- * Behavioural tests for the alternative {@see Differ} strategies. The minimal-edit guarantees and
- * the core invariants for {@see MyersDiffer}/{@see LcsDiffer} live in {@see DifferTest}; this file
- * covers the prefix/suffix decorator, patience and Hirschberg variants.
+ * Behavioural tests for the alternative {@see Differ} strategies — the prefix/suffix decorator,
+ * patience, Hirschberg and Ratcliff/Obershelp. The minimal-edit guarantees and the core invariants
+ * for {@see MyersDiffer}/{@see LcsDiffer} live in {@see DifferTest}.
+ *
+ * The reconstruction invariant alone is deliberately weak (a "delete everything, add everything"
+ * differ would satisfy it), so the quality-oriented strategies are additionally pinned with exact
+ * alignment snapshots and delegation spies, and the minimal ones with an edit-count parity check.
  */
 #[Test]
 #[Covers(PrefixSuffixDiffer::class)]
@@ -32,8 +37,8 @@ use Testo\Test;
 final class DifferStrategiesTest
 {
     /**
-     * Every strategy — including patience, which does not minimise edits — must still emit a valid
-     * edit script: dropping the other side's edits reconstructs each side verbatim.
+     * Every strategy — including patience and Ratcliff/Obershelp, which do not minimise edits — must
+     * still emit a valid edit script: dropping the other side's edits reconstructs each side verbatim.
      */
     #[DataCross(
         new DataProvider('strategies'),
@@ -48,9 +53,29 @@ final class DifferStrategiesTest
     }
 
     /**
+     * Reconstruction must also hold on a large input that exercises the recursive/stack-based paths
+     * (Hirschberg's divide-and-conquer, patience recursion, the Ratcliff/Obershelp stack) — not just
+     * the tiny hand-written scenarios above.
+     */
+    #[DataProvider('strategies')]
+    public function reconstructsLargeInput(Differ $differ): void
+    {
+        $base = \array_map(static fn(int $i): string => "line {$i}", \range(1, 300));
+        $expected = \implode("\n", $base);
+        $base[150] = 'line CHANGED';
+        \array_splice($base, 80, 0, ['inserted']);
+        $actual = \implode("\n", $base);
+
+        $diff = $differ->diff($expected, $actual);
+
+        Assert::same(self::reconstruct($diff, DiffOp::Add), $expected);
+        Assert::same(self::reconstruct($diff, DiffOp::Remove), $actual);
+    }
+
+    /**
      * The minimal strategies (memory-efficient LCS, and Myers behind the prefix/suffix decorator)
-     * compute a shortest edit script, so their edit count must equal plain Myers'. Patience is
-     * intentionally excluded — it optimises alignment, not edit count.
+     * compute a shortest edit script, so their edit count must equal plain Myers'. Patience and
+     * Ratcliff/Obershelp are intentionally excluded — they optimise alignment, not edit count.
      */
     #[DataCross(
         new DataProvider('minimalStrategies'),
@@ -64,31 +89,95 @@ final class DifferStrategiesTest
     }
 
     /**
-     * Patience anchors on lines that are unique on both sides. Here "x" repeats and cannot anchor,
-     * but "ANCHOR" is unique and pins the alignment, so it survives as a single context line instead
-     * of being torn into a remove/add pair the way a sliding minimal-edit diff might.
+     * Patience anchors on lines unique to both sides. "x" repeats and cannot anchor, but "ANCHOR" is
+     * unique and pins the alignment: it stays a single context line while the duplicated "x"s around
+     * it are paired as additions. The exact script is asserted so a regression in alignment is caught
+     * (reconstruction alone would not notice).
      */
-    public function patienceKeepsAUniqueCommonLineAsContext(): void
+    public function patienceProducesAnchoredAlignment(): void
     {
         $diff = (new PatienceDiffer())->diff("x\nANCHOR\nx", "x\nx\nANCHOR\nx\nx");
 
-        Assert::same(self::countOp($diff, DiffOp::Context, 'ANCHOR'), 1);
-        Assert::same(self::countOp($diff, DiffOp::Remove, 'ANCHOR'), 0);
+        Assert::same(self::render($diff), ['  x', '+ x', '  ANCHOR', '+ x', '  x']);
     }
 
     /**
-     * With no line unique to both sides patience has nothing to anchor on and defers to its fallback
-     * differ; trimming the shared prefix/suffix first leaves the edit count identical to plain Myers.
+     * Ratcliff/Obershelp anchors on the single longest matching block. On a reversal it keeps only
+     * the longest run ("a" here) as context and rewrites the rest, which is its defining behaviour.
      */
-    public function patienceFallsBackToMyersEditCountWithoutUniqueLines(): void
+    public function ratcliffAnchorsOnLongestBlock(): void
     {
-        $expected = "a\na\nb";
-        $actual = "a\nb\nb";
+        $diff = (new RatcliffObershelpDiffer())->diff("a\nb\nc", "c\nb\na");
 
-        $patience = (new PatienceDiffer(new MyersDiffer()))->diff($expected, $actual);
-        $myers = (new MyersDiffer())->diff($expected, $actual);
+        Assert::same(self::render($diff), ['+ c', '+ b', '  a', '- b', '- c']);
+    }
 
-        Assert::same(self::editCount($patience), self::editCount($myers));
+    /**
+     * With no line unique to both sides patience has nothing to anchor on and must defer to its
+     * fallback differ — verified directly via a recording spy, not merely inferred from the result.
+     */
+    public function patienceDelegatesToFallbackWithoutAnchor(): void
+    {
+        $spy = new RecordingDiffer(new MyersDiffer());
+
+        $diff = (new PatienceDiffer($spy))->diff("a\na\nb", "a\nb\nb");
+
+        Assert::count($spy->calls, 1);
+        Assert::same(self::reconstruct($diff, DiffOp::Add), "a\na\nb");
+        Assert::same(self::reconstruct($diff, DiffOp::Remove), "a\nb\nb");
+    }
+
+    /**
+     * The reverse: when every line already matches, the shared prefix/suffix trimming consumes the
+     * whole input and the fallback is never touched.
+     */
+    public function patienceSkipsFallbackForIdenticalInput(): void
+    {
+        $spy = new RecordingDiffer(new MyersDiffer());
+
+        (new PatienceDiffer($spy))->diff("a\nb\nc", "a\nb\nc");
+
+        Assert::count($spy->calls, 0);
+    }
+
+    /**
+     * The decorator must trim the shared head/tail itself and hand only the differing middle to its
+     * inner differ — confirmed by inspecting exactly what the spy received.
+     */
+    public function prefixSuffixPassesOnlyTheMiddleToItsInner(): void
+    {
+        $spy = new RecordingDiffer(new MyersDiffer());
+
+        $diff = (new PrefixSuffixDiffer($spy))->diff("head\nA\ntail", "head\nB\ntail");
+
+        Assert::count($spy->calls, 1);
+        Assert::same($spy->calls[0], ['A', 'B']);
+        Assert::same(self::reconstruct($diff, DiffOp::Add), "head\nA\ntail");
+        Assert::same(self::reconstruct($diff, DiffOp::Remove), "head\nB\ntail");
+    }
+
+    /**
+     * On large inputs Ratcliff/Obershelp's autojunk heuristic drops over-popular lines from the
+     * anchor index. With the heuristic on or off the result must stay a valid edit script — here a
+     * delimiter line repeats far above the threshold across 260 lines.
+     */
+    public function ratcliffStaysCorrectWithPopularLines(): void
+    {
+        $lines = [];
+        for ($i = 0; $i < 130; $i++) {
+            $lines[] = "item {$i}";
+            $lines[] = '---';
+        }
+        $expected = \implode("\n", $lines);
+        $lines[60] = 'item CHANGED';
+        $actual = \implode("\n", $lines);
+
+        foreach ([true, false] as $autoJunk) {
+            $diff = (new RatcliffObershelpDiffer($autoJunk))->diff($expected, $actual);
+
+            Assert::same(self::reconstruct($diff, DiffOp::Add), $expected);
+            Assert::same(self::reconstruct($diff, DiffOp::Remove), $actual);
+        }
     }
 
     /**
@@ -135,6 +224,7 @@ final class DifferStrategiesTest
         yield 'duplicate lines' => ["a\na\na", "a\na"];
         yield 'reorder' => ["a\nb\nc", "c\nb\na"];
         yield 'repeated delimiters' => ["{\na\n}\n{\nb\n}", "{\nb\n}\n{\na\n}"];
+        yield 'match only in left a-half boundary' => ["x\nz", "x"];
     }
 
     /**
@@ -154,6 +244,25 @@ final class DifferStrategiesTest
     }
 
     /**
+     * Render a diff as one prefixed string per line (`  ` context, `- ` remove, `+ ` add) for exact,
+     * readable alignment snapshots.
+     *
+     * @param list<DiffLine> $diff
+     * @return list<string>
+     */
+    private static function render(array $diff): array
+    {
+        return \array_map(
+            static fn(DiffLine $line): string => match ($line->op) {
+                DiffOp::Context => "  {$line->line}",
+                DiffOp::Remove => "- {$line->line}",
+                DiffOp::Add => "+ {$line->line}",
+            },
+            $diff,
+        );
+    }
+
+    /**
      * @param list<DiffLine> $diff
      * @return int<0, max>
      */
@@ -162,20 +271,6 @@ final class DifferStrategiesTest
         $count = 0;
         foreach ($diff as $line) {
             $line->op === DiffOp::Context or $count++;
-        }
-
-        return $count;
-    }
-
-    /**
-     * @param list<DiffLine> $diff
-     * @return int<0, max>
-     */
-    private static function countOp(array $diff, DiffOp $op, string $line): int
-    {
-        $count = 0;
-        foreach ($diff as $entry) {
-            ($entry->op === $op && $entry->line === $line) and $count++;
         }
 
         return $count;

--- a/tests/Output/Unit/Rendering/Diff/DifferStrategiesTest.php
+++ b/tests/Output/Unit/Rendering/Diff/DifferStrategiesTest.php
@@ -16,6 +16,7 @@ use Testo\Output\Rendering\Diff\LcsDiffer;
 use Testo\Output\Rendering\Diff\MyersDiffer;
 use Testo\Output\Rendering\Diff\PatienceDiffer;
 use Testo\Output\Rendering\Diff\PrefixSuffixDiffer;
+use Testo\Output\Rendering\Diff\RatcliffObershelpDiffer;
 use Testo\Test;
 
 /**
@@ -27,6 +28,7 @@ use Testo\Test;
 #[Covers(PrefixSuffixDiffer::class)]
 #[Covers(PatienceDiffer::class)]
 #[Covers(HirschbergDiffer::class)]
+#[Covers(RatcliffObershelpDiffer::class)]
 final class DifferStrategiesTest
 {
     /**
@@ -110,6 +112,7 @@ final class DifferStrategiesTest
         yield 'hirschberg' => [new HirschbergDiffer()];
         yield 'prefix-suffix' => [new PrefixSuffixDiffer()];
         yield 'patience' => [new PatienceDiffer()];
+        yield 'ratcliff-obershelp' => [new RatcliffObershelpDiffer()];
     }
 
     public static function minimalStrategies(): iterable

--- a/tests/Output/Unit/Rendering/Diff/DifferStrategiesTest.php
+++ b/tests/Output/Unit/Rendering/Diff/DifferStrategiesTest.php
@@ -157,6 +157,62 @@ final class DifferStrategiesTest
     }
 
     /**
+     * When the shared suffix runs all the way back to a-index 0 (here the whole of `a`, "x", is the
+     * shared tail of "y\nx"), the trimmed middle is one-sided — `midA = []`, `midB = ["y"]` — and the
+     * decorator emits it directly without ever consulting its inner differ. A guard that refuses to
+     * include index 0 in the suffix would leave a two-sided middle and delegate, so the spy must record
+     * zero calls.
+     */
+    public function prefixSuffixIncludesAIndexZeroInSharedSuffix(): void
+    {
+        $spy = new RecordingDiffer(new MyersDiffer());
+
+        $diff = (new PrefixSuffixDiffer($spy))->diff("x", "y\nx");
+
+        Assert::count($spy->calls, 0);
+        Assert::same(self::render($diff), ['+ y', '  x']);
+    }
+
+    /**
+     * Mirror of the a-index case for the b side: when the shared suffix runs all the way back to
+     * b-index 0 (here the whole of `b`, "x", is the shared tail of "y\nx"), the trimmed middle is
+     * one-sided — `midA = ["y"]`, `midB = []` — and the decorator emits it directly without ever
+     * consulting its inner differ. A guard that refuses to include b-index 0 in the suffix would
+     * leave a two-sided middle and delegate, so the spy must record zero calls.
+     */
+    public function prefixSuffixIncludesBIndexZeroInSharedSuffix(): void
+    {
+        $spy = new RecordingDiffer(new MyersDiffer());
+
+        $diff = (new PrefixSuffixDiffer($spy))->diff("y\nx", "x");
+
+        Assert::count($spy->calls, 0);
+        Assert::same(self::render($diff), ['- y', '  x']);
+    }
+
+    /**
+     * On fully identical input the prefix scan must stop exactly at the shared length and never probe
+     * one index past the end of either side. A bound that reads `$a[$max]`/`$b[$max]` would raise an
+     * "Undefined array key" warning (the slices happen to collapse to the same context lines, so only
+     * the warning betrays it). Promote any warning to an exception so the off-by-one is caught, and pin
+     * the exact emitted script: three context lines, nothing else.
+     */
+    public function prefixSuffixDoesNotReadPastTheSharedLength(): void
+    {
+        \set_error_handler(static function (int $severity, string $message): bool {
+            throw new \RuntimeException("Unexpected PHP warning: {$message}");
+        });
+
+        try {
+            $diff = (new PrefixSuffixDiffer())->diff("a\nb\nc", "a\nb\nc");
+        } finally {
+            \restore_error_handler();
+        }
+
+        Assert::same(self::render($diff), ['  a', '  b', '  c']);
+    }
+
+    /**
      * On large inputs Ratcliff/Obershelp's autojunk heuristic drops over-popular lines from the
      * anchor index. With the heuristic on or off the result must stay a valid edit script — here a
      * delimiter line repeats far above the threshold across 260 lines.

--- a/tests/Output/Unit/Rendering/Diff/DifferTest.php
+++ b/tests/Output/Unit/Rendering/Diff/DifferTest.php
@@ -98,6 +98,68 @@ final class DifferTest
         }
     }
 
+    /**
+     * Pins the LCS DP table's last column (j == n). When the last actual line participates in a
+     * non-trivial alignment, the rightmost column must be fully computed; a loop that stops one
+     * column short leaves it at 0 and corrupts the backtrack into a non-minimal script. For this
+     * input the minimal edit count is 2 (Myers' answer): LCS must match it, not over-report.
+     */
+    public function lcsFillsLastTableColumn(): void
+    {
+        $expected = "b\nb\na\nc";
+        $actual = "b\nc\nb\na";
+
+        $lcs = (new LcsDiffer())->diff($expected, $actual);
+        $myers = (new MyersDiffer())->diff($expected, $actual);
+
+        Assert::same(self::editCount($lcs), 2);
+        Assert::same(self::editCount($lcs), self::editCount($myers));
+    }
+
+    /**
+     * Pins the LCS backtrack's termination on the actual side. When `actual` is consumed first — here
+     * the single line "b" matches the middle of "a\nb\nc" — the diagonal walk reaches `$j == 0` while
+     * `$i > 0` (two expected lines still to remove). The loop must stop the moment `$j` hits 0 and let
+     * the trailing `while ($i > 0)` emit the leftover removals; a guard that keeps looping at `$j == 0`
+     * reads `$b[$j - 1]` == `$b[-1]` (undefined). The two paths happen to emit the same removals, so a
+     * value assertion alone cannot tell them apart — only the off-by-one's "Undefined array key -1"
+     * warning betrays it. Promote any warning to an exception to catch the over-run, and still pin the
+     * exact script as a regression guard.
+     */
+    public function lcsStopsBacktrackWhenActualIsExhausted(): void
+    {
+        \set_error_handler(static function (int $severity, string $message): bool {
+            throw new \RuntimeException("Unexpected PHP warning: {$message}");
+        });
+
+        try {
+            $diff = (new LcsDiffer())->diff("a\nb\nc", "b");
+        } finally {
+            \restore_error_handler();
+        }
+
+        Assert::same(self::render($diff), ['- a', '  b', '- c']);
+        Assert::same(self::editCount($diff), 2);
+        Assert::same(self::reconstruct($diff, DiffOp::Add), "a\nb\nc");
+        Assert::same(self::reconstruct($diff, DiffOp::Remove), 'b');
+    }
+
+    /**
+     * Pins the LCS backtrack tie-break. With a pure tie — `expected = "a"`, `actual = "b"`, where
+     * neither line matches and both DP neighbours are equal (`$lcs[$i-1][$j] == $lcs[$i][$j-1]`) — the
+     * choice of `>=` vs `>` flips the emitted order. The original `>=` takes the Remove branch (decrement
+     * `$i`), so the trailing `while ($j > 0)` unshifts the Add ahead of it, yielding `[+ b, - a]`; a `>`
+     * mutant skips to the `else` Add branch, leaving the Remove for the trailing `while ($i > 0)` to
+     * unshift first, yielding `[- a, + b]`. Both reconstruct correctly and share the same edit count, so
+     * only the exact ordered script distinguishes them.
+     */
+    public function lcsTieBreakOrdersAddBeforeRemove(): void
+    {
+        $diff = (new LcsDiffer())->diff('a', 'b');
+
+        Assert::same(self::render($diff), ['+ b', '- a']);
+    }
+
     public static function differs(): iterable
     {
         yield 'myers' => [new MyersDiffer()];
@@ -133,6 +195,25 @@ final class DifferTest
         }
 
         return \implode("\n", $lines);
+    }
+
+    /**
+     * Render a diff as one prefixed string per line (`  ` context, `- ` remove, `+ ` add) for exact,
+     * readable alignment snapshots.
+     *
+     * @param list<DiffLine> $diff
+     * @return list<string>
+     */
+    private static function render(array $diff): array
+    {
+        return \array_map(
+            static fn(DiffLine $line): string => match ($line->op) {
+                DiffOp::Context => "  {$line->line}",
+                DiffOp::Remove => "- {$line->line}",
+                DiffOp::Add => "+ {$line->line}",
+            },
+            $diff,
+        );
     }
 
     /**

--- a/tests/Output/Unit/Rendering/Diff/DifferTest.php
+++ b/tests/Output/Unit/Rendering/Diff/DifferTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Unit\Rendering\Diff;
+
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Data\DataCross;
+use Testo\Data\DataProvider;
+use Testo\Output\Rendering\Diff\DiffLine;
+use Testo\Output\Rendering\Diff\Differ;
+use Testo\Output\Rendering\Diff\DiffOp;
+use Testo\Output\Rendering\Diff\LcsDiffer;
+use Testo\Output\Rendering\Diff\MyersDiffer;
+use Testo\Test;
+
+#[Test]
+#[Covers(MyersDiffer::class)]
+#[Covers(LcsDiffer::class)]
+#[Covers(DiffLine::class)]
+final class DifferTest
+{
+    /**
+     * The core invariant every differ must hold: keeping only the lines that exist on a side (context
+     * plus that side's edits) must reconstruct that side verbatim. Checked for both implementations.
+     */
+    #[DataCross(
+        new DataProvider('differs'),
+        new DataProvider('scenarios'),
+    )]
+    public function reconstructsBothSides(Differ $differ, string $expected, string $actual): void
+    {
+        $diff = $differ->diff($expected, $actual);
+
+        Assert::same(self::reconstruct($diff, DiffOp::Add), $expected);
+        Assert::same(self::reconstruct($diff, DiffOp::Remove), $actual);
+    }
+
+    /**
+     * Both algorithms compute a minimal edit script, so they must report the same number of edits
+     * (the order or tie-breaking may differ, the count may not).
+     */
+    #[DataProvider('scenarios')]
+    public function myersAndLcsAgreeOnEditCount(string $expected, string $actual): void
+    {
+        $myers = (new MyersDiffer())->diff($expected, $actual);
+        $lcs = (new LcsDiffer())->diff($expected, $actual);
+
+        Assert::same(self::editCount($myers), self::editCount($lcs));
+    }
+
+    public function identicalInputProducesOnlyContext(): void
+    {
+        $diff = (new MyersDiffer())->diff("a\nb\nc", "a\nb\nc");
+
+        Assert::count($diff, 3);
+        foreach ($diff as $line) {
+            Assert::same($line->op, DiffOp::Context);
+        }
+    }
+
+    /**
+     * The whole point of switching to Myers: a large, nearly identical input that the O(N·M) LCS
+     * table would choke on must diff in O((N+M)·D) — here D is 1, so the script is a single
+     * remove/add pair and the rest stays context.
+     */
+    public function myersScalesToLargeNearlyIdenticalInput(): void
+    {
+        $expected = \implode("\n", \array_map(static fn(int $i): string => "line {$i}", \range(1, 5000)));
+        $actual = \str_replace('line 2500', 'line CHANGED', $expected);
+
+        $diff = (new MyersDiffer())->diff($expected, $actual);
+
+        Assert::same(self::editCount($diff), 2);
+        Assert::same(self::reconstruct($diff, DiffOp::Add), $expected);
+        Assert::same(self::reconstruct($diff, DiffOp::Remove), $actual);
+    }
+
+    public static function differs(): iterable
+    {
+        yield 'myers' => [new MyersDiffer()];
+        yield 'lcs' => [new LcsDiffer()];
+    }
+
+    public static function scenarios(): iterable
+    {
+        yield 'identical' => ["a\nb\nc", "a\nb\nc"];
+        yield 'single change' => ["a\nb\nc", "a\nX\nc"];
+        yield 'append' => ["a\nb", "a\nb\nc"];
+        yield 'prepend' => ["b\nc", "a\nb\nc"];
+        yield 'remove middle' => ["a\nb\nc", "a\nc"];
+        yield 'all different' => ["a\nb", "x\ny"];
+        yield 'empty expected' => ['', "a\nb"];
+        yield 'empty actual' => ["a\nb", ''];
+        yield 'both empty' => ['', ''];
+        yield 'duplicate lines' => ["a\na\na", "a\na"];
+        yield 'reorder' => ["a\nb\nc", "c\nb\na"];
+    }
+
+    /**
+     * Reconstruct one side of the comparison by dropping the edits that belong to the other side.
+     * Excluding {@see DiffOp::Add} leaves the expected side; excluding {@see DiffOp::Remove} the actual.
+     *
+     * @param list<DiffLine> $diff
+     */
+    private static function reconstruct(array $diff, DiffOp $exclude): string
+    {
+        $lines = [];
+        foreach ($diff as $line) {
+            $line->op === $exclude or $lines[] = $line->line;
+        }
+
+        return \implode("\n", $lines);
+    }
+
+    /**
+     * @param list<DiffLine> $diff
+     * @return int<0, max>
+     */
+    private static function editCount(array $diff): int
+    {
+        $count = 0;
+        foreach ($diff as $line) {
+            $line->op === DiffOp::Context or $count++;
+        }
+
+        return $count;
+    }
+}

--- a/tests/Output/Unit/Rendering/Diff/DifferTest.php
+++ b/tests/Output/Unit/Rendering/Diff/DifferTest.php
@@ -1,5 +1,6 @@
 <?php
 
+
 declare(strict_types=1);
 
 namespace Tests\Output\Unit\Rendering\Diff;
@@ -75,6 +76,26 @@ final class DifferTest
         Assert::same(self::editCount($diff), 2);
         Assert::same(self::reconstruct($diff, DiffOp::Add), $expected);
         Assert::same(self::reconstruct($diff, DiffOp::Remove), $actual);
+    }
+
+    /**
+     * LcsDiffer must not access undefined array keys during its DP table traversal.
+     * The base-row index must be 0, not 1; accessing key 0 on a table that starts at 1
+     * would emit PHP warnings for "Undefined array key 0" and "Trying to access array
+     * offset on null", which this test surfaces by promoting warnings to exceptions.
+     */
+    public function lcsEmitsNoWarnings(): void
+    {
+        $previous = \set_error_handler(
+            static fn(int $errno, string $errstr): never => throw new \ErrorException($errstr, $errno),
+            \E_WARNING | \E_NOTICE,
+        );
+        try {
+            $diff = (new LcsDiffer())->diff("a\nb\nc", "a\nX\nc");
+            Assert::count($diff, 4);
+        } finally {
+            \set_error_handler($previous);
+        }
     }
 
     public static function differs(): iterable

--- a/tests/Output/Unit/Rendering/StackTraceTest.php
+++ b/tests/Output/Unit/Rendering/StackTraceTest.php
@@ -133,6 +133,30 @@ final class StackTraceTest
     }
 
     /**
+     * The depth-limited scan must be strictly below {@see StackTrace::SEARCH_DEPTH}: an
+     * AssertMethod sitting exactly at the limit index (frame 3 of a 5-frame trace, limit
+     * being `min(5, 3) = 3`) is one frame too deep and must NOT be reached, so the trace
+     * is returned untouched. Reaching it would wrongly trim the trace down to that frame.
+     */
+    public function doesNotScanFrameAtDepthLimit(): void
+    {
+        // Arrange: frames 0-2 carry no AssertMethod; the AssertMethod sits at index 3 == limit
+        $trace = [
+            ['class' => MiddlewareStub::class, 'function' => 'run'],
+            ['class' => MiddlewareStub::class, 'function' => 'run'],
+            ['class' => MiddlewareStub::class, 'function' => 'run'],
+            ['class' => AssertMethodStub::class, 'function' => 'run'],
+            ['class' => MiddlewareStub::class, 'function' => 'run'],
+        ];
+
+        // Act
+        $result = StackTrace::cutStackTrace($trace);
+
+        // Assert: the AssertMethod at the limit index is out of scan range, nothing is cut
+        Assert::same($result, $trace);
+    }
+
+    /**
      * The boundary represents the test function frame: anything below it is application
      * code, anything above is runner internals. AssertMethod is only meaningful below
      * the boundary, so reaching the boundary must abort the search.
@@ -202,6 +226,91 @@ final class StackTraceTest
         // Assert: AssertMethod found despite being beyond SEARCH_DEPTH
         Assert::same($result[0]['class'], AssertMethodStub::class);
         Assert::same($result[0]['function'], 'run');
+    }
+
+    /**
+     * A frame with a null class or function (e.g. a top-level closure) must be skipped,
+     * not treated as a stop point. When such a frame sits before an AssertMethod within
+     * the scan range, the scan must continue past it and still find the AssertMethod to
+     * trim. Aborting the scan at the null frame would leave the trace untouched.
+     */
+    public function skipsNullFrameBeforeAssertMethod(): void
+    {
+        $trace = [
+            ['function' => 'someClosure'],
+            ['class' => AssertMethodStub::class, 'function' => 'run'],
+            ['class' => MiddlewareStub::class, 'function' => 'run'],
+        ];
+
+        $result = StackTrace::cutStackTrace($trace);
+
+        Assert::true(\count($result) < \count($trace));
+        Assert::same($result[0]['class'], AssertMethodStub::class);
+        Assert::same($result[0]['function'], 'run');
+    }
+
+    /**
+     * The per-frame lookup must consult the resolved cache *first* and only fall back to
+     * reflection on a miss (`cache[key] ?? resolve(...)`). Swapping the operands would
+     * always re-run reflection and ignore the cached verdict. Seeding the cache with a
+     * value that disagrees with reflection isolates the order: `MiddlewareStub::run`
+     * carries no AssertMethod (reflection -> false), but a cached `true` must win and
+     * trim the trace at that frame.
+     */
+    public function cacheVerdictTakesPriorityOverReflection(): void
+    {
+        $key = MiddlewareStub::class . '::run';
+        $cache = (new \ReflectionClass(StackTrace::class))->getProperty('cutTraceCache');
+        $original = $cache->getValue();
+        $cache->setValue(null, [$key => true]);
+
+        try {
+            $trace = [
+                ['class' => ThrowingStub::class, 'function' => 'fail'],
+                ['class' => MiddlewareStub::class, 'function' => 'run'],
+                ['class' => MiddlewareStub::class, 'function' => 'run'],
+            ];
+
+            $result = StackTrace::cutStackTrace($trace);
+
+            // Cached `true` wins over reflection's `false`: the frame is treated as an
+            // AssertMethod and everything below it (ThrowingStub::fail) is trimmed.
+            Assert::true(\count($result) < \count($trace));
+            Assert::same($result[0]['class'], MiddlewareStub::class);
+            Assert::same($result[0]['function'], 'run');
+        } finally {
+            $cache->setValue(null, $original);
+        }
+    }
+
+    /**
+     * When an AssertMethod cut point is found, every preceding frame that resolved
+     * `false` is written into the static cache as `false`, so subsequent scans skip the
+     * reflection lookup for them. A non-AssertMethod frame sitting *before* the cut point
+     * must therefore appear in the cache as `false` after the call.
+     */
+    public function cachesPrecedingUncachedFramesAsFalse(): void
+    {
+        $key = MiddlewareStub::class . '::run';
+        $cache = (new \ReflectionClass(StackTrace::class))->getProperty('cutTraceCache');
+        $original = $cache->getValue();
+        $cache->setValue(null, []);
+
+        try {
+            $trace = [
+                ['class' => MiddlewareStub::class, 'function' => 'run'],
+                ['class' => AssertMethodStub::class, 'function' => 'run'],
+            ];
+
+            StackTrace::cutStackTrace($trace);
+
+            // The MiddlewareStub frame preceding the AssertMethod cut point is cached false.
+            $stored = $cache->getValue();
+            Assert::true(\array_key_exists($key, $stored));
+            Assert::false($stored[$key]);
+        } finally {
+            $cache->setValue(null, $original);
+        }
     }
 
     /**

--- a/tests/Output/suites.php
+++ b/tests/Output/suites.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 use Testo\Application\Config\FinderConfig;
+use Testo\Application\Config\Plugin\SuitePlugins;
 use Testo\Application\Config\SuiteConfig;
+use Testo\Bench\BenchmarkPlugin;
 use Testo\Output\Rendering\StackTrace;
 
 return [
@@ -19,6 +21,15 @@ return [
         name: 'Output/Unit',
         location: new FinderConfig(
             include: [__DIR__ . '/Unit'],
+        ),
+    ),
+    new SuiteConfig(
+        name: 'Output/Bench',
+        location: new FinderConfig(
+            include: [__DIR__ . '/Bench'],
+        ),
+        plugins: SuitePlugins::only(
+            new BenchmarkPlugin(),
         ),
     ),
 ];


### PR DESCRIPTION
## What was changed

Extracted the terminal comparison-block diff out of `Formatter` into a dedicated `Differ` abstraction under `core/Output/Rendering/Diff/`, made the production default a Myers greedy **O(ND)** implementation, and added several alternative strategies for comparison.

**Strategies (all `@internal`, all implement `Differ`):**
- `MyersDiffer` — production default: O((N+M)·D) time, linear memory, no `array_unshift` backtrack cascade
- `LcsDiffer` — the original O(N·M) LCS table, retained for reference and benchmarking
- `PrefixSuffixDiffer` — decorator that trims the shared head/tail (context) and only diffs the changed middle with the wrapped differ
- `PatienceDiffer` — Bram Cohen's patience diff: anchors on unique-common lines via LIS, falls back to Myers; optimises for *readable* alignment, not minimal edits
- `HirschbergDiffer` — linear-space LCS (memory-efficient counterpart to the table): same minimal result, O(M) working rows

`Formatter::comparisonBlock` consumes the abstraction; the private `computeLineDiff` is gone.

**Tests:** `DifferTest` (Myers/LCS invariants + parity) and `DifferStrategiesTest` (reconstruction invariant for all strategies, edit-count parity with Myers for the minimal ones, patience anchor behaviour, Hirschberg-vs-LCS peak-memory). `DiffBench` compares all five head-to-head.

See commit history for details.

## Why?

The old diff used a full LCS dynamic-programming table — **O(N·M)** time *and* memory — plus an **O(N²)** `array_unshift` backtrack. On large near-identical inputs (e.g. `Assert::same` on big arrays/strings) that meant **seconds and hundreds of MB just to render an already-failed test** — a real OOM footgun in the runner.

Measured (PHP 8.4):

| input | LCS (old) | Myers (new) |
|---|---|---|
| 200 lines, 8 diff | ~2.2 ms | ~64 µs (~34×) |
| 1000 lines, 20 diff | ~218 ms / 22 MB | ~1.6 ms / 8 MB |
| 3000 lines, 30 diff | ~2.0 s / 206 MB | ~13 ms / 16 MB |

Bench across all five strategies (200 lines / 8 spread changes): Myers ~68µs · prefix-suffix ~79µs · patience ~169µs · lcs ~2.2ms · hirschberg ~3.9ms. Hirschberg matches LCS in time but in linear memory; the prefix/suffix decorator wins when changes are localised.

Inspired by sebastianbergmann/diff#138, but kept in-house (no new runtime dependency) per Testo's minimal-core philosophy.

## Checklist

- Closes #<!-- add issue number here -->
- Tested
  - [x] Tested manually
  - [x] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->