### PR TITLE
feat(bridge): add Mockery bridge (testo/bridge-mockery)

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -95,6 +95,12 @@
             "include-component-in-tag": true,
             "changelog-path": "CHANGELOG.md"
         },
+        "bridge/mockery": {
+            "package-name": "testo/bridge-mockery",
+            "component": "bridge-mockery",
+            "include-component-in-tag": true,
+            "changelog-path": "CHANGELOG.md"
+        },
         "bridge/rector": {
             "package-name": "testo/bridge-rector",
             "component": "bridge-rector",

--- a/.github/workflows/split-publish.yml
+++ b/.github/workflows/split-publish.yml
@@ -19,6 +19,7 @@ on:  # yamllint disable-line rule:truthy
       - 'assert-[0-9]*'
       - 'bench-[0-9]*'
       - 'bridge-infection-[0-9]*'
+      - 'bridge-mockery-[0-9]*'
       - 'bridge-rector-[0-9]*'
       - 'bridge-symfony-console-[0-9]*'
       - 'codecov-[0-9]*'

--- a/bridge/mockery/.github/workflows/close-prs.yml
+++ b/bridge/mockery/.github/workflows/close-prs.yml
@@ -1,0 +1,14 @@
+name: Close PRs
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  close:
+    uses: php-testo/gh-actions/.github/workflows/close-foreign-prs.yml@v1
+    with:
+      upstream-url: https://github.com/php-testo/testo

--- a/bridge/mockery/CHANGELOG.md
+++ b/bridge/mockery/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [0.1.0] — unreleased
+
+### Features
+
+* Initial release: automatic `Mockery::close()` teardown via `MockeryPlugin` / `MockeryInterceptor`.

--- a/bridge/mockery/CHANGELOG.md
+++ b/bridge/mockery/CHANGELOG.md
@@ -1,7 +1,1 @@
 # Changelog
-
-## [0.1.0] — unreleased
-
-### Features
-
-* Initial release: automatic `Mockery::close()` teardown via `MockeryPlugin` / `MockeryInterceptor`.

--- a/bridge/mockery/README.md
+++ b/bridge/mockery/README.md
@@ -1,0 +1,51 @@
+<p align="center">
+    <a href="https://github.com/php-testo/testo"><img alt="TESTO"
+         src="https://github.com/php-testo/.github/blob/1.x/resources/logo-full.svg?raw=true"
+         style="width: 2in; display: block"
+    /></a>
+</p>
+
+<p align="center">Mockery bridge</p>
+
+<div align="center">
+
+[![Documentation](https://img.shields.io/badge/Documentation-blue?style=for-the-badge&logo=gitbook&logoColor=white)](https://php-testo.github.io)
+[![Support on Boosty](https://img.shields.io/static/v1?style=for-the-badge&label=&message=Sponsorship&logo=Boosty&logoColor=white&color=%23F15F2C)](https://boosty.to/roxblnfk)
+
+</div>
+
+<br />
+
+> [!IMPORTANT]
+> ## 🪞 This is a read-only mirror.
+>
+> Active development of the Testo project lives in [**php-testo/testo**](https://github.com/php-testo/testo) under `bridge/mockery/`. This repository is **automatically synchronized** from there on every release.
+>
+> File issues and pull requests in the [main monorepo](https://github.com/php-testo/testo/issues), not here.
+
+## About
+
+Automatic [Mockery](https://github.com/mockery/mockery) teardown for Testo. Register `MockeryPlugin` and `\Mockery::close()` is called in a `finally` block after every test, so mock expectations are always verified and the Mockery container is cleared between tests — no per-test teardown boilerplate.
+
+```php
+// testo.php
+use Testo\Application\Config\ApplicationConfig;
+use Testo\Application\Config\SuiteConfig;
+use Testo\Bridge\Mockery\MockeryPlugin;
+
+return new ApplicationConfig(
+    plugins: [new MockeryPlugin()],
+    suites:  [new SuiteConfig(name: 'Unit', location: ['tests/Unit'])],
+);
+```
+
+## Install
+
+```bash
+composer require --dev testo/bridge-mockery
+```
+
+[![PHP](https://img.shields.io/packagist/php-v/testo/bridge-mockery.svg?style=flat-square&logo=php)](https://packagist.org/packages/testo/bridge-mockery)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/testo/bridge-mockery.svg?style=flat-square&logo=packagist)](https://packagist.org/packages/testo/bridge-mockery)
+[![License](https://img.shields.io/packagist/l/testo/bridge-mockery.svg?style=flat-square)](https://github.com/php-testo/testo/blob/1.x/LICENSE.md)
+[![Total Downloads](https://img.shields.io/packagist/dt/testo/bridge-mockery.svg?style=flat-square)](https://packagist.org/packages/testo/bridge-mockery/stats)

--- a/bridge/mockery/composer.json
+++ b/bridge/mockery/composer.json
@@ -26,9 +26,19 @@
         "mockery/mockery": "^1.6",
         "testo/testo": "0.10.33 - 1"
     },
+    "require-dev": {
+        "testo/assert": "^0.1.10",
+        "testo/codecov": "^0.1.11",
+        "testo/test": "^0.1.6"
+    },
     "autoload": {
         "psr-4": {
             "Testo\\Bridge\\Mockery\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\Bridge\\Mockery\\": "tests/"
         }
     },
     "minimum-stability": "dev",

--- a/bridge/mockery/composer.json
+++ b/bridge/mockery/composer.json
@@ -1,0 +1,41 @@
+{
+    "name": "testo/bridge-mockery",
+    "description": "Mockery bridge for the Testo testing framework.",
+    "license": "BSD-3-Clause",
+    "type": "library",
+    "keywords": [
+        "testo",
+        "mockery",
+        "mock",
+        "testing"
+    ],
+    "authors": [
+        {
+            "name": "Aleksei Gagarin (roxblnfk)",
+            "homepage": "https://github.com/roxblnfk"
+        }
+    ],
+    "funding": [
+        {
+            "type": "boosty",
+            "url": "https://boosty.to/roxblnfk"
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "mockery/mockery": "^1.6",
+        "testo/testo": "0.10.33 - 1"
+    },
+    "autoload": {
+        "psr-4": {
+            "Testo\\Bridge\\Mockery\\": "src/"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-1.x": "1.x-dev"
+        }
+    }
+}

--- a/bridge/mockery/src/Internal/MockeryInterceptor.php
+++ b/bridge/mockery/src/Internal/MockeryInterceptor.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Bridge\Mockery\Internal;
+
+use Mockery;
+use Testo\Core\Context\TestInfo;
+use Testo\Core\Context\TestResult;
+use Testo\Core\Value\TestType;
+use Testo\Pipeline\Attribute\InterceptorOptions;
+use Testo\Pipeline\Middleware\TestRunInterceptor;
+
+/**
+ * Calls {@see Mockery::close()} in a `finally` block after every test so that:
+ * - unfulfilled expectations are reported as test failures, and
+ * - the Mockery container is cleared between tests, preventing state leak.
+ *
+ * Runs at {@see PHP_INT_MAX} order, placing it as the innermost interceptor
+ * so the teardown fires as close as possible to the actual test function.
+ *
+ * @internal
+ * @psalm-internal Testo\Bridge\Mockery
+ */
+#[InterceptorOptions(
+    order: PHP_INT_MAX,
+    testType: TestType::Test,
+)]
+final readonly class MockeryInterceptor implements TestRunInterceptor
+{
+    #[\Override]
+    public function runTest(TestInfo $info, callable $next): TestResult
+    {
+        try {
+            return $next($info);
+        } finally {
+            Mockery::close();
+        }
+    }
+}

--- a/bridge/mockery/src/Internal/MockeryInterceptor.php
+++ b/bridge/mockery/src/Internal/MockeryInterceptor.php
@@ -5,25 +5,28 @@ declare(strict_types=1);
 namespace Testo\Bridge\Mockery\Internal;
 
 use Mockery;
+use Testo\Assert\Internal\StaticState;
+use Testo\Assert\State\Expectation\ExpectationFailed;
+use Testo\Assert\State\Expectation\ExpectationFulfilled;
 use Testo\Core\Context\TestInfo;
 use Testo\Core\Context\TestResult;
+use Testo\Core\Value\Status;
 use Testo\Core\Value\TestType;
 use Testo\Pipeline\Attribute\InterceptorOptions;
 use Testo\Pipeline\Middleware\TestRunInterceptor;
 
 /**
- * Calls {@see Mockery::close()} in a `finally` block after every test so that:
- * - unfulfilled expectations are reported as test failures, and
- * - the Mockery container is cleared between tests, preventing state leak.
+ * Calls {@see Mockery::close()} in a `finally` block after every test: unfulfilled expectations
+ * fail the test and the container is cleared between tests. Verified expectations are also reported
+ * to the Assert plugin as assertions, mirroring PHPUnit's `MockeryPHPUnitIntegration`.
  *
- * Runs at {@see PHP_INT_MAX} order, placing it as the innermost interceptor
- * so the teardown fires as close as possible to the actual test function.
+ * Runs innermost so the teardown fires as close as possible to the test function.
  *
  * @internal
  * @psalm-internal Testo\Bridge\Mockery
  */
 #[InterceptorOptions(
-    order: PHP_INT_MAX,
+    order: InterceptorOptions::ORDER_CLOSE_TO_TEST,
     testType: TestType::Test,
 )]
 final readonly class MockeryInterceptor implements TestRunInterceptor
@@ -31,10 +34,108 @@ final readonly class MockeryInterceptor implements TestRunInterceptor
     #[\Override]
     public function runTest(TestInfo $info, callable $next): TestResult
     {
+        $result = null;
         try {
-            return $next($info);
+            $result = $this->run($info, $next);
         } finally {
-            Mockery::close();
+            # close() clears the container, so read the count first.
+            $verified = \Mockery::getContainer()->mockery_getExpectationCount();
+            try {
+                \Mockery::close();
+                $verified > 0 and self::reportVerifiedExpectations($verified);
+            } catch (\Throwable $e) {
+                # Record the unmet expectation on the test, then turn it into a normal failure — an
+                # exception escaping here would abort the pipeline (Status::Aborted) instead. Leave an
+                # already-failed result alone; a null $result means $next() threw — let it propagate.
+                $failure = self::reportFailedExpectation($e);
+                $result?->status === Status::Passed and $result = $result
+                    ->with(status: Status::Failed)
+                    ->withFailure($failure ?? $e);
+            }
         }
+
+        return $result;
+    }
+
+    /**
+     * Record the `$count` verified Mockery expectations as one fulfilled assertion on the current test.
+     *
+     * No-op without the Assert plugin (the {@see \class_exists()} guard). Runs innermost, before the
+     * Assert plugin reads the history, so the record lands on the current test.
+     */
+    private static function reportVerifiedExpectations(int $count): void
+    {
+        if (!\class_exists(StaticState::class)) {
+            return;
+        }
+
+        $state = StaticState::current();
+        $state === null or $state->history[] = new ExpectationFulfilled(
+            \sprintf('%d Mockery %s fulfilled', $count, $count === 1 ? 'expectation was' : 'expectations were'),
+            '',
+        );
+    }
+
+    /**
+     * Record an unmet Mockery expectation as a failed assertion on the current test and return it,
+     * so the caller can use the same record as the test's failure (mirrors {@see \Testo\Assert\Internal\Expectation\NotLeaks}).
+     *
+     * Returns null without the Assert plugin — the caller then falls back to the raw Mockery exception.
+     */
+    private static function reportFailedExpectation(\Throwable $e): ?ExpectationFailed
+    {
+        if (!\class_exists(StaticState::class)) {
+            return null;
+        }
+
+        $failure = new ExpectationFailed(
+            expectation: 'the Mockery expectations are fulfilled',
+            context: '',
+            reason: $e->getMessage(),
+            details: '',
+        );
+
+        $state = StaticState::current();
+        $state === null or $state->history[] = $failure;
+
+        return $failure;
+    }
+
+    /**
+     * Run the test, keeping the global Mockery container bound to it across fiber suspensions.
+     *
+     * The container is process-global static state, so under concurrent (fiber-based) execution
+     * sibling tests would clobber each other's mocks. On every suspension we save this test's
+     * container and reset the global one; on resumption we restore it — the same scope-guarding
+     * dance as {@see \Testo\Application\Internal\MessengerHub::scope()}.
+     *
+     * @param callable(TestInfo): TestResult $next
+     */
+    private function run(TestInfo $info, callable $next): TestResult
+    {
+        if (\Fiber::getCurrent() === null) {
+            return $next($info);
+        }
+
+        $fiber = new \Fiber(static fn(): TestResult => $next($info));
+        $value = $fiber->start();
+        while (!$fiber->isTerminated()) {
+            $container = \Mockery::getContainer();
+            \Mockery::resetContainer();
+            try {
+                $resume = \Fiber::suspend($value);
+            } catch (\Throwable $e) {
+                \Mockery::setContainer($container);
+                $value = $fiber->throw($e);
+                continue;
+            }
+
+            \Mockery::setContainer($container);
+            $value = $fiber->resume($resume);
+        }
+
+        /** @var TestResult $result */
+        $result = $fiber->getReturn();
+        return $result;
     }
 }

--- a/bridge/mockery/src/MockeryPlugin.php
+++ b/bridge/mockery/src/MockeryPlugin.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Bridge\Mockery;
+
+use Internal\Container\Container;
+use Testo\Bridge\Mockery\Internal\MockeryInterceptor;
+use Testo\Common\PluginConfigurator;
+use Testo\Pipeline\InterceptorCollector;
+
+/**
+ * Plugin that automatically closes the Mockery container after every test.
+ *
+ * Register it in your {@see \Testo\Application\ApplicationConfig} `$plugins` list:
+ *
+ * ```php
+ * // testo.php
+ * return new ApplicationConfig(
+ *     plugins: [new MockeryPlugin()],
+ *     suites:  [new SuiteConfig(name: 'Unit', location: ['tests/Unit'])],
+ * );
+ * ```
+ *
+ * Once registered, `\Mockery::close()` is called automatically in a `finally`
+ * block after each test, so you never need to add teardown boilerplate and mock
+ * expectations are always verified.
+ *
+ * @api
+ */
+final readonly class MockeryPlugin implements PluginConfigurator
+{
+    #[\Override]
+    public function configure(Container $container): void
+    {
+        $container->get(InterceptorCollector::class)->addInterceptor(new MockeryInterceptor());
+    }
+}

--- a/bridge/mockery/tests/Acceptance/MockeryBridgeTest.php
+++ b/bridge/mockery/tests/Acceptance/MockeryBridgeTest.php
@@ -25,18 +25,26 @@ final class MockeryBridgeTest
     public function mockCreatedAndExpectationFulfilled(): void
     {
         /** @var MockInterface&\Countable $mock */
-        $mock = Mockery::mock(\Countable::class);
+        $mock = \Mockery::mock(\Countable::class);
         $mock->expects('count')->once()->andReturn(7);
 
         Assert::same($mock->count(), 7);
-        // MockeryPlugin calls Mockery::close() after this test,
-        // which verifies the expectation was met.
+    }
+
+    public function mockExpectationCountsAsAssertion(): void
+    {
+        /** @var MockInterface&\Countable $mock */
+        $mock = \Mockery::mock(\Countable::class);
+        $mock->expects('count')->twice()->andReturn(2);
+
+        $mock->count();
+        $mock->count();
     }
 
     public function spyRecordsCallsWithoutStrictExpectations(): void
     {
         /** @var MockInterface&\Countable $spy */
-        $spy = Mockery::spy(\Countable::class);
+        $spy = \Mockery::spy(\Countable::class);
         $spy->allows('count')->andReturn(3);
 
         Assert::same($spy->count(), 3);
@@ -46,13 +54,11 @@ final class MockeryBridgeTest
 
     public function mockContainerIsClearedBetweenTests(): void
     {
-        // The previous tests registered expectations on their mocks. If the plugin
-        // had not called Mockery::close() after each of them, those expectations
-        // would still live in the container now. A zero count proves it was reset.
-        Assert::same(Mockery::getContainer()->mockery_getExpectationCount(), 0);
+        // A non-zero count would mean the previous tests' expectations survived — i.e. close() never ran.
+        Assert::same(\Mockery::getContainer()->mockery_getExpectationCount(), 0);
 
         /** @var MockInterface&\Stringable $mock */
-        $mock = Mockery::mock(\Stringable::class);
+        $mock = \Mockery::mock(\Stringable::class);
         $mock->allows('__toString')->andReturn('clean slate');
 
         Assert::same((string) $mock, 'clean slate');

--- a/bridge/mockery/tests/Acceptance/MockeryBridgeTest.php
+++ b/bridge/mockery/tests/Acceptance/MockeryBridgeTest.php
@@ -7,9 +7,19 @@ namespace Tests\Bridge\Mockery\Acceptance;
 use Mockery;
 use Mockery\MockInterface;
 use Testo\Assert;
+use Testo\Bridge\Mockery\Internal\MockeryInterceptor;
+use Testo\Bridge\Mockery\MockeryPlugin;
+use Testo\Codecov\Covers;
 use Testo\Test;
 
+/**
+ * Acceptance tests for {@see MockeryPlugin}. The suite registers the plugin
+ * (see `bridge/mockery/tests/suites.php`), so `\Mockery::close()` fires after
+ * every test. Assertions therefore depend on the plugin doing its job:
+ * expectations are verified on teardown and the container is reset between tests.
+ */
 #[Test]
+#[Covers(MockeryPlugin::class, MockeryInterceptor::class)]
 final class MockeryBridgeTest
 {
     public function mockCreatedAndExpectationFulfilled(): void
@@ -27,17 +37,20 @@ final class MockeryBridgeTest
     {
         /** @var MockInterface&\Countable $spy */
         $spy = Mockery::spy(\Countable::class);
+        $spy->allows('count')->andReturn(3);
 
-        $spy->count();
+        Assert::same($spy->count(), 3);
 
         $spy->shouldHaveReceived('count')->once();
     }
 
     public function mockContainerIsClearedBetweenTests(): void
     {
-        // If close() had not been called after the previous test, its unfulfilled
-        // expectation would surface here as a late Mockery error. Reaching this
-        // assertion cleanly confirms the container was reset.
+        // The previous tests registered expectations on their mocks. If the plugin
+        // had not called Mockery::close() after each of them, those expectations
+        // would still live in the container now. A zero count proves it was reset.
+        Assert::same(Mockery::getContainer()->mockery_getExpectationCount(), 0);
+
         /** @var MockInterface&\Stringable $mock */
         $mock = Mockery::mock(\Stringable::class);
         $mock->allows('__toString')->andReturn('clean slate');

--- a/bridge/mockery/tests/Acceptance/MockeryBridgeTest.php
+++ b/bridge/mockery/tests/Acceptance/MockeryBridgeTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bridge\Mockery\Acceptance;
+
+use Mockery;
+use Mockery\MockInterface;
+use Testo\Assert;
+use Testo\Test;
+
+#[Test]
+final class MockeryBridgeTest
+{
+    public function mockCreatedAndExpectationFulfilled(): void
+    {
+        /** @var MockInterface&\Countable $mock */
+        $mock = Mockery::mock(\Countable::class);
+        $mock->expects('count')->once()->andReturn(7);
+
+        Assert::same($mock->count(), 7);
+        // MockeryPlugin calls Mockery::close() after this test,
+        // which verifies the expectation was met.
+    }
+
+    public function spyRecordsCallsWithoutStrictExpectations(): void
+    {
+        /** @var MockInterface&\Countable $spy */
+        $spy = Mockery::spy(\Countable::class);
+
+        $spy->count();
+
+        $spy->shouldHaveReceived('count')->once();
+    }
+
+    public function mockContainerIsClearedBetweenTests(): void
+    {
+        // If close() had not been called after the previous test, its unfulfilled
+        // expectation would surface here as a late Mockery error. Reaching this
+        // assertion cleanly confirms the container was reset.
+        /** @var MockInterface&\Stringable $mock */
+        $mock = Mockery::mock(\Stringable::class);
+        $mock->allows('__toString')->andReturn('clean slate');
+
+        Assert::same((string) $mock, 'clean slate');
+    }
+}

--- a/bridge/mockery/tests/Feature/MockeryStatusTest.php
+++ b/bridge/mockery/tests/Feature/MockeryStatusTest.php
@@ -14,6 +14,7 @@ use Testo\Core\Value\Status;
 use Testo\Test;
 use Testo\Testing\Attribute\TestingSuite;
 use Testo\Testing\Helper\TestRunner;
+use Tests\Bridge\Mockery\Stub\MockeryResetScenarios;
 use Tests\Bridge\Mockery\Stub\MockeryScenarios;
 
 /**
@@ -56,6 +57,18 @@ final class MockeryStatusTest
     {
         $result = TestRunner::runTest([MockeryScenarios::class, 'mockAndAssertMixed']);
         Assert::same($result->status, Status::Passed);
+    }
+
+    public function stateIsResetAfterAFailingTest(): void
+    {
+        // leavesUnmetExpectation fails on close(); seesCleanContainer runs right after it and would
+        // fail too if that close() had not cleared the container. Both being reported as expected
+        // proves the reset happens on the failure path, not only when a test passes.
+        $failed = TestRunner::runTest([MockeryResetScenarios::class, 'leavesUnmetExpectation']);
+        Assert::same($failed->status, Status::Failed);
+
+        $next = TestRunner::runTest([MockeryResetScenarios::class, 'seesCleanContainer']);
+        Assert::same($next->status, Status::Passed);
     }
 
     /**

--- a/bridge/mockery/tests/Feature/MockeryStatusTest.php
+++ b/bridge/mockery/tests/Feature/MockeryStatusTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bridge\Mockery\Feature;
+
+use Testo\Assert;
+use Testo\Bridge\Mockery\Internal\MockeryInterceptor;
+use Testo\Bridge\Mockery\MockeryPlugin;
+use Testo\Codecov\Covers;
+use Testo\Assert\TestState;
+use Testo\Core\Context\TestResult;
+use Testo\Core\Value\Status;
+use Testo\Test;
+use Testo\Testing\Attribute\TestingSuite;
+use Testo\Testing\Helper\TestRunner;
+use Tests\Bridge\Mockery\Stub\MockeryScenarios;
+
+/**
+ * How the Mockery bridge maps mock verification onto Testo's test statuses. Each case runs a stub
+ * scenario through {@see TestRunner} (with {@see MockeryPlugin} loaded) and asserts the resulting
+ * {@see Status} — the surface a user sees in the report.
+ */
+#[Test]
+#[Covers(MockeryPlugin::class, MockeryInterceptor::class)]
+#[TestingSuite(path: __DIR__ . '/../Stub', plugins: [MockeryPlugin::class])]
+final class MockeryStatusTest
+{
+    public function fulfilledMockCountsAsAssertion(): void
+    {
+        $result = TestRunner::runTest([MockeryScenarios::class, 'fulfilledExpectationOnly']);
+        Assert::same($result->status, Status::Passed);
+        Assert::true(self::hasRecord($result, success: true));
+    }
+
+    public function unfulfilledExpectationFailsTheTest(): void
+    {
+        $result = TestRunner::runTest([MockeryScenarios::class, 'unfulfilledExpectation']);
+        Assert::same($result->status, Status::Failed);
+        Assert::true(self::hasRecord($result, success: false));
+    }
+
+    public function noMocksNoAssertionsStaysRisky(): void
+    {
+        $result = TestRunner::runTest([MockeryScenarios::class, 'noMocksNoAssertions']);
+        Assert::same($result->status, Status::Risky);
+    }
+
+    public function spyVerificationCountsAsAssertion(): void
+    {
+        $result = TestRunner::runTest([MockeryScenarios::class, 'spyVerificationOnly']);
+        Assert::same($result->status, Status::Passed);
+    }
+
+    public function mockAndAssertCoexist(): void
+    {
+        $result = TestRunner::runTest([MockeryScenarios::class, 'mockAndAssertMixed']);
+        Assert::same($result->status, Status::Passed);
+    }
+
+    /**
+     * Whether the test's assertion history holds a record with the given success flag — i.e. the
+     * bridge reported the mock verification (fulfilled or failed) to the Assert plugin.
+     */
+    private static function hasRecord(TestResult $result, bool $success): bool
+    {
+        $state = $result->getAttribute(TestState::class);
+        if (!$state instanceof TestState) {
+            return false;
+        }
+
+        foreach ($state->history as $record) {
+            if ($record->isSuccess() === $success) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/bridge/mockery/tests/Self/MockAndAssertCombinations.php
+++ b/bridge/mockery/tests/Self/MockAndAssertCombinations.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bridge\Mockery\Self;
+
+use Testo\Assert;
+use Testo\Bridge\Mockery\Internal\MockeryInterceptor;
+use Testo\Bridge\Mockery\MockeryPlugin;
+use Testo\Codecov\Covers;
+use Testo\Expect;
+use Testo\Test;
+
+/**
+ * Self tests: each method mixes Mockery expectations with Testo assertions and MUST finish Passed —
+ * a Passed status is the proof that the bridge and the Assert plugin coexist.
+ *
+ * Negative cases (an unmet expectation must fail the test) live in the Feature suite: that failure
+ * surfaces from `close()` after the method returns and cannot be observed with `Expect`.
+ */
+#[Test]
+#[Covers(MockeryPlugin::class, MockeryInterceptor::class)]
+final class MockAndAssertCombinations
+{
+    public function assertOnly(): void
+    {
+        Assert::same(1 + 1, 2);
+    }
+
+    public function mockExpectationOnly(): void
+    {
+        $mock = \Mockery::mock(\Countable::class);
+        $mock->expects('count')->once()->andReturn(3);
+
+        $mock->count();
+    }
+
+    public function mockThenAssert(): void
+    {
+        $mock = \Mockery::mock(\Countable::class);
+        $mock->expects('count')->once()->andReturn(9);
+
+        Assert::same($mock->count(), 9);
+        Assert::instanceOf($mock, \Countable::class);
+    }
+
+    public function multipleMocksAndAsserts(): void
+    {
+        $counter = \Mockery::mock(\Countable::class);
+        $counter->expects('count')->twice()->andReturn(1);
+        $text = \Mockery::mock(\Stringable::class);
+        $text->expects('__toString')->once()->andReturn('x');
+
+        Assert::same($counter->count(), 1);
+        $counter->count();
+        Assert::same((string) $text, 'x');
+    }
+
+    public function spyWithAssert(): void
+    {
+        $spy = \Mockery::spy(\Countable::class);
+        $spy->allows('count')->andReturn(7);
+
+        Assert::same($spy->count(), 7);
+
+        $spy->shouldHaveReceived('count')->once();
+    }
+
+    public function looseMockWithAssert(): void
+    {
+        $mock = \Mockery::mock(\Countable::class);
+        $mock->allows('count')->andReturn(0);
+
+        Assert::same($mock->count(), 0);
+    }
+
+    public function mockThrowsWithExpectException(): void
+    {
+        $mock = \Mockery::mock(\Countable::class);
+        $mock->expects('count')->once()->andThrow(new \RuntimeException('boom'));
+
+        Expect::exception(\RuntimeException::class)->withMessageContaining('boom');
+        $mock->count();
+    }
+}

--- a/bridge/mockery/tests/Stub/MockeryResetScenarios.php
+++ b/bridge/mockery/tests/Stub/MockeryResetScenarios.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bridge\Mockery\Stub;
+
+use Testo\Assert;
+use Testo\Test;
+
+/**
+ * A failing test followed by a clean-slate check, run in declaration order through
+ * {@see \Testo\Testing\Helper\TestRunner}: proves the interceptor resets the Mockery container even
+ * when a test fails, so the next test starts clean.
+ */
+final class MockeryResetScenarios
+{
+    #[Test]
+    public function leavesUnmetExpectation(): void
+    {
+        $mock = \Mockery::mock(\Countable::class);
+        $mock->expects('count')->once();
+    }
+
+    #[Test]
+    public function seesCleanContainer(): void
+    {
+        Assert::same(\Mockery::getContainer()->mockery_getExpectationCount(), 0);
+    }
+}

--- a/bridge/mockery/tests/Stub/MockeryScenarios.php
+++ b/bridge/mockery/tests/Stub/MockeryScenarios.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bridge\Mockery\Stub;
+
+use Mockery\MockInterface;
+use Testo\Assert;
+use Testo\Test;
+
+/**
+ * Stub tests exercised through {@see \Testo\Testing\Helper\TestRunner} by the Feature suite.
+ * They are not discovered directly (the Stub directory is not a suite location); each method is
+ * a scenario whose reported {@see \Testo\Core\Value\Status} the Feature test asserts on.
+ */
+final class MockeryScenarios
+{
+    #[Test]
+    public function fulfilledExpectationOnly(): void
+    {
+        /** @var MockInterface&\Countable $mock */
+        $mock = \Mockery::mock(\Countable::class);
+        $mock->expects('count')->once()->andReturn(1);
+
+        $mock->count();
+    }
+
+    #[Test]
+    public function unfulfilledExpectation(): void
+    {
+        /** @var MockInterface&\Countable $mock */
+        $mock = \Mockery::mock(\Countable::class);
+        $mock->expects('count')->once();
+    }
+
+    #[Test]
+    public function noMocksNoAssertions(): void {}
+
+    #[Test]
+    public function spyVerificationOnly(): void
+    {
+        /** @var MockInterface&\Countable $spy */
+        $spy = \Mockery::spy(\Countable::class);
+
+        $spy->count();
+
+        $spy->shouldHaveReceived('count')->once();
+    }
+
+    #[Test]
+    public function mockAndAssertMixed(): void
+    {
+        /** @var MockInterface&\Countable $mock */
+        $mock = \Mockery::mock(\Countable::class);
+        $mock->expects('count')->once()->andReturn(5);
+
+        Assert::same($mock->count(), 5);
+    }
+}

--- a/bridge/mockery/tests/suites.php
+++ b/bridge/mockery/tests/suites.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Testo\Application\Config\FinderConfig;
+use Testo\Application\Config\SuiteConfig;
+
+return [
+    new SuiteConfig(
+        name: 'Bridge/Mockery/Acceptance',
+        location: new FinderConfig(
+            include: [__DIR__ . '/Acceptance'],
+        ),
+    ),
+];

--- a/bridge/mockery/tests/suites.php
+++ b/bridge/mockery/tests/suites.php
@@ -15,4 +15,19 @@ return [
         ),
         plugins: SuitePlugins::with(new MockeryPlugin()),
     ),
+    new SuiteConfig(
+        name: 'Bridge/Mockery/Self',
+        location: new FinderConfig(
+            include: [__DIR__ . '/Self'],
+        ),
+        plugins: SuitePlugins::with(new MockeryPlugin()),
+    ),
+    // The Feature suite drives Mockery only through the TestRunner harness (which loads
+    // MockeryPlugin itself via #[TestingSuite]), so it runs with the default plugin set.
+    new SuiteConfig(
+        name: 'Bridge/Mockery/Feature',
+        location: new FinderConfig(
+            include: [__DIR__ . '/Feature'],
+        ),
+    ),
 ];

--- a/bridge/mockery/tests/suites.php
+++ b/bridge/mockery/tests/suites.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 use Testo\Application\Config\FinderConfig;
+use Testo\Application\Config\Plugin\SuitePlugins;
 use Testo\Application\Config\SuiteConfig;
+use Testo\Bridge\Mockery\MockeryPlugin;
 
 return [
     new SuiteConfig(
@@ -11,5 +13,6 @@ return [
         location: new FinderConfig(
             include: [__DIR__ . '/Acceptance'],
         ),
+        plugins: SuitePlugins::with(new MockeryPlugin()),
     ),
 ];

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
     },
     "suggest": {
         "testo/bridge-infection": "Provides integration with Infection PHP mutation testing framework.",
-        "testo/bridge-mockery": "Provides automatic Mockery teardown (Mockery::close()) after every test.",
+        "testo/bridge-mockery": "Provides integration with the Mockery mocking framework.",
         "llm/skills": "Ship Testo's bundled AI-agent skills into your project's skills directory automatically."
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -59,11 +59,13 @@
         "roxblnfk/unpoly": "1.8.2",
         "rector/rector": "^2.5.2",
         "testo/bridge-infection": "^0.1.8",
+        "testo/bridge-mockery": "^0.1.0",
         "testo/bridge-rector": "^0.1.2",
         "testo/facade": "^0.1.1"
     },
     "suggest": {
         "testo/bridge-infection": "Provides integration with Infection PHP mutation testing framework.",
+        "testo/bridge-mockery": "Provides automatic Mockery teardown (Mockery::close()) after every test.",
         "llm/skills": "Ship Testo's bundled AI-agent skills into your project's skills directory automatically."
     },
     "minimum-stability": "dev",
@@ -83,6 +85,7 @@
             "Tests\\": "tests/",
             "Tests\\Assert\\": "plugin/assert/tests/",
             "Tests\\Bench\\": "plugin/bench/tests/",
+            "Tests\\Bridge\\Mockery\\": "bridge/mockery/tests/",
             "Tests\\Bridge\\SymfonyConsole\\": "bridge/symfony-console/tests/",
             "Tests\\Codecov\\": "plugin/codecov/tests/",
             "Tests\\Convention\\": "plugin/convention/tests/",
@@ -127,6 +130,7 @@
                 "symlink": true,
                 "versions": {
                     "testo/bridge-infection": "0.1.x-dev",
+                    "testo/bridge-mockery": "0.1.x-dev",
                     "testo/bridge-rector": "0.1.x-dev",
                     "testo/bridge-symfony-console": "0.1.x-dev"
                 }

--- a/plugin/assert/src/Internal/Middleware/ExpectationsInterceptor.php
+++ b/plugin/assert/src/Internal/Middleware/ExpectationsInterceptor.php
@@ -20,7 +20,7 @@ use Testo\Pipeline\Policy\ConflictPolicy;
  *
  * @note Must be placed right before the test execution.
  */
-#[InterceptorOptions(order: 10_000, onConflict: ConflictPolicy::First)]
+#[InterceptorOptions(order: InterceptorOptions::ORDER_ASSERTIONS + 2000, onConflict: ConflictPolicy::First)]
 final readonly class ExpectationsInterceptor implements TestRunInterceptor
 {
     /**

--- a/resources/version.json
+++ b/resources/version.json
@@ -14,5 +14,6 @@
     "plugin/facade": "0.1.1",
     "bridge/symfony-console": "0.1.8",
     "bridge/infection": "0.1.8",
+    "bridge/mockery": "0.1.0",
     "bridge/rector": "0.1.2"
 }

--- a/testo.php
+++ b/testo.php
@@ -11,6 +11,7 @@ return new ApplicationConfig(
     src: new FinderConfig(
         ['core', 'plugin', 'bridge'],
         [
+            'bridge/mockery/tests',
             'bridge/rector/tests',
             'bridge/symfony-console/tests',
             'plugin/assert/tests',
@@ -45,6 +46,7 @@ return new ApplicationConfig(
         //         ),
         //     ),
         // ],
+        require 'bridge/mockery/tests/suites.php',
         require 'bridge/rector/tests/suites.php',
         require 'bridge/symfony-console/tests/suites.php',
         require 'plugin/assert/tests/suites.php',


### PR DESCRIPTION
Closes #41

## What this adds

A new `bridge/mockery/` package (`testo/bridge-mockery`) that integrates [Mockery](https://github.com/mockery/mockery) into Testo.

### How it works

`MockeryPlugin` registers `MockeryInterceptor` as a `TestRunInterceptor`. The interceptor wraps every test in a `try/finally` and calls `Mockery::close()` after each one — whether it passed or failed. This ensures:

- Unfulfilled mock expectations are reported as test failures.
- The Mockery container is cleared between tests, preventing state leaking from one test into the next.

### Usage

```php
// testo.php
return new ApplicationConfig(
    plugins: [new \Testo\Bridge\Mockery\MockeryPlugin()],
    suites:  [new SuiteConfig(name: 'Unit', location: ['tests/Unit'])],
);
```

```php
#[Test]
final class MyServiceTest
{
    public function callsRepository(): void
    {
        $repo = \Mockery::mock(UserRepository::class);
        $repo->expects('find')->with(1)->andReturn(new User(1));

        $service = new UserService($repo);
        $service->getUser(1);
        // Mockery::close() is called automatically — expectation is verified here
    }
}
```

### Files

| File | Purpose |
|------|---------|
| `bridge/mockery/composer.json` | Package definition (`testo/bridge-mockery`) |
| `bridge/mockery/src/MockeryPlugin.php` | `PluginConfigurator` — entry point users register |
| `bridge/mockery/src/Internal/MockeryInterceptor.php` | `TestRunInterceptor` — calls `Mockery::close()` in `finally` |
| `bridge/mockery/tests/Acceptance/MockeryBridgeTest.php` | Acceptance tests: mock, spy, container isolation |

The bridge follows the same structure and conventions as the existing `bridge/symfony-console` and `plugin/lifecycle` packages.