### PR TITLE
style(rector): apply ArrowFunctionDelegatingCallToFirstClassCallableRector

### DIFF
--- a/plugin/assert/src/Internal/Expectation/NotLeaks.php
+++ b/plugin/assert/src/Internal/Expectation/NotLeaks.php
@@ -27,7 +27,7 @@ final class NotLeaks
     public function __construct(
         object ...$objects,
     ) {
-        $this->map = \array_map(static fn(object $object): \WeakReference => \WeakReference::create($object), $objects);
+        $this->map = \array_map(\WeakReference::create(...), $objects);
     }
 
     /**

--- a/rector.php
+++ b/rector.php
@@ -45,9 +45,6 @@ return RectorConfig::configure()
         __DIR__ . '/core/Testing/Attribute/TestingSuite.php',
         __DIR__ . '/core/Core/Context/Identity.php',
 
-        // ArrowFunctionDelegatingCallToFirstClassCallableRector
-        __DIR__ . '/plugin/assert/src/Internal/Expectation/NotLeaks.php',
-
         // MakePropertyReadonlyRector + misc single-file simplifications
         __DIR__ . '/core/Tokenizer/Reflection/TokenizedFile.php',
         __DIR__ . '/core/Application/Application.php',


### PR DESCRIPTION
Seventh follow-up from #263's split — see #281 for the foundation PR and the full breakdown.

## What this PR does

Applies `ArrowFunctionDelegatingCallToFirstClassCallableRector` to `NotLeaks.php` — converts an arrow function that just delegates to a static call into PHP 8.1's first-class callable syntax. (`Renderer.php`'s own instance of this rule was already applied in #286, alongside its dead-code fix — Rector processes per-file.)

## Verification

- `composer rector:ci` — clean, 0 files
- Full Testo suite — 1666 passed, 6 failed / 7 error (same pre-existing `Bench/Self` baseline as the earlier PRs in this series, unrelated)

Stacked on #286 — this PR's diff will shrink to just `NotLeaks.php` once the earlier PRs merge.
