### PR TITLE
style(rector): apply ClassPropertyAssignToConstructorPromotionRector

### DIFF
--- a/core/Core/Context/Identity.php
+++ b/core/Core/Context/Identity.php
@@ -43,31 +43,25 @@ abstract readonly class Identity
     public int $runtimeId;
 
     /**
-     * {@see $runtimeId} of the run this one opened inside — the suite for a case, the case for a test,
-     * the test for a data set — and `null` at a suite, which opens inside the run itself.
+     * @param int<1, max>|null $parentId {@see $runtimeId} of the run this one opened inside — the suite
+     *        for a case, the case for a test, the test for a data set — and `null` at a suite, which
+     *        opens inside the run itself. The step-down factories pass it.
      *
-     * The one thing an address says about the level above it, and a number rather than a reference:
-     * reading it stays a field access, and a consumer building a tree of the run (an IDE's
-     * `parentNodeId`, say) reads the same field at every level instead of knowing which type it holds
-     * and where that type keeps its parent. Process-local, like the number it points at.
+     *        The one thing an address says about the level above it, and a number rather than a
+     *        reference: reading it stays a field access, and a consumer building a tree of the run
+     *        (an IDE's `parentNodeId`, say) reads the same field at every level instead of knowing
+     *        which type it holds and where that type keeps its parent. Process-local, like the number
+     *        it points at.
      *
-     * A data set's parent is its test, so there it holds the same number as
-     * {@see Identity\TestIdentity::$pipelineId}. The two still answer different questions — *whose
-     * child is this* and *which test run is this part of* — and part company at every other level:
-     * a test's parent is its case, while its `pipelineId` is itself.
-     *
-     * @var int<1, max>|null
+     *        A data set's parent is its test, so there it holds the same number as
+     *        {@see Identity\TestIdentity::$pipelineId}. The two still answer different questions —
+     *        *whose child is this* and *which test run is this part of* — and part company at every
+     *        other level: a test's parent is its case, while its `pipelineId` is itself.
      */
