### PR TITLE
style(rector): remove dead code (unused methods/vars/params)

### DIFF
--- a/core/Application/Internal/SuiteFactory.php
+++ b/core/Application/Internal/SuiteFactory.php
@@ -34,7 +34,7 @@ final readonly class SuiteFactory
     public function create(SuiteConfig $config, Filter $filter): SuiteInfo
     {
         $files = $this->getFilesIterator($config, $filter);
-        $definitions = $this->getCaseDefinitions($config, $files, $filter);
+        $definitions = $this->getCaseDefinitions($files, $filter);
 
         $cases = [];
         foreach ($definitions as $definition) {
@@ -89,7 +89,7 @@ final readonly class SuiteFactory
      * @param iterable<TokenizedFile> $files
      * @return list<CaseDefinition>
      */
-    private function getCaseDefinitions(SuiteConfig $config, iterable $files, Filter $filter): array
+    private function getCaseDefinitions(iterable $files, Filter $filter): array
     {
         $cases = [];
         # Prepare interceptors pipeline

--- a/core/Output/Teamcity/Teamcity/TeamcityLogger.php
+++ b/core/Output/Teamcity/Teamcity/TeamcityLogger.php
@@ -375,8 +375,6 @@ final class TeamcityLogger
      */
     public function handleSingleTestResult(TestResult $result, ?int $duration = null, ?string $overrideName = null): void
     {
-        $name = $overrideName ?? $result->info->name;
-
         match ($result->status) {
             Status::Passed, Status::Flaky => $this->handlePassedTest($result, $duration, $overrideName),
             Status::Failed, Status::Error => $this->handleFailedTest($result, $duration, $overrideName),

--- a/core/Output/Terminal/Renderer/TerminalLogger.php
+++ b/core/Output/Terminal/Renderer/TerminalLogger.php
@@ -512,7 +512,6 @@ final class TerminalLogger
             $item = new FormattedItem(
                 name: "Run #{$runNumber}",
                 status: $runResult->status,
-                duration: null,
                 indentLevel: 1,
                 description: (string) $runKey,
             );

--- a/plugin/bench/src/Internal/BenchHandler.php
+++ b/plugin/bench/src/Internal/BenchHandler.php
@@ -117,7 +117,7 @@ final readonly class BenchHandler
         int $calls,
     ): IterationSet {
         $cases = [];
-        foreach ($functions as $k => $function) {
+        foreach ($functions as $function) {
             $cases[] = self::runCase($function, $calls);
         }
 

--- a/plugin/bench/src/Internal/Renderer.php
+++ b/plugin/bench/src/Internal/Renderer.php
@@ -241,31 +241,11 @@ final class Renderer
     /**
      * @param list<string> $headers
      * @param list<list<string>> $rows
-     */
-    private static function renderTable(array $headers, array $rows): string
-    {
-        $widths = self::calculateWidths($headers, $rows);
-
-        $separator = self::separator($widths);
-        $lines = [$separator, self::row($headers, $widths), $separator];
-
-        foreach ($rows as $r) {
-            $lines[] = self::row($r, $widths);
-        }
-
-        $lines[] = $separator;
-
-        return \implode("\n", $lines);
-    }
-
-    /**
-     * @param list<string> $headers
-     * @param list<list<string>> $rows
      * @return list<int>
      */
     private static function calculateWidths(array $headers, array $rows): array
     {
-        $widths = \array_map(static fn(string $h): int => \mb_strlen($h), $headers);
+        $widths = \array_map(\mb_strlen(...), $headers);
 
         foreach ($rows as $row) {
             foreach ($row as $i => $cell) {
@@ -300,20 +280,6 @@ final class Renderer
             $parts[] = isset($rightAlign[$i])
                 ? ' ' . $pad . $cell . ' '
                 : ' ' . $cell . $pad . ' ';
-        }
-
-        return '|' . \implode('|', $parts) . '|';
-    }
-
-    /**
-     * @param list<string> $cells
-     * @param list<int> $widths
-     */
-    private static function centeredRow(array $cells, array $widths): string
-    {
-        $parts = [];
-        foreach ($cells as $i => $cell) {
-            $parts[] = ' ' . self::centerPad($cell, $widths[$i]) . ' ';
         }
 
         return '|' . \implode('|', $parts) . '|';
@@ -424,18 +390,5 @@ final class Renderer
         }
 
         return \implode('. ', $reasons);
-    }
-
-    private static function centerPad(string $text, int $width): string
-    {
-        $len = \mb_strlen($text);
-        if ($len >= $width) {
-            return $text;
-        }
-
-        $left = (int) (($width - $len) / 2);
-        $right = $width - $len - $left;
-
-        return \str_repeat(' ', $left) . $text . \str_repeat(' ', $right);
     }
 }

--- a/rector.php
+++ b/rector.php
@@ -50,13 +50,6 @@ return RectorConfig::configure()
         __DIR__ . '/core/Application/Config/ApplicationConfig.php',
         __DIR__ . '/core/Application/Internal/Messenger/State.php',
 
-        // Dead code: unused private methods / vars / params
-        __DIR__ . '/plugin/bench/src/Internal/Renderer.php',
-        __DIR__ . '/plugin/bench/src/Internal/BenchHandler.php',
-        __DIR__ . '/core/Output/Teamcity/Teamcity/TeamcityLogger.php',
-        __DIR__ . '/core/Application/Internal/SuiteFactory.php',
-        __DIR__ . '/core/Output/Terminal/Renderer/TerminalLogger.php',
-
         // ArrowFunctionDelegatingCallToFirstClassCallableRector
         __DIR__ . '/plugin/assert/src/Internal/Expectation/NotLeaks.php',
 


### PR DESCRIPTION
Sixth follow-up from #263's split — see #281 for the foundation PR and the full breakdown.

## What this PR does

Removes genuinely dead code: unused private methods, an unused `foreach` key, an unused local variable, an unused private-method parameter, and a redundant named argument matching its own default.

- **`Renderer.php`** (bench): removes 3 entirely unused private methods (`renderTable`, `centeredRow`, `centerPad` — none called anywhere). Also picks up `ArrowFunctionDelegatingCallToFirstClassCallableRector` for this same file (`mb_strlen` arrow fn → first-class callable) since Rector processes per-file, not per-rule — so the PR originally planned for that rule now only needs to cover `NotLeaks.php`.
- **`BenchHandler.php`**: unused `foreach` key.
- **`TeamcityLogger.php`**: unused local `$name` variable.
- **`SuiteFactory.php`**: unused `$config` parameter on a `private` method (`getCaseDefinitions`) — confirmed genuinely unused, not a latent bug (eyeballed the diff directly).
- **`TerminalLogger.php`**: `duration: null` named argument matching its own default value.

## Verification

- `composer rector:ci` — clean, 0 files
- Full Testo suite — 1666 passed, 6 failed / 7 error (same pre-existing `Bench/Self` baseline as the earlier PRs in this series, unrelated)

Stacked on #285 — this PR's diff will shrink to just the 5 files above once the earlier PRs merge.
