### PR TITLE
style(rector): remove useless doc tags; drop redundant property default

### DIFF
--- a/core/Application/Config/Internal/ConfigInflector.php
+++ b/core/Application/Config/Internal/ConfigInflector.php
@@ -114,7 +114,6 @@ final class ConfigInflector implements Inflector
                 // Cast value to the property type
                 $type = $property->getType();
 
-                /** @var mixed $result */
                 $result = match (true) {
                     !$type instanceof \ReflectionNamedType => $value,
                     $type->allowsNull() && $value === '' => null,

--- a/core/Common/Info.php
+++ b/core/Common/Info.php
@@ -45,7 +45,6 @@ final class Info
             return $cache = self::VERSION;
         }
 
-        /** @var mixed $version */
         $version = \json_decode($fileContent, true)['.'] ?? null;
 
         return $cache = \is_string($version) && $version !== ''

--- a/core/Pipeline/Pipeline.php
+++ b/core/Pipeline/Pipeline.php
@@ -28,7 +28,7 @@ final class Pipeline
     private mixed $last;
 
     /** @var list<TInterceptor> */
-    private array $interceptors = [];
+    private array $interceptors;
 
     /** @var int<0, max> Current interceptor key */
     private int $current = 0;

--- a/plugin/fiber/src/Internal/RunInFiberInterceptor.php
+++ b/plugin/fiber/src/Internal/RunInFiberInterceptor.php
@@ -70,7 +70,6 @@ final readonly class RunInFiberInterceptor implements TestCaseRunInterceptor, Te
 
         $task->error === null or throw $task->error;
 
-        /** @var TestResult */
         return $task->result;
     }
 }

--- a/plugin/filter/src/Internal/FilterInterceptor.php
+++ b/plugin/filter/src/Internal/FilterInterceptor.php
@@ -232,7 +232,6 @@ final class FilterInterceptor implements FileLocatorInterceptor, CaseLocatorInte
      *
      * Also records {@see DataPointer}s for matched tests so Stage 3 can inject them.
      *
-     * @param CaseDefinition $case
      *
      * @return array<string, TestDefinition> Matched tests keyed by name
      */

--- a/rector.php
+++ b/rector.php
@@ -50,14 +50,6 @@ return RectorConfig::configure()
         __DIR__ . '/core/Application/Config/ApplicationConfig.php',
         __DIR__ . '/core/Application/Internal/Messenger/State.php',
 
-        // Useless-tag removal (RemoveUselessVarTagRector / RemoveUselessParamTagRector /
-        // RemoveUselessReturnTagRector / RemoveNonExistingVarAnnotationRector)
-        __DIR__ . '/core/Application/Config/Internal/ConfigInflector.php',
-        __DIR__ . '/core/Common/Info.php',
-        __DIR__ . '/plugin/fiber/src/Internal/RunInFiberInterceptor.php',
-        __DIR__ . '/plugin/filter/src/Internal/FilterInterceptor.php',
-        __DIR__ . '/core/Pipeline/Pipeline.php',
-
         // Dead code: unused private methods / vars / params
         __DIR__ . '/plugin/bench/src/Internal/Renderer.php',
         __DIR__ . '/plugin/bench/src/Internal/BenchHandler.php',


### PR DESCRIPTION
Fifth follow-up from #263's split — see #281 for the foundation PR and the full breakdown.

## What this PR does

Two related, small findings grouped together, removing 5 files from `rector.php`'s temporary skip list:

- `RemoveUselessVarTagRector` / `RemoveUselessParamTagRector` / `RemoveNonExistingVarAnnotationRector` — drops `@var`/`@param` tags that duplicate a typed property or don't correspond to an actual parameter. Files: `ConfigInflector`, `Info`, `RunInFiberInterceptor`, `FilterInterceptor`.
- `RemoveDefaultValueFromAssignedPropertyRector` — `Pipeline.php`'s `$interceptors` always gets assigned in the constructor (`Sorter::sortAndFilter(...)`), so its `= []` default is redundant.

### On the `Pipeline.php` "Why removed?" questions from #263 review

Neither of the two `@return self<...>` tags on `Pipeline::prepare()`/`combine()` are touched by this PR. I confirmed via `composer rector:ci` that current Rector does **not** flag them as useless — they carry generic type parameters (`self<TInt, TIn, TOut>`) the plain `: self` return type doesn't express, so removing them would be a real loss of type information, not a useless-tag cleanup. They stay untouched.

## Verification

- `composer rector:ci` — clean, 0 files
- Full Testo suite — 1666 passed, 6 failed / 7 error (same pre-existing `Bench/Self` baseline as the earlier PRs in this series, unrelated)

Stacked on #284 — this PR's diff will shrink to just the 5 files above once the earlier PRs merge.