-    public ?int $parentId;
-
-    /**
-     * @param int<1, max>|null $parentId Run this one opens inside; the step-down factories pass it, and
-     *        a suite has none. {@see $parentId}
-     */
-    public function __construct(?int $parentId = null)
-    {
+    public function __construct(
+        public ?int $parentId = null,
+    ) {
         $this->runtimeId = RuntimeSequence::next();
-        $this->parentId = $parentId;
     }
 
     /**

--- a/core/Core/Context/Identity.php
+++ b/core/Core/Context/Identity.php
@@ -42,32 +42,26 @@ abstract readonly class Identity
      */
     public int $runtimeId;
 
-    /**
-     * {@see $runtimeId} of the run this one opened inside — the suite for a case, the case for a test,
-     * the test for a data set — and `null` at a suite, which opens inside the run itself.
-     *
-     * The one thing an address says about the level above it, and a number rather than a reference:
-     * reading it stays a field access, and a consumer building a tree of the run (an IDE's
-     * `parentNodeId`, say) reads the same field at every level instead of knowing which type it holds
-     * and where that type keeps its parent. Process-local, like the number it points at.
-     *
-     * A data set's parent is its test, so there it holds the same number as
-     * {@see Identity\TestIdentity::$pipelineId}. The two still answer different questions — *whose
-     * child is this* and *which test run is this part of* — and part company at every other level:
-     * a test's parent is its case, while its `pipelineId` is itself.
-     *
-     * @var int<1, max>|null
-     */
-    public ?int $parentId;
-
-    /**
-     * @param int<1, max>|null $parentId Run this one opens inside; the step-down factories pass it, and
-     *        a suite has none. {@see $parentId}
-     */
-    public function __construct(?int $parentId = null)
-    {
+    public function __construct(
+        /**
+         * {@see $runtimeId} of the run this one opened inside — the suite for a case, the case for a test,
+         * the test for a data set — and `null` at a suite, which opens inside the run itself.
+         *
+         * The one thing an address says about the level above it, and a number rather than a reference:
+         * reading it stays a field access, and a consumer building a tree of the run (an IDE's
+         * `parentNodeId`, say) reads the same field at every level instead of knowing which type it holds
+         * and where that type keeps its parent. Process-local, like the number it points at.
+         *
+         * A data set's parent is its test, so there it holds the same number as
+         * {@see Identity\TestIdentity::$pipelineId}. The two still answer different questions — *whose
+         * child is this* and *which test run is this part of* — and part company at every other level:
+         * a test's parent is its case, while its `pipelineId` is itself.
+         *
+         * @var int<1, max>|null
+         */
+        public ?int $parentId = null,
+    ) {
         $this->runtimeId = RuntimeSequence::next();
-        $this->parentId = $parentId;
     }
 
     /**

--- a/core/Core/Context/Identity.php
+++ b/core/Core/Context/Identity.php
@@ -42,26 +42,32 @@ abstract readonly class Identity
      */
     public int $runtimeId;
 
-    public function __construct(
-        /**
-         * {@see $runtimeId} of the run this one opened inside — the suite for a case, the case for a test,
-         * the test for a data set — and `null` at a suite, which opens inside the run itself.
-         *
-         * The one thing an address says about the level above it, and a number rather than a reference:
-         * reading it stays a field access, and a consumer building a tree of the run (an IDE's
-         * `parentNodeId`, say) reads the same field at every level instead of knowing which type it holds
-         * and where that type keeps its parent. Process-local, like the number it points at.
-         *
-         * A data set's parent is its test, so there it holds the same number as
-         * {@see Identity\TestIdentity::$pipelineId}. The two still answer different questions — *whose
-         * child is this* and *which test run is this part of* — and part company at every other level:
-         * a test's parent is its case, while its `pipelineId` is itself.
-         *
-         * @var int<1, max>|null
-         */
-        public ?int $parentId = null,
-    ) {
+    /**
+     * {@see $runtimeId} of the run this one opened inside — the suite for a case, the case for a test,
+     * the test for a data set — and `null` at a suite, which opens inside the run itself.
+     *
+     * The one thing an address says about the level above it, and a number rather than a reference:
+     * reading it stays a field access, and a consumer building a tree of the run (an IDE's
+     * `parentNodeId`, say) reads the same field at every level instead of knowing which type it holds
+     * and where that type keeps its parent. Process-local, like the number it points at.
+     *
+     * A data set's parent is its test, so there it holds the same number as
+     * {@see Identity\TestIdentity::$pipelineId}. The two still answer different questions — *whose
+     * child is this* and *which test run is this part of* — and part company at every other level:
+     * a test's parent is its case, while its `pipelineId` is itself.
+     *
+     * @var int<1, max>|null
+     */
+    public ?int $parentId;
+
+    /**
+     * @param int<1, max>|null $parentId Run this one opens inside; the step-down factories pass it, and
+     *        a suite has none. {@see $parentId}
+     */
+    public function __construct(?int $parentId = null)
+    {
         $this->runtimeId = RuntimeSequence::next();
+        $this->parentId = $parentId;
     }
 
     /**

--- a/core/Output/Json/JsonPlugin.php
+++ b/core/Output/Json/JsonPlugin.php
@@ -46,9 +46,6 @@ final class JsonPlugin implements PluginConfigurator
      */
     private readonly ?Path $path;
 
-    /** @var resource|null Stream used in stdout mode; resolved to {@see \STDOUT} on write. */
-    private $stream;
-
     private readonly JsonReport $report;
 
     /**
@@ -59,10 +56,9 @@ final class JsonPlugin implements PluginConfigurator
      * @param resource|null $stream Stream for stdout mode; defaults to {@see \STDOUT}. Ignored
      *        when a file path is set.
      */
-    public function __construct(?string $outputPath = null, $stream = null)
+    public function __construct(?string $outputPath = null, private $stream = null)
     {
         $this->path = $outputPath !== null && $outputPath !== '' ? Path::create($outputPath) : null;
-        $this->stream = $stream;
         $this->report = new JsonReport();
     }
 

--- a/core/Output/Rendering/SharedStream.php
+++ b/core/Output/Rendering/SharedStream.php
@@ -23,9 +23,6 @@ namespace Testo\Output\Rendering;
  */
 final class SharedStream
 {
-    /** @var resource */
-    private $stream;
-
     /**
      * Test currently writing live; `null` when the stream is free.
      */
@@ -56,9 +53,8 @@ final class SharedStream
     /**
      * @param resource $stream
      */
-    public function __construct($stream)
+    public function __construct(private $stream)
     {
-        $this->stream = $stream;
     }
 
     /**

--- a/core/Output/Rendering/SharedStream.php
+++ b/core/Output/Rendering/SharedStream.php
@@ -53,9 +53,7 @@ final class SharedStream
     /**
      * @param resource $stream
      */
-    public function __construct(private $stream)
-    {
-    }
+    public function __construct(private $stream) {}
 
     /**
      * Write on behalf of `$owner`, or with no owner at all.

--- a/core/Testing/Attribute/TestingSuite.php
+++ b/core/Testing/Attribute/TestingSuite.php
@@ -16,9 +16,6 @@ use Testo\Common\PluginConfigurator;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION)]
 final readonly class TestingSuite
 {
-    /** @var list<class-string<PluginConfigurator>|PluginConfigurator> */
-    public array $plugins;
-
     /**
      * @param non-empty-string|Path $path Stub directory or file path.
      * @param list<class-string<PluginConfigurator>|PluginConfigurator> $plugins Extra plugins to load
@@ -34,11 +31,9 @@ final readonly class TestingSuite
      */
     public function __construct(
         public string|Path $path,
-        array $plugins = [],
+        public array $plugins = [],
         public array $options = [],
         public array $arguments = [],
         public array $env = [],
-    ) {
-        $this->plugins = $plugins;
-    }
+    ) {}
 }

--- a/rector.php
+++ b/rector.php
@@ -29,10 +29,6 @@ return RectorConfig::configure()
         // CompositeException: constructor-promoting $errors makes the constructor's own
         // doc comment awkward to place. Not promoting for now (see #263 review).
         __DIR__ . '/plugin/fiber/src/Exception/CompositeException.php',
-        // Identity: promoting $parentId hides its assignment inside the parameter list —
-        // an explicit `$this->parentId = $parentId;` in the constructor body, like its
-        // sibling $runtimeId in the same class, keeps the assignment visible (see #283 review).
-        __DIR__ . '/core/Core/Context/Identity.php',
         // Filter.php: large refactor surface, deferred until it can be reviewed on its own (#263).
         __DIR__ . '/plugin/filter/Filter.php',
         // DefinitionLocator::functionReflection() looks unused today but is kept intentionally —

--- a/rector.php
+++ b/rector.php
@@ -29,6 +29,10 @@ return RectorConfig::configure()
         // CompositeException: constructor-promoting $errors makes the constructor's own
         // doc comment awkward to place. Not promoting for now (see #263 review).
         __DIR__ . '/plugin/fiber/src/Exception/CompositeException.php',
+        // Identity: promoting $parentId hides its assignment inside the parameter list —
+        // an explicit `$this->parentId = $parentId;` in the constructor body, like its
+        // sibling $runtimeId in the same class, keeps the assignment visible (see #283 review).
+        __DIR__ . '/core/Core/Context/Identity.php',
         // Filter.php: large refactor surface, deferred until it can be reviewed on its own (#263).
         __DIR__ . '/plugin/filter/Filter.php',
         // DefinitionLocator::functionReflection() looks unused today but is kept intentionally —

--- a/rector.php
+++ b/rector.php
@@ -39,12 +39,6 @@ return RectorConfig::configure()
         // closely-related cluster of rules) at a time — see #263 review discussion. Each file is
         // removed from this list by the PR that applies its fix. ---
 
-        // ClassPropertyAssignToConstructorPromotionRector
-        __DIR__ . '/core/Output/Json/JsonPlugin.php',
-        __DIR__ . '/core/Output/Rendering/SharedStream.php',
-        __DIR__ . '/core/Testing/Attribute/TestingSuite.php',
-        __DIR__ . '/core/Core/Context/Identity.php',
-
         // AddArrowFunctionReturnTypeRector
         __DIR__ . '/bridge/symfony-console/src/Command/Init.php',
         __DIR__ . '/core/Application/Config/ApplicationConfig.php',


### PR DESCRIPTION
Third follow-up from #263's split — see #281 for the foundation PR and the full breakdown.

## What this PR does

Applies `ClassPropertyAssignToConstructorPromotionRector` to 3 files, removing them from `rector.php`'s temporary skip list: `JsonPlugin`, `SharedStream`, `TestingSuite`.

One needed manual touch-up beyond Rector's raw output, specifically flagged in #263 review:

**`TestingSuite.php`** ("Need to fix CS") — Rector collapsed the promoted constructor onto one long line. Reformatted back to one parameter per line, matching this file's own pre-existing style.

**`Identity.php`** — originally included in this PR, but reverted per review: promoting `$parentId` hides its assignment inside the parameter list. Restored to a plain property with an explicit `$this->parentId = $parentId;` in the constructor body — same as its sibling $runtimeId in the same class — and added to rector.php's skip list with that rationale, following the same pattern already used for CompositeException.php.

## Verification

- `composer rector:ci` — clean, 0 files
- Full Testo suite — 1666 passed, 6 failed / 7 error (same pre-existing `Bench/Self` baseline as #281/#282, unrelated)

Stacked on #282 (which is stacked on #281) — this PR's diff will shrink to just the files above once those merge.
