### PR TITLE
style(rector): apply AddArrowFunctionReturnTypeRector

### DIFF
--- a/bridge/symfony-console/src/Command/Init.php
+++ b/bridge/symfony-console/src/Command/Init.php
@@ -250,7 +250,7 @@ final class Init extends Command
         $runHints = $composerKeys === []
             ? ['   <comment>$ vendor/bin/testo</comment>']
             : \array_map(
-                static fn(string $key) => \sprintf('   <comment>$ composer %s</comment>', $key),
+                static fn(string $key): string => \sprintf('   <comment>$ composer %s</comment>', $key),
                 $composerKeys,
             );
 

--- a/core/Application/Config/ApplicationConfig.php
+++ b/core/Application/Config/ApplicationConfig.php
@@ -45,7 +45,7 @@ final readonly class ApplicationConfig
 
         # Validate suite configs
         $suites === [] and throw new \InvalidArgumentException('At least one test suite must be defined.');
-        \array_walk($suites, static fn(mixed $suite) => $suite instanceof SuiteConfig
+        \array_walk($suites, static fn(mixed $suite): bool => $suite instanceof SuiteConfig
             or throw new \InvalidArgumentException(
                 'Each suite must be an instance of SuiteConfig.',
             ));

--- a/core/Application/Internal/Messenger/State.php
+++ b/core/Application/Internal/Messenger/State.php
@@ -143,7 +143,7 @@ final class State implements Destroyable
         if ($this->holdEvents) {
             $this->heldEvents = \array_merge($this->heldEvents, $events);
             # Keep held events in time order so they are released chronologically on commit.
-            \usort($this->heldEvents, static fn(Message $a, Message $b) => $a->time <=> $b->time);
+            \usort($this->heldEvents, static fn(Message $a, Message $b): int => $a->time <=> $b->time);
             return;
         }
 
@@ -176,7 +176,7 @@ final class State implements Destroyable
 
         # Out-of-order (clock skew / interleaving): combine and stable-sort by time.
         $merged = \array_merge($this->messages, $state->messages);
-        \usort($merged, static fn(Message $a, Message $b) => $a->time <=> $b->time);
+        \usort($merged, static fn(Message $a, Message $b): int => $a->time <=> $b->time);
         $this->messages = $merged;
     }
 }

--- a/rector.php
+++ b/rector.php
@@ -45,11 +45,6 @@ return RectorConfig::configure()
         __DIR__ . '/core/Testing/Attribute/TestingSuite.php',
         __DIR__ . '/core/Core/Context/Identity.php',
 
-        // AddArrowFunctionReturnTypeRector
-        __DIR__ . '/bridge/symfony-console/src/Command/Init.php',
-        __DIR__ . '/core/Application/Config/ApplicationConfig.php',
-        __DIR__ . '/core/Application/Internal/Messenger/State.php',
-
         // ArrowFunctionDelegatingCallToFirstClassCallableRector
         __DIR__ . '/plugin/assert/src/Internal/Expectation/NotLeaks.php',
 


### PR DESCRIPTION
Fourth follow-up from #263's split — see #281 for the foundation PR and the full breakdown.

## What this PR does

Applies `AddArrowFunctionReturnTypeRector` to 3 files, removing them from `rector.php`'s temporary skip list: `Init.php` (bridge/symfony-console), `ApplicationConfig.php`, `State.php` (2 spots).

Purely mechanical — each diff just adds an explicit return type Rector inferred for an arrow function that already returned that type implicitly.

## Verification

- `composer rector:ci` — clean, 0 files
- Full Testo suite — 1666 passed, 6 failed / 7 error (same pre-existing `Bench/Self` baseline as #281/#282/#283, unrelated)

Stacked on #283 — this PR's diff will shrink to just the 3 files above once the earlier PRs merge.
