### PR TITLE
fix(data): correctly bind non-static DataProvider methods to their instance

### DIFF
--- a/plugin/data/src/Internal/DataProviderInterceptor.php
+++ b/plugin/data/src/Internal/DataProviderInterceptor.php
@@ -222,8 +222,8 @@ final readonly class DataProviderInterceptor implements TestRunInterceptor
             if ($class->hasMethod($provider)) {
                 $m = $class->getMethod($provider);
                 $provider = match (true) {
-                    $m->isStatic() => $m->getClosure(null),
-                    default => static fn() => $m->getClosure($info->caseInfo->instance->getInstance()),
+                    $m->isStatic() => $m->getClosure(),
+                    default => $m->getClosure(($info->caseInfo->instance ?? throw new \LogicException("Cannot use non-static DataProvider '{$provider}': test has no class instance."))->getInstance()),
                 };
             }
 

--- a/plugin/data/tests/Unit/Fixture/NonStaticProviderTarget.php
+++ b/plugin/data/tests/Unit/Fixture/NonStaticProviderTarget.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Data\Unit\Fixture;
+
+use Testo\Data\DataProvider;
+
+/**
+ * Fixture with a non-static (instance) data provider method.
+ *
+ * Used to verify that {@see \Testo\Data\Internal\DataProviderInterceptor} correctly
+ * binds the provider method to the class instance when it is not static.
+ */
+final class NonStaticProviderTarget
+{
+    public function instanceProvider(): array
+    {
+        return [[10], [20]];
+    }
+
+    #[DataProvider('instanceProvider')]
+    public function target(int $value): void {}
+}

--- a/plugin/data/tests/Unit/Internal/DataProviderInterceptorTest.php
+++ b/plugin/data/tests/Unit/Internal/DataProviderInterceptorTest.php
@@ -7,6 +7,7 @@ namespace Tests\Data\Unit\Internal;
 use Internal\Path;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Testo\Assert;
+use Testo\Assert\ExpectException;
 use Testo\Codecov\Covers;
 use Testo\Core\Context\CaseInfo;
 use Testo\Core\Context\Identity\SuiteIdentity;
@@ -14,11 +15,13 @@ use Testo\Core\Context\TestInfo;
 use Testo\Core\Context\TestResult;
 use Testo\Core\Definition\CaseDefinition;
 use Testo\Core\Definition\TestDefinition;
+use Testo\Core\Value\CaseInstance;
 use Testo\Core\Value\Status;
 use Testo\Data\Internal\DataProviderInterceptor;
 use Testo\Data\MultipleResult;
 use Testo\Test;
 use Tests\Data\Unit\Fixture\MultiProviderTarget;
