### PR TITLE
style(rector): misc single-file simplifications

### DIFF
--- a/core/Application/Application.php
+++ b/core/Application/Application.php
@@ -77,7 +77,7 @@ final readonly class Application
                         'Configuration file %s must return an instance of %s, %s returned.',
                         $configFile,
                         ApplicationConfig::class,
-                        get_debug_type($cfg),
+                        \get_debug_type($cfg),
                     ),
                 );
                 return $cfg;

--- a/core/Application/Application.php
+++ b/core/Application/Application.php
@@ -77,7 +77,7 @@ final readonly class Application
                         'Configuration file %s must return an instance of %s, %s returned.',
                         $configFile,
                         ApplicationConfig::class,
-                        \is_object($cfg) ? \get_class($cfg) : \gettype($cfg),
+                        get_debug_type($cfg),
                     ),
                 );
                 return $cfg;

--- a/core/Core/Internal/RuntimeSequence.php
+++ b/core/Core/Internal/RuntimeSequence.php
@@ -14,6 +14,7 @@ namespace Testo\Core\Internal;
  */
 final class RuntimeSequence
 {
+    /** @var int<0, max> */
     private static int $last = 0;
 
     /**
@@ -21,7 +22,6 @@ final class RuntimeSequence
      */
     public static function next(): int
     {
-        /** @var int<1, max> */
         return ++self::$last;
     }
 }

--- a/core/Output/Terminal/Renderer/Formatter.php
+++ b/core/Output/Terminal/Renderer/Formatter.php
@@ -267,9 +267,8 @@ final class Formatter
         $result = "\n\n " . Style::bold('Summary') . "\n\n";
         $result .= self::statRow('Time', Style::dim("{$testsTime} tests · {$overheadTime} overhead"));
         $result .= self::statRow('Total', "{$total} tests · {$assertions} assertions");
-        $result .= self::statRow('', $breakdown);
 
-        return $result;
+        return $result . self::statRow('', $breakdown);
     }
 
     /**
@@ -390,9 +389,8 @@ final class Formatter
             : '';
 
         $result = "{$indent}{$symbol} {$item->name}{$durationStr}\n";
-        $result .= self::description($item->description, $item->indentLevel, $format);
 
-        return $result;
+        return $result . self::description($item->description, $item->indentLevel, $format);
     }
 
     /**
@@ -400,7 +398,7 @@ final class Formatter
      */
     private static function formatDotRun(FormattedItem $item): string
     {
-        $symbol = match ($item->status) {
+        return match ($item->status) {
             Status::Passed => DotSymbol::Passed->value,
             Status::Failed => Style::error(DotSymbol::Failed->value),
             Status::Skipped => Style::warning(DotSymbol::Skipped->value),
@@ -410,8 +408,6 @@ final class Formatter
             Status::Flaky => Style::info(DotSymbol::Passed->value),
             Status::Cancelled => Style::dim(DotSymbol::Skipped->value),
         };
-
-        return $symbol;
     }
 
     /**

--- a/core/Tokenizer/Reflection/TokenizedFile.php
+++ b/core/Tokenizer/Reflection/TokenizedFile.php
@@ -76,7 +76,7 @@ final class TokenizedFile
      *
      * @internal
      */
-    private int $countTokens = 0;
+    private readonly int $countTokens;
 
     /**
      * Namespaces used in file and their token positions.

--- a/plugin/assert/src/Internal/Assertion/AssertJson.php
+++ b/plugin/assert/src/Internal/Assertion/AssertJson.php
@@ -410,7 +410,7 @@ final readonly class AssertJson implements JsonAbstract
                 }
 
                 // Numeric key
-                if (\is_string($key) && \ctype_digit($key)) {
+                if (\ctype_digit($key)) {
                     $key = (int) $key;
                 }
 

--- a/plugin/assert/src/Internal/Assertion/Traits/IterableTrait.php
+++ b/plugin/assert/src/Internal/Assertion/Traits/IterableTrait.php
@@ -159,7 +159,7 @@ trait IterableTrait
     private static function countIterable(iterable $value): int
     {
         // if Countable
-        if (\is_array($value) || $value instanceof \Countable) {
+        if (is_countable($value)) {
             return \count($value);
         }
 

--- a/rector.php
+++ b/rector.php
@@ -45,14 +45,6 @@ return RectorConfig::configure()
         __DIR__ . '/core/Testing/Attribute/TestingSuite.php',
         __DIR__ . '/core/Core/Context/Identity.php',
 
-        // MakePropertyReadonlyRector + misc single-file simplifications
-        __DIR__ . '/core/Tokenizer/Reflection/TokenizedFile.php',
-        __DIR__ . '/core/Application/Application.php',
-        __DIR__ . '/plugin/assert/src/Internal/Assertion/AssertJson.php',
-        __DIR__ . '/plugin/assert/src/Internal/Assertion/Traits/IterableTrait.php',
-        __DIR__ . '/core/Output/Terminal/Renderer/Formatter.php',
-        __DIR__ . '/core/Core/Internal/RuntimeSequence.php',
-
         // Standalone bugfix (not mechanical Rector output — Rector separately flags an
         // unrelated tag/type finding in this file; resolved as part of the bugfix PR)
         __DIR__ . '/plugin/data/src/Internal/DataProviderInterceptor.php',


### PR DESCRIPTION
Eighth follow-up from #263's split — see #281 for the foundation PR and the full breakdown.

## What this PR does

Six independent, single-rule findings grouped into one PR since each is a one-line, self-contained change:

- **`TokenizedFile.php`** (`MakePropertyReadonlyRector`) — `$countTokens` is assigned exactly once, in the constructor, and only read afterward (confirmed by grepping every usage before applying). Marked `readonly`.
- **`Application.php`** — replaces the manual `is_object($x) ? get_class($x) : gettype($x)` pattern with PHP 8's `get_debug_type()`, which exists specifically to replace it.
- **`AssertJson.php`** (`RemoveAlwaysTrueIfConditionRector`) — `ctype_digit()` already implies string input in this context, so the preceding `is_string()` check was always true.
- **`IterableTrait.php`** (`IsCountableRector`) — `is_array($x) || $x instanceof \Countable` is exactly what `is_countable()` checks.
- **`Formatter.php`** — three spots where a value was assigned then immediately concatenated/returned on the next line, collapsed to a single expression.
- **`RuntimeSequence.php`** (`RemoveNonExistingVarAnnotationRector`) — dropped `next()`'s inline `@var int<1, max>` on `++self::$last`. Psalm still needs that precision — plain `int $last` alone doesn't let it narrow the increment to the declared `int<1, max>` return type. Restored it one level up as `@var int<0, max>` on the property itself, which satisfies both Rector (confirmed via `composer rector:ci` — nothing left to flag) and Psalm.

## Verification

- `composer rector:ci` — clean, 0 files
- Full Testo suite — 1666 passed, 6 failed / 7 error (same pre-existing `Bench/Self` baseline as the earlier PRs in this series, unrelated)

Stacked on #287 — this PR's diff will shrink to just the 6 files above once the earlier PRs merge.