+use Tests\Data\Unit\Fixture\NonStaticProviderTarget;
 
 /**
  * @see DataProviderInterceptor
@@ -54,6 +57,51 @@ final class DataProviderInterceptorTest
         Assert::same(\count($summary->results), 6);
     }
 
+    public function supportsNonStaticProviderMethodBoundToInstance(): void
+    {
+        $target = new NonStaticProviderTarget();
+        $instance = new class($target) implements CaseInstance {
+            public function __construct(private readonly NonStaticProviderTarget $obj) {}
+
+            #[\Override]
+            public function getInstance(): object { return $this->obj; }
+
+            #[\Override]
+            public function hasInstance(): bool { return true; }
+        };
+
+        $dispatcher = self::createDispatcher();
+        $interceptor = new DataProviderInterceptor($dispatcher);
+        $info = self::createTestInfoWithInstance($instance);
+        $callCount = 0;
+        $next = static function (TestInfo $info) use (&$callCount): TestResult {
+            ++$callCount;
+            return new TestResult(info: $info, status: Status::Passed);
+        };
+
+        $result = $interceptor->runTest($info, $next);
+
+        // instanceProvider() returns [[10], [20]] — 2 data sets
+        Assert::same($callCount, 2);
+        Assert::same($result->status, Status::Passed);
+    }
+
+    #[ExpectException(\LogicException::class)]
+    public function throwsWhenNonStaticProviderUsedWithoutClassInstance(): void
+    {
+        $dispatcher = self::createDispatcher();
+        $interceptor = new DataProviderInterceptor($dispatcher);
+
+        // CaseInfo with no instance — the null coalescing throw should fire.
+        $reflection = new \ReflectionMethod(NonStaticProviderTarget::class, 'target');
+        $caseDefinition = new CaseDefinition(name: 'TestCase', type: 'test', file: Path::create(__FILE__));
+        $caseInfo = new CaseInfo(suiteIdentity: new SuiteIdentity('Data/Unit'), definition: $caseDefinition, instance: null);
+        $testDefinition = new TestDefinition(reflection: $reflection);
+        $info = new TestInfo(name: 'target', caseInfo: $caseInfo, testDefinition: $testDefinition);
+
+        $interceptor->runTest($info, static fn(TestInfo $i): TestResult => new TestResult(info: $i, status: Status::Passed));
+    }
+
     private static function createDispatcher(): EventDispatcherInterface
     {
         return new class() implements EventDispatcherInterface {
@@ -74,6 +122,20 @@ final class DataProviderInterceptorTest
         $reflection = new \ReflectionMethod(MultiProviderTarget::class, 'target');
         $caseDefinition = new CaseDefinition(name: 'TestCase', type: 'test', file: Path::create(__FILE__));
         $caseInfo = new CaseInfo(suiteIdentity: new SuiteIdentity('Data/Unit'), definition: $caseDefinition);
+        $testDefinition = new TestDefinition(reflection: $reflection);
+
+        return new TestInfo(
+            name: 'target',
+            caseInfo: $caseInfo,
+            testDefinition: $testDefinition,
+        );
+    }
+
+    private static function createTestInfoWithInstance(CaseInstance $instance): TestInfo
+    {
+        $reflection = new \ReflectionMethod(NonStaticProviderTarget::class, 'target');
+        $caseDefinition = new CaseDefinition(name: 'TestCase', type: 'test', file: Path::create(__FILE__));
+        $caseInfo = new CaseInfo(suiteIdentity: new SuiteIdentity('Data/Unit'), definition: $caseDefinition, instance: $instance);
         $testDefinition = new TestDefinition(reflection: $reflection);
 
         return new TestInfo(

--- a/rector.php
+++ b/rector.php
@@ -79,7 +79,6 @@ return RectorConfig::configure()
         // Standalone bugfixes (not mechanical Rector output — Rector separately flags an
         // unrelated tag/type finding in these same files; resolved as part of each bugfix PR)
         __DIR__ . '/core/Output/Rendering/ChannelRenderer.php',
-        __DIR__ . '/plugin/data/src/Internal/DataProviderInterceptor.php',
     ])
     ->withPhpSets(php82: true)
     ->withPreparedSets(


### PR DESCRIPTION
Ninth follow-up from #263's split — see #281 for the foundation PR and the full breakdown. This one is a **standalone bugfix**, not mechanical Rector output — but it happens to resolve a finding Rector separately flags in these same lines, so `DataProviderInterceptor.php` comes off `rector.php`'s skip list too.

## The bug

`DataProviderInterceptor::fromDataProvider()` resolved a non-static provider method's closure like this:

```php
default => static fn() => $m->getClosure($info->caseInfo->instance->getInstance()),
```

Wrapping the `getClosure()` call in an arrow function meant `$provider` held a `\Closure` that *returns* a closure, not the closure itself — calling `$provider()` later never actually invoked the data provider method. It also unconditionally dereferenced `$info->caseInfo->instance->getInstance()` with no null check, so a non-static provider used without a class instance would fail with a confusing null-property-access error instead of a clear one.

## The fix

```php
default => $m->getClosure(($info->caseInfo->instance
    ?? throw new \LogicException("Cannot use non-static DataProvider '{$provider}': test has no class instance."))
    ->getInstance()),
```

Also fixes the static branch: `$m->getClosure(null)` is now just `$m->getClosure()` — a static method's closure needs no bound object at all.

## Tests

Adds `NonStaticProviderTarget` fixture and two tests:
- `supportsNonStaticProviderMethodBoundToInstance` — a non-static provider bound to a real instance now actually runs and its data sets are collected.
- `throwsWhenNonStaticProviderUsedWithoutClassInstance` — the new `LogicException` fires with a clear message when no instance exists.

## Verification

- `composer rector:ci` — clean, 0 files
- Full Testo suite — 1668 passed (+2 from the new tests), 6 failed/7 error unchanged (same pre-existing `Bench/Self` baseline as the earlier PRs in this series, unrelated)
- Both new tests confirmed passing by name: `vendor/bin/testo --filter=DataProviderInterceptorTest` → 3/3 passed

Stacked on #288 — this PR's diff will shrink to just the 3 files above once the earlier PRs merge.
